### PR TITLE
Reduce Cards Memory Footprint

### DIFF
--- a/src/Domain/Implementations/Services/OpenGraphCardService.cs
+++ b/src/Domain/Implementations/Services/OpenGraphCardService.cs
@@ -17,9 +17,9 @@ namespace BridgeBeats.Domain.Implementations.Services {
         public string BaseUrl => baseUrl;
 
         private readonly ConcurrentDictionary<string, (MediaLinkResult Result, DateTime Expiry)> _store = new();
-        private readonly TimeSpan _expirationTime = TimeSpan.FromDays( 6 );
+        private readonly TimeSpan _expirationTime = TimeSpan.FromHours( 1 );
         private int _operationCounter;
-        private const int CleanupInterval = 10000;
+        private const int CleanupInterval = 500;
 
         /// <inheritdoc/>
         public string StoreResult( MediaLinkResult result ) {


### PR DESCRIPTION
The container is regularly restarting due to memory contstraints. Now that we can lookup old cards from the sqlite db we should keep a vastly reduced amount of cards in memory