### PR TITLE
Fix partial lookups

### DIFF
--- a/Tests/Integration/RedisMediaLinkCacheTests.cs
+++ b/Tests/Integration/RedisMediaLinkCacheTests.cs
@@ -356,6 +356,38 @@ public class RedisMediaLinkCacheTests {
     }
 
     /// <summary>
+    /// Verifies that the cache marks partial results as stale regardless of age, so callers
+    /// re-enter the lookup path and wait for the complete result.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task CheckRecordFreshness_ReturnsStale_WhenResultIsPartial( ) {
+        // Arrange - a freshly looked-up but PARTIAL result
+        MediaLinkResult result = CreateTestResult( "PARTIALTEST123", false );
+        result.IsPartial = true;
+
+        string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:PARTIALTEST123";
+
+        _ = _mockAtProto
+            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( recordUri );
+
+        _ = _mockAtProto
+            .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
+            .ReturnsAsync( result );
+
+        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+
+        // Act
+        (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
+            await _cache.TryGetCachedResultByISRCAsync( "PARTIALTEST123" );
+
+        // Assert
+        Assert.IsNotNull( lookupResult );
+        Assert.IsTrue( lookupResult.Value.isStale, "Partial results should always be stale-eligible" );
+    }
+
+    /// <summary>
     /// Verifies that <see cref="RedisMediaLinkCache.AddInputLinksAsync"/> skips writing when the record
     /// already exists with the same RecordUri, avoiding unnecessary Redis writes during cache bootstrap.
     /// </summary>

--- a/Tests/Integration/RedisSagaStateManagerTests.cs
+++ b/Tests/Integration/RedisSagaStateManagerTests.cs
@@ -443,7 +443,7 @@ public class RedisSagaStateManagerTests {
             LookupRequestType.IsrcLookup,
             "USRC12345678",
             QueuePriority.Bulk,
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         LookupSagaState resumed = await _sagaManager.GetOrCreateAsync(
@@ -452,7 +452,7 @@ public class RedisSagaStateManagerTests {
             LookupRequestType.IsrcLookup,
             "USRC12345678",
             QueuePriority.Interactive,
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Assert - first recorded origin priority is kept
@@ -494,7 +494,7 @@ public class RedisSagaStateManagerTests {
             LookupRequestType.IsrcLookup,
             "USRC12345678",
             QueuePriority.Interactive,
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Assert
@@ -529,5 +529,59 @@ public class RedisSagaStateManagerTests {
         // Assert
         Assert.IsTrue( first );
         Assert.IsFalse( second );
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RedisSagaStateManager.InitializeProviderStatesAsync"/> never
+    /// regresses an already-recorded provider state back to pending, while still creating
+    /// pending states for providers that have no state yet.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task InitializeProviderStatesAsync_PreservesExistingProviderState( ) {
+        // Arrange
+        string lookupKey = "isrc:USRC12345678";
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+
+        _ = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            cancellationToken: TestContext.CancellationToken
+        );
+
+        ProviderLookupState completedState = new(
+            Provider: SupportedProviders.Spotify,
+            IsComplete: true,
+            IsSuccess: true,
+            ResultJson: """{"trackId": "abc123"}""",
+            CompletedAt: DateTimeOffset.UtcNow,
+            ErrorMessage: null
+        );
+
+        await _sagaManager.UpdateProviderStateAsync( sagaId, completedState, TestContext.CancellationToken );
+
+        // Act - re-initialize including the already-completed provider
+        await _sagaManager.InitializeProviderStatesAsync(
+            sagaId,
+            [SupportedProviders.Spotify, SupportedProviders.AppleMusic],
+            TestContext.CancellationToken
+        );
+
+        // Assert - completed provider is untouched, missing provider is created pending
+        LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken );
+        Assert.IsNotNull( saga );
+        Assert.HasCount( 2, saga.ProviderStates );
+
+        ProviderLookupState spotify = saga.ProviderStates[SupportedProviders.Spotify];
+        Assert.IsTrue( spotify.IsComplete );
+        Assert.IsTrue( spotify.IsSuccess );
+        Assert.AreEqual( """{"trackId": "abc123"}""", spotify.ResultJson );
+
+        ProviderLookupState apple = saga.ProviderStates[SupportedProviders.AppleMusic];
+        Assert.IsFalse( apple.IsComplete );
+        Assert.IsFalse( apple.IsSuccess );
+        Assert.IsNull( apple.ResultJson );
     }
 }

--- a/Tests/Integration/RedisSagaStateManagerTests.cs
+++ b/Tests/Integration/RedisSagaStateManagerTests.cs
@@ -90,7 +90,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Assert
@@ -120,7 +120,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Act - try to create again with different values
@@ -129,7 +129,7 @@ public class RedisSagaStateManagerTests {
             "different-key",
             LookupRequestType.UpcLookup,
             "DIFFERENT",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Assert - should return original, not new values
@@ -167,7 +167,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         ProviderLookupState providerState = new(
@@ -210,7 +210,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         ProviderLookupState spotifyState = new(
@@ -262,7 +262,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Act
@@ -292,7 +292,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Act
@@ -320,7 +320,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         await _sagaManager.UpdateProviderStateAsync( sagaId, new ProviderLookupState(
@@ -402,7 +402,7 @@ public class RedisSagaStateManagerTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Add incomplete provider
@@ -423,5 +423,111 @@ public class RedisSagaStateManagerTests {
         LookupSagaState? complete = await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken );
         Assert.IsNotNull( complete );
         Assert.IsTrue( complete.IsComplete );
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RedisSagaStateManager.GetOrCreateAsync"/> persists the origin
+    /// priority on creation and that the first recorded priority wins on resume.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task GetOrCreateAsync_PersistsOriginPriority_FirstWriterWins( ) {
+        // Arrange
+        string lookupKey = "isrc:USRC12345678";
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+
+        // Act - create with Bulk origin, then resume with Interactive
+        LookupSagaState created = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            QueuePriority.Bulk,
+            TestContext.CancellationToken
+        );
+
+        LookupSagaState resumed = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            QueuePriority.Interactive,
+            TestContext.CancellationToken
+        );
+
+        // Assert - first recorded origin priority is kept
+        Assert.AreEqual( QueuePriority.Bulk, created.OriginPriority );
+        Assert.AreEqual( QueuePriority.Bulk, resumed.OriginPriority );
+
+        LookupSagaState? fetched = await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken );
+        Assert.IsNotNull( fetched );
+        Assert.AreEqual( QueuePriority.Bulk, fetched.OriginPriority );
+    }
+
+    /// <summary>
+    /// Verifies that a saga created without an origin priority (e.g. by the orchestrator)
+    /// records the first explicitly provided origin priority on resume, and that sagas
+    /// without the field default to Background.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task GetOrCreateAsync_WithoutOriginPriority_DefaultsToBackgroundUntilRecorded( ) {
+        // Arrange
+        string lookupKey = "isrc:USRC12345678";
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+
+        // Act - create without an origin priority (orchestrator path)
+        _ = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            cancellationToken: TestContext.CancellationToken
+        );
+
+        LookupSagaState? beforeRecorded = await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken );
+
+        // Resume with the first request's priority (worker path)
+        LookupSagaState resumed = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            QueuePriority.Interactive,
+            TestContext.CancellationToken
+        );
+
+        // Assert
+        Assert.IsNotNull( beforeRecorded );
+        Assert.AreEqual( QueuePriority.Background, beforeRecorded.OriginPriority );
+        Assert.AreEqual( QueuePriority.Interactive, resumed.OriginPriority );
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RedisSagaStateManager.TryMarkSecondariesQueuedAsync"/> returns
+    /// true exactly once per saga so racing coordinator handlers cannot both queue secondaries.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task TryMarkSecondariesQueuedAsync_OnlyFirstCallerWins( ) {
+        // Arrange
+        string lookupKey = "isrc:USRC12345678";
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+
+        _ = await _sagaManager.GetOrCreateAsync(
+            sagaId,
+            lookupKey,
+            LookupRequestType.IsrcLookup,
+            "USRC12345678",
+            cancellationToken: TestContext.CancellationToken
+        );
+
+        // Act
+        bool first = await _sagaManager.TryMarkSecondariesQueuedAsync( sagaId, TestContext.CancellationToken );
+        bool second = await _sagaManager.TryMarkSecondariesQueuedAsync( sagaId, TestContext.CancellationToken );
+
+        // Assert
+        Assert.IsTrue( first );
+        Assert.IsFalse( second );
     }
 }

--- a/Tests/Integration/SagaPollingIntegrationTests.cs
+++ b/Tests/Integration/SagaPollingIntegrationTests.cs
@@ -91,7 +91,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Mark provider as complete
@@ -142,7 +142,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         await _sagaManager.UpdateProviderStateAsync( sagaId, new ProviderLookupState(
@@ -179,7 +179,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Add provider but don't complete it
@@ -214,7 +214,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         await _sagaManager.UpdateProviderStateAsync( sagaId, new ProviderLookupState(
@@ -249,7 +249,7 @@ public class SagaPollingIntegrationTests {
                 lookupKey,
                 LookupRequestType.IsrcLookup,
                 $"USRC{i:D10}",
-                TestContext.CancellationToken
+                cancellationToken: TestContext.CancellationToken
             );
 
             await _sagaManager.UpdateProviderStateAsync( sagaId, new ProviderLookupState(
@@ -359,7 +359,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Assert - Should be in pending index
@@ -384,7 +384,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Verify it's in the index
@@ -416,7 +416,7 @@ public class SagaPollingIntegrationTests {
             lookupKey,
             LookupRequestType.IsrcLookup,
             "USRC12345678",
-            TestContext.CancellationToken
+            cancellationToken: TestContext.CancellationToken
         );
 
         // Verify it's in the index

--- a/Tests/Unit/CachingMediaLinkServiceTests.cs
+++ b/Tests/Unit/CachingMediaLinkServiceTests.cs
@@ -431,11 +431,11 @@ public class CachingMediaLinkServiceTests {
     }
 
     /// <summary>
-    /// Verifies that no messages are added when the result is partial but there
-    /// are no rate-limited providers in the response.
+    /// Verifies that a pending-provider message is added when the result is partial but no
+    /// providers are rate-limited (secondary lookups still in flight).
     /// </summary>
     [TestMethod]
-    public async Task GetInfoByISRCAsync_WhenPartialButNoRateLimitedProviders_ShouldNotAddMessages( ) {
+    public async Task GetInfoByISRCAsync_WhenPartialButNoRateLimitedProviders_ShouldAddPendingMessage( ) {
         // Arrange
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
 
@@ -444,6 +444,7 @@ public class CachingMediaLinkServiceTests {
             .ReturnsAsync( new LookupResult {
                 Result = expectedResult,
                 IsPartial = true,
+                SagaId = "test-saga",
                 RateLimitedProviders = []
             } );
 
@@ -452,7 +453,36 @@ public class CachingMediaLinkServiceTests {
 
         // Assert
         Assert.IsNotNull( result );
-        Assert.IsNull( result.Messages );
+        Assert.IsTrue( result.IsPartial, "The DTO should be flagged partial for downstream consumers" );
+        Assert.IsNotNull( result.Messages );
+        Assert.HasCount( 1, result.Messages );
+        Assert.Contains( "still being fetched", result.Messages[0] );
+    }
+
+    /// <summary>
+    /// Verifies that a partial lookup result sets the partial flag on the returned DTO
+    /// even when the stored result did not carry it.
+    /// </summary>
+    [TestMethod]
+    public async Task GetInfoByISRCAsync_WhenPartial_ShouldFlagResultPartial( ) {
+        // Arrange
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        Assert.IsFalse( expectedResult.IsPartial );
+
+        _ = _orchestratorMock
+            .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
+            .ReturnsAsync( new LookupResult {
+                Result = expectedResult,
+                IsPartial = true,
+                SagaId = "test-saga"
+            } );
+
+        // Act
+        MediaLinkResult? result = await _service.GetInfoByISRCAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result );
+        Assert.IsTrue( result.IsPartial );
     }
 
     #endregion

--- a/Tests/Unit/LookupOrchestratorTests.cs
+++ b/Tests/Unit/LookupOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
@@ -307,6 +308,37 @@ public class LookupOrchestratorTests {
         ), Times.Once );
         _queueMock.Verify(
             q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), QueuePriority.Interactive ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the queued request carries the Interactive origin priority so the saga
+    /// coordinator can enqueue secondary lookups at the originating caller's priority.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WithCacheMissAndDeduplicationAcquired_ShouldEnqueueWithInteractiveOriginPriority( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+        SetupDeduplicationWaitWithResult( );
+
+        MediaLinkResult result1 = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( result1 );
+
+        // Act
+        _ = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        _queueMock.Verify(
+            q => q.EnqueueAsync(
+                It.Is<QueuedLookupRequest>( r => r.OriginPriority == QueuePriority.Interactive ),
+                QueuePriority.Interactive
+            ),
             Times.Once
         );
     }
@@ -735,6 +767,124 @@ public class LookupOrchestratorTests {
     }
 
     /// <summary>
+    /// Verifies that LookupByContentAsync uses the full interactive wait budget when the
+    /// content contains a single link.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByContentAsync_WithSingleLink_ShouldUseFullInteractiveBudget( ) {
+        // Arrange
+        string content = "Check out https://open.spotify.com/track/abc123";
+        SetupCacheMissForUrl( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        List<TimeSpan> capturedTimeouts = [];
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .Callback<string, TimeSpan, CancellationToken>( ( _, timeout, _ ) => capturedTimeouts.Add( timeout ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        List<LookupResult> results = [];
+        await foreach (LookupResult result in _orchestrator.LookupByContentAsync( content )) {
+            results.Add( result );
+        }
+
+        // Assert
+        Assert.HasCount( 1, results );
+        Assert.HasCount( 1, capturedTimeouts );
+        Assert.AreEqual( TimeSpan.FromSeconds( 30 ), capturedTimeouts[0] );
+    }
+
+    /// <summary>
+    /// Verifies that LookupByContentAsync scales the per-link wait budget down when multiple
+    /// links are present so the total stays under the content wait budget (90s).
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByContentAsync_WithMultipleLinks_ShouldScalePerLinkWaitBudget( ) {
+        // Arrange - 4 links: per-link budget = min(30s, 90s / 4) = 22.5s
+        string content = string.Join(
+            " ",
+            Enumerable.Range( 1, 4 ).Select( i => $"https://open.spotify.com/track/track{i}" )
+        );
+        SetupCacheMissForUrl( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        List<TimeSpan> capturedTimeouts = [];
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .Callback<string, TimeSpan, CancellationToken>( ( _, timeout, _ ) => capturedTimeouts.Add( timeout ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        List<LookupResult> results = [];
+        await foreach (LookupResult result in _orchestrator.LookupByContentAsync( content )) {
+            results.Add( result );
+        }
+
+        // Assert
+        Assert.HasCount( 4, results );
+        Assert.HasCount( 4, capturedTimeouts );
+        foreach (TimeSpan timeout in capturedTimeouts) {
+            Assert.AreEqual( TimeSpan.FromSeconds( 22.5 ), timeout );
+        }
+    }
+
+    /// <summary>
+    /// Verifies that LookupByContentAsync applies the per-link wait budget floor (5s) when
+    /// the content contains many links.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByContentAsync_WithManyLinks_ShouldApplyPerLinkBudgetFloor( ) {
+        // Arrange - 20 links: 90s / 20 = 4.5s, clamped up to the 5s floor
+        string content = string.Join(
+            " ",
+            Enumerable.Range( 1, 20 ).Select( i => $"https://open.spotify.com/track/track{i}" )
+        );
+        SetupCacheMissForUrl( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        List<TimeSpan> capturedTimeouts = [];
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .Callback<string, TimeSpan, CancellationToken>( ( _, timeout, _ ) => capturedTimeouts.Add( timeout ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        List<LookupResult> results = [];
+        await foreach (LookupResult result in _orchestrator.LookupByContentAsync( content )) {
+            results.Add( result );
+        }
+
+        // Assert
+        Assert.HasCount( 20, results );
+        Assert.HasCount( 20, capturedTimeouts );
+        foreach (TimeSpan timeout in capturedTimeouts) {
+            Assert.AreEqual( TimeSpan.FromSeconds( 5 ), timeout );
+        }
+    }
+
+    /// <summary>
     /// Verifies that LookupByContentAsync returns an empty collection when content has no music URLs.
     /// </summary>
     [TestMethod]
@@ -807,6 +957,725 @@ public class LookupOrchestratorTests {
     }
 
     /// <summary>
+    /// Verifies that the orchestrator keeps waiting after a partial result and returns the final
+    /// result when it is published within the time budget.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenPartialThenFinalWithinBudget_ShouldReturnFinal( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        // First read: saga is partial with a pending provider; second read: saga finalized
+        LookupSagaState partialSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+        LookupSagaState finalSaga = CreateSagaState(
+            isPartial: false,
+            partialResultUri: partialUri,
+            finalResultUri: TestRecordUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
+        );
+
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialSaga )
+            .ReturnsAsync( finalSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsFalse( result.IsPartial );
+        _deduplicatorMock.Verify(
+            d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the orchestrator returns an honestly-flagged partial result when the final
+    /// result never arrives within the time budget.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenFinalNeverArrives_ShouldReturnHonestPartial( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        LookupSagaState partialSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialSaga );
+
+        // Final never published - wait times out
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( (string?)null );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.SagaId );
+    }
+
+    /// <summary>
+    /// Verifies that the orchestrator returns the partial with rate limit info when the
+    /// rate-limited sentinel is published while waiting for the final result.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenRateLimitSentinelDuringFinalWait_ShouldReturnPartialWithInfo( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        // First read: two providers pending, none rate-limited yet (so the wait proceeds);
+        // second read (after sentinel): rate limit info recorded
+        LookupSagaState pendingSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false), (SupportedProviders.Tidal, false)]
+        );
+        LookupSagaState rateLimitedSaga = pendingSaga with { RateLimitInfo = rateLimitInfo };
+
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( pendingSaga )
+            .ReturnsAsync( rateLimitedSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( LookupConstants.RateLimitedSentinel );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        Assert.AreEqual( SupportedProviders.AppleMusic, result.RateLimitedProviders[0].Provider );
+    }
+
+    /// <summary>
+    /// Verifies that the orchestrator returns the partial immediately (without waiting)
+    /// when every pending provider is rate-limited.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenAllPendingProvidersRateLimited_ShouldReturnPartialImmediately( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState rateLimitedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: rateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( rateLimitedSaga );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        _deduplicatorMock.Verify(
+            d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a second caller (already-in-flight branch) also waits for the final
+    /// result when the published result is only partial.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WithInFlightPartialResult_ShouldKeepWaitingForFinal( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationInFlight( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        LookupSagaState partialSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+        LookupSagaState finalSaga = CreateSagaState(
+            isPartial: false,
+            partialResultUri: partialUri,
+            finalResultUri: TestRecordUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
+        );
+
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialSaga )
+            .ReturnsAsync( finalSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsFalse( result.IsPartial );
+        _sagaManagerMock.Verify(
+            s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that resuming a saga that already stored a partial result resolves it
+    /// directly without re-queueing the initial provider lookup.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenResumedSagaHasPartialResult_ShouldNotReenqueue( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        LookupSagaState resumedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .ReturnsAsync( resumedSaga );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( resumedSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( (string?)null );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ) ),
+            Times.Never
+        );
+        _deduplicatorMock.Verify(
+            d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that resuming a saga with a stored result releases the just-acquired
+    /// deduplication lock with the known result URI (instead of leaking it for its full
+    /// TTL), so concurrently blocked waiters receive the stored result.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenResumedSagaHasStoredResult_ShouldReleaseLockWithKnownUri( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        LookupSagaState resumedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .ReturnsAsync( resumedSaga );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( resumedSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( (string?)null );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        _ = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - released with the known URI (not null: an empty publish would leave waiters stuck)
+        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), partialUri ), Times.Once );
+        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), null ), Times.Never );
+    }
+
+    /// <summary>
+    /// Verifies that the already-in-flight branch skips the blind completion wait when the
+    /// saga already stored a result and instead goes to the final-result wait, which honors
+    /// the rate-limit escape hatch.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WithInFlightSagaHavingStoredResult_ShouldSkipBlindWaitAndHonorEscapeHatch( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationInFlight( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState rateLimitedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: rateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( rateLimitedSaga );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - escape hatch returned the partial without ever blind-waiting
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        _deduplicatorMock.Verify(
+            d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the already-in-flight branch returns the saga's stored partial data
+    /// (instead of a links-less result) when the rate-limited sentinel is received.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WithInFlightRateLimitSentinel_ShouldReturnStoredPartialData( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationInFlight( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState rateLimitedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: rateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        // First read (pre-wait check): no saga yet; second read (after sentinel): partial stored
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( (LookupSagaState?)null )
+            .ReturnsAsync( rateLimitedSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( LookupConstants.RateLimitedSentinel );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( partialUri ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - available partial links are returned alongside the rate-limit info
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        Assert.AreEqual( SupportedProviders.AppleMusic, result.RateLimitedProviders[0].Provider );
+    }
+
+    /// <summary>
+    /// Verifies that expired rate-limit info does not trigger the escape hatch: the
+    /// orchestrator keeps waiting and returns the final result when it arrives.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenAllPendingRateLimitsExpired_ShouldKeepWaitingForFinal( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        // Rate limit lapsed five minutes ago - waiting CAN help, escape hatch must not fire
+        List<ProviderRateLimitInfo> expiredRateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( -5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState partialSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: expiredRateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+        LookupSagaState finalSaga = CreateSagaState(
+            isPartial: false,
+            partialResultUri: partialUri,
+            finalResultUri: TestRecordUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
+        );
+
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialSaga )
+            .ReturnsAsync( finalSaga );
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        MediaLinkResult expectedResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( expectedResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - the final result was waited for instead of returning a stale partial
+        Assert.IsNotNull( result.Result );
+        Assert.IsFalse( result.IsPartial );
+        _deduplicatorMock.Verify(
+            d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that expired rate-limit info is not reported to the caller when the wait
+    /// budget runs out (no stale "retry after" messaging).
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenRateLimitExpiredAndBudgetExhausted_ShouldNotReportExpiredRateLimits( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        List<ProviderRateLimitInfo> expiredRateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( -5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState partialSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: expiredRateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialSaga );
+
+        // Final never published - wait times out
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .ReturnsAsync( (string?)null );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNull( result.RateLimitedProviders );
+    }
+
+    /// <summary>
+    /// Verifies that the creator-path timeout returns the final result when the saga has a
+    /// FinalResultUri but no partial (e.g. ISRC/UPC direct lookups never write a partial).
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenCreateWaitTimesOutWithFinalResult_ShouldReturnFinal( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        // No completion notification arrives within the budget
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( (string?)null );
+
+        LookupSagaState finalSaga = CreateSagaState(
+            isPartial: false,
+            finalResultUri: TestRecordUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true), (SupportedProviders.Tidal, true)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( finalSaga );
+
+        MediaLinkResult finalResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( TestRecordUri ) )
+            .ReturnsAsync( finalResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - the cached final result is returned, honestly flagged as complete
+        Assert.IsNotNull( result.Result );
+        Assert.IsFalse( result.IsPartial );
+        Assert.IsNull( result.SagaId );
+    }
+
+    /// <summary>
+    /// Verifies that the create path returns the saga's stored partial data (instead of a
+    /// links-less result) when the rate-limited sentinel is received.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenRateLimitSentinelOnCreatePath_ShouldReturnStoredPartialData( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( LookupConstants.RateLimitedSentinel );
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState rateLimitedSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            rateLimitInfo: rateLimitInfo,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( rateLimitedSaga );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( partialUri ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - available partial links are returned alongside the rate-limit info
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        Assert.AreEqual( SupportedProviders.AppleMusic, result.RateLimitedProviders[0].Provider );
+    }
+
+    /// <summary>
+    /// Verifies that a rate-limit condition arising in the subscribe gap (between reading
+    /// saga state and the completion subscription becoming active) is detected by the
+    /// missed-result check and resolved into a partial result via the sentinel.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenRateLimitArisesInSubscribeGap_ShouldReturnPartialViaSentinel( ) {
+        // Arrange
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+
+        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
+            .ReturnsAsync( partialUri );
+
+        List<ProviderRateLimitInfo> rateLimitInfo = [
+            new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
+        ];
+
+        LookupSagaState pendingSaga = CreateSagaState(
+            isPartial: true,
+            partialResultUri: partialUri,
+            providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
+        );
+        LookupSagaState rateLimitedSaga = pendingSaga with { RateLimitInfo = rateLimitInfo };
+
+        // First read (wait loop): no rate limits yet; second read (gap check inside the
+        // deduplicator): rate limit recorded; third read (sentinel handling): unchanged
+        _ = _sagaManagerMock
+            .SetupSequence( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( pendingSaga )
+            .ReturnsAsync( rateLimitedSaga )
+            .ReturnsAsync( rateLimitedSaga );
+
+        // Simulate the deduplicator running the missed-result check after subscribing
+        _ = _deduplicatorMock
+            .Setup( d => d.WaitForFinalCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ), It.IsAny<Func<Task<string?>>?>( ) ) )
+            .Returns( ( string _, TimeSpan _, Func<Task<string?>>? missedResultCheck, CancellationToken _ ) => missedResultCheck!( ) );
+
+        MediaLinkResult partialResult = CreateMediaLinkResult( );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( partialResult );
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert - the gap check surfaced the sentinel and the partial was returned
+        Assert.IsNotNull( result.Result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        Assert.AreEqual( SupportedProviders.AppleMusic, result.RateLimitedProviders[0].Provider );
+    }
+
+    /// <summary>
     /// Verifies that LookupByIsrcAsync releases the deduplication lock when an error occurs.
     /// </summary>
     [TestMethod]
@@ -864,6 +1733,42 @@ public class LookupOrchestratorTests {
                     IsAlbum = false
                 }
             }
+        };
+    }
+
+    /// <summary>
+    /// Creates a test <see cref="LookupSagaState"/> with the given provider completion states.
+    /// </summary>
+    private static LookupSagaState CreateSagaState(
+        bool isPartial = false,
+        string? partialResultUri = null,
+        string? finalResultUri = null,
+        List<ProviderRateLimitInfo>? rateLimitInfo = null,
+        (SupportedProviders provider, bool isComplete)[]? providers = null
+    ) {
+        Dictionary<SupportedProviders, ProviderLookupState> states = [];
+        foreach ((SupportedProviders provider, bool isComplete) in providers ?? []) {
+            states[provider] = new ProviderLookupState(
+                Provider: provider,
+                IsComplete: isComplete,
+                IsSuccess: isComplete,
+                ResultJson: null,
+                CompletedAt: isComplete ? DateTimeOffset.UtcNow : null,
+                ErrorMessage: null
+            );
+        }
+
+        return new LookupSagaState {
+            SagaId = "test-saga",
+            LookupKey = "test-key",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = TestIsrc,
+            CreatedAt = DateTimeOffset.UtcNow,
+            IsPartial = isPartial,
+            PartialResultUri = partialResultUri,
+            FinalResultUri = finalResultUri,
+            ProviderStates = states,
+            RateLimitInfo = rateLimitInfo
         };
     }
 

--- a/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
+++ b/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
@@ -220,6 +220,49 @@ public class QueueProcessorBackgroundServiceTests {
     }
 
     /// <summary>
+    /// Verifies that the request's origin priority is threaded through to saga creation so the
+    /// coordinator can later enqueue secondary lookups at the origin's priority.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_WithBulkOriginPriority_ShouldPassOriginPriorityToSagaCreation( ) {
+        // Arrange
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" ) with {
+            OriginPriority = QueuePriority.Bulk
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert
+        _sagaManagerMock.Verify(
+            s => s.GetOrCreateAsync(
+                request.SagaId,
+                It.IsAny<string>( ),
+                request.LookupType,
+                request.LookupValue,
+                It.Is<QueuePriority?>( p => p == QueuePriority.Bulk ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
     /// Verifies that messages are requeued with delay when the endpoint is rate limited.
     /// </summary>
     [TestMethod]
@@ -712,6 +755,72 @@ public class QueueProcessorBackgroundServiceTests {
                     info.Count == 1 &&
                     info[0].Provider == TestProvider &&
                     !string.IsNullOrEmpty( info[0].Endpoint )
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that rate limit info recorded by other providers is merged with (not overwritten by)
+    /// this provider's entry, so the orchestrator's all-providers-rate-limited escape hatch can
+    /// still match when multiple providers are rate-limited.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_WhenRateLimitExceptionThrown_ShouldMergeRateLimitInfoWithOtherProviders( ) {
+        // Arrange
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
+
+        // Saga already carries rate limit info from a different provider
+        ProviderRateLimitInfo existingInfo = new(
+            SupportedProviders.AppleMusic,
+            DateTimeOffset.UtcNow.AddMinutes( 5 ),
+            "IsrcLookup"
+        );
+        LookupSagaState saga = new( ) {
+            SagaId = request.SagaId,
+            LookupKey = "test-key",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US1234567890",
+            ProviderStates = [],
+            RateLimitInfo = [existingInfo]
+        };
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( saga );
+
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new RetryAfterExceededException(
+                retryAfter,
+                TimeSpan.FromSeconds( 30 ),
+                new Uri( "https://api.spotify.com/v1/tracks" ),
+                SupportedProviders.Spotify
+            ) );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert - Both the existing AppleMusic entry and the new Spotify entry are present
+        _sagaManagerMock.Verify(
+            s => s.SetRateLimitInfoAsync(
+                request.SagaId,
+                It.Is<List<ProviderRateLimitInfo>>( info =>
+                    info.Count == 2 &&
+                    info.Any( r => r.Provider == SupportedProviders.AppleMusic ) &&
+                    info.Any( r => r.Provider == TestProvider )
                 ),
                 It.IsAny<CancellationToken>( )
             ),

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -946,7 +946,9 @@ public class SagaCoordinatorBackgroundServiceTests {
 
     /// <summary>
     /// Verifies that when a concurrent handler already claimed the secondaries-queued marker,
-    /// the losing handler queues nothing but still defers finalization (writes the partial).
+    /// the losing handler queues nothing but still runs the idempotent state initialization
+    /// and partial marking (so its published partial can never read as final) and defers
+    /// finalization (writes the partial).
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -1013,9 +1015,16 @@ public class SagaCoordinatorBackgroundServiceTests {
             q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
+
+        // Assert - The idempotent state/partial writes still run (they happen before the
+        // marker claim so a published partial can never be mistaken for a final result)
         _sagaManagerMock.Verify(
             s => s.InitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ),
-            Times.Never
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
+            Times.Once
         );
 
         // Assert - It still defers finalization (secondaries pending elsewhere)
@@ -1027,6 +1036,179 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - The partial result is still written for waiting callers
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that pending provider states are initialized and the saga is marked partial
+    /// BEFORE the secondaries-queued marker is claimed. The marker loser's caller publishes
+    /// the partial and releases waiters immediately, so the saga must already read as
+    /// incomplete and partial by then - otherwise a waiting orchestrator could see
+    /// IsComplete=true with IsPartial=false and mistake the one-provider result for a final.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_ShouldInitializeStatesAndMarkPartialBeforeClaimingMarker( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        // Record the order of the saga-manager calls that close the partial-vs-final race
+        List<string> callOrder = [];
+        _ = _sagaManagerMock
+            .Setup( s => s.InitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => callOrder.Add( "InitializeProviderStates" ) )
+            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock
+            .Setup( s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => callOrder.Add( "SetIsPartial" ) )
+            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => callOrder.Add( "TryMarkSecondariesQueued" ) )
+            .ReturnsAsync( true );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - The idempotent writes both precede the marker claim
+        CollectionAssert.AreEqual(
+            new List<string> { "InitializeProviderStates", "SetIsPartial", "TryMarkSecondariesQueued" },
+            callOrder
+        );
+    }
+
+    /// <summary>
+    /// Verifies that finalization is still deferred when every secondary enqueue fails:
+    /// pending provider states were initialized and the saga marked partial, so finalizing
+    /// would publish a result missing providers as complete and overwrite richer cached
+    /// data. The partial is written instead and the stale-partial cache path retries later.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenEveryEnqueueFails_ShouldStillDeferFinalizationAndWritePartial( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        // Every secondary enqueue fails (e.g. the queue backend is unavailable)
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = queueMock
+            .Setup( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "queue unavailable" ) );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - All enqueues were attempted (AppleMusic + Tidal) and failed
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 )
+        );
+
+        // Assert - The saga is NOT finalized: the one-provider result must not be published
+        // as complete while providers are still missing
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - The partial result is written for waiting callers instead
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -55,6 +55,11 @@ public class SagaCoordinatorBackgroundServiceTests {
         _loggerMock = new Mock<ILogger<SagaCoordinatorBackgroundService>>( );
 
         _ = _redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( _subscriberMock.Object );
+
+        // By default the coordinator wins the secondaries-queued marker (no concurrent handler)
+        _ = _sagaManagerMock
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
     }
 
     #region Constructor Tests
@@ -519,6 +524,577 @@ public class SagaCoordinatorBackgroundServiceTests {
         );
     }
 
+    /// <summary>
+    /// Verifies that finalizing a saga clears its partial flag so callers no longer treat it as partial.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteFinalResult_WhenSagaIsFinalized_ShouldClearIsPartialFlag( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Should have cleared the partial flag after setting the final result URI
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( completeSaga.SagaId, false, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region Secondary Lookup Tests
+
+    /// <summary>
+    /// Verifies that when secondary lookups are queued for a completed initial lookup, the saga
+    /// is marked partial and the secondary requests are enqueued at Interactive priority so a
+    /// waiting caller receives the complete result as fast as possible.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenSecondaryLookupsQueued_ShouldMarkPartialAndQueueInteractive( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        // No cached data for the external ID - all other providers need secondary lookups
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Saga should be marked partial when secondaries are queued
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Secondary lookups queued at Interactive priority (AppleMusic + Tidal)
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), QueuePriority.Interactive, It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 )
+        );
+
+        // Assert - Partial result written with the IsPartial flag set on the stored record
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Waiters notified with the partial result URI
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( uriSaga.LookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that cached provider results found via the external ID are materialized into the
+    /// saga as completed provider states so the final result includes them, instead of a
+    /// one-provider final overwriting the richer existing record.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenAllOtherProvidersCached_ShouldMaterializeCachedResultsAndFinalize( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        // Cache has fresh data for both remaining providers - no secondary lookups needed
+        MediaLinkResult cachedResult = CreateCachedExternalIdResult( SupportedProviders.AppleMusic, SupportedProviders.Tidal );
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( (cachedResult, TestRecordUri, false) );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Cached provider results materialized into the saga as completed states
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                TestSagaId,
+                It.Is<ProviderLookupState>( p =>
+                    p.Provider == SupportedProviders.AppleMusic &&
+                    p.IsComplete &&
+                    p.IsSuccess &&
+                    p.ResultJson != null &&
+                    p.CompletedAt != null
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                TestSagaId,
+                It.Is<ProviderLookupState>( p =>
+                    p.Provider == SupportedProviders.Tidal &&
+                    p.IsComplete &&
+                    p.IsSuccess &&
+                    p.ResultJson != null
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+
+        // Assert - No secondary lookups queued (everything came from cache)
+        _queueResolverMock.Verify( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ), Times.Never );
+
+        // Assert - Final result stored with ALL three providers' results, not marked partial
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync(
+                It.Is<MediaLinkResult>( r => r.Results.Count == 3 && !r.IsPartial ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+
+        // Assert - Saga finalized
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies the mixed case: providers found in cache are materialized into the saga while
+    /// the remaining providers are queued for secondary lookups, so cached data is never dropped
+    /// from the partial (or eventual final) result.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenSomeProvidersCached_ShouldMaterializeCachedAndQueueRemaining( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        // Cache has fresh data for AppleMusic only - Tidal still needs a secondary lookup
+        MediaLinkResult cachedResult = CreateCachedExternalIdResult( SupportedProviders.AppleMusic );
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( (cachedResult, TestRecordUri, false) );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Cached AppleMusic result materialized into the saga
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                TestSagaId,
+                It.Is<ProviderLookupState>( p =>
+                    p.Provider == SupportedProviders.AppleMusic &&
+                    p.IsComplete &&
+                    p.IsSuccess &&
+                    p.ResultJson != null
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+
+        // Assert - Only the uncached provider (Tidal) queued for a secondary lookup
+        queueMock.Verify(
+            q => q.EnqueueAsync(
+                It.Is<QueuedLookupRequest>( r => r.Provider == SupportedProviders.Tidal ),
+                QueuePriority.Interactive,
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Partial result includes the cached provider's data (Spotify + AppleMusic)
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync(
+                It.Is<MediaLinkResult>( r => r.Results.Count == 2 && r.IsPartial ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once
+        );
+
+        // Assert - Saga not finalized while the secondary lookup is pending
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that secondary lookups for a bulk-origin saga (e.g. JetStream firehose) are
+    /// queued at Background priority instead of competing with interactive lookups.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenSagaOriginatedFromBulk_ShouldQueueSecondariesAtBackground( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState bulkSaga = CreateUriLookupSaga( QueuePriority.Bulk );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( bulkSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Secondaries queued at Background priority, carrying the bulk origin
+        queueMock.Verify(
+            q => q.EnqueueAsync(
+                It.Is<QueuedLookupRequest>( r => r.OriginPriority == QueuePriority.Bulk ),
+                QueuePriority.Background,
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Exactly( 2 )
+        );
+
+        // Assert - Nothing entered the interactive lane
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), QueuePriority.Interactive, It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when a concurrent handler already claimed the secondaries-queued marker,
+    /// the losing handler queues nothing but still defers finalization (writes the partial).
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenSecondariesMarkerAlreadyTaken_ShouldNotEnqueueButStillDeferFinalization( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        // Another handler already won the race to queue secondaries
+        _ = _sagaManagerMock
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - start the service, then simulate a saga completion event via Pub/Sub
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - The losing handler must not queue duplicate secondary lookups
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+        _sagaManagerMock.Verify(
+            s => s.InitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - It still defers finalization (secondaries pending elsewhere)
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - The partial result is still written for waiting callers
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the polling fallback runs the same secondary-lookup check as the Pub/Sub
+    /// handlers: a saga discovered via polling must not be finalized as complete while other
+    /// providers still need secondary lookups.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Polling_WhenUriSagaNeedsSecondaryLookups_ShouldQueueThemAndWritePartialInsteadOfFinalizing( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [uriSaga] );
+
+        // No cached data for the external ID - all other providers need secondary lookups
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( queueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - polling runs immediately on startup
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Secondary lookups queued for the missing providers (AppleMusic + Tidal)
+        queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), QueuePriority.Interactive, It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 )
+        );
+
+        // Assert - Partial result written instead of a premature final
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
     #endregion
 
     #region Helper Methods
@@ -539,6 +1115,70 @@ public class SagaCoordinatorBackgroundServiceTests {
             _enabledProviders,
             _loggerMock.Object
         );
+    }
+
+    /// <summary>
+    /// Creates a test <see cref="LookupSagaState"/> for a completed URL lookup whose result
+    /// carries an external ID, making it eligible for secondary provider lookups.
+    /// </summary>
+    /// <param name="originPriority">The origin priority recorded on the saga.</param>
+    /// <returns>A new <see cref="LookupSagaState"/> instance for a URI lookup.</returns>
+    private static LookupSagaState CreateUriLookupSaga( QueuePriority originPriority = QueuePriority.Interactive ) {
+        string resultJson = """
+        {
+            "artist": "Test Artist",
+            "title": "Test Song",
+            "externalId": "USRC12345678",
+            "url": "https://open.spotify.com/track/abc123",
+            "isAlbum": false
+        }
+        """;
+
+        return new LookupSagaState {
+            SagaId = TestSagaId,
+            LookupKey = "urilookup:testhash123",
+            LookupType = LookupRequestType.UriLookup,
+            LookupValue = "https://open.spotify.com/track/abc123",
+            CreatedAt = DateTimeOffset.UtcNow.AddSeconds( -30 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            PartialResultUri = null,
+            FinalResultUri = null,
+            IsPartial = false,
+            InitialProvider = SupportedProviders.Spotify,
+            RateLimitInfo = null,
+            OriginPriority = originPriority
+        };
+    }
+
+    /// <summary>
+    /// Creates a test <see cref="MediaLinkResult"/> representing cached external-ID data
+    /// containing results for the specified providers.
+    /// </summary>
+    /// <param name="providers">The providers with cached results.</param>
+    /// <returns>A new <see cref="MediaLinkResult"/> instance.</returns>
+    private static MediaLinkResult CreateCachedExternalIdResult( params SupportedProviders[] providers ) {
+        MediaLinkResult cachedResult = new( );
+
+        foreach (SupportedProviders provider in providers) {
+            cachedResult.Results[provider] = new MusicLookupResult {
+                Artist = "Test Artist",
+                Title = "Test Song",
+                ExternalId = "USRC12345678",
+                URL = $"https://{provider}.example.com/track/abc123",
+                IsAlbum = false
+            };
+        }
+
+        return cachedResult;
     }
 
     /// <summary>

--- a/src/BridgeBeats.Contracts/Interfaces/IRequestDeduplicator.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IRequestDeduplicator.cs
@@ -43,4 +43,31 @@ public interface IRequestDeduplicator {
     /// or <c>null</c> if the request failed or the timeout was reached.
     /// </returns>
     Task<string?> WaitForCompletionAsync( string requestKey, TimeSpan timeout, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Subscribe to the next completion notification for a request that has already produced
+    /// a partial result (the in-flight lock may already be released).
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="WaitForCompletionAsync"/>, a missing in-flight lock is NOT treated as
+    /// completion. To close the gap between the caller reading state and subscribing,
+    /// <paramref name="missedResultCheck"/> is invoked AFTER the subscription is active;
+    /// a non-empty value it returns is used as the result without waiting.
+    /// </remarks>
+    /// <param name="requestKey">The unique key for the request to wait for.</param>
+    /// <param name="timeout">Maximum time to wait for the next notification.</param>
+    /// <param name="missedResultCheck">
+    /// Optional callback that re-checks durable state (e.g., the saga's final result URI)
+    /// for a result published before the subscription was active.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// The next non-empty published payload (a result URI or rate-limit sentinel),
+    /// or <c>null</c> if the timeout was reached.
+    /// </returns>
+    Task<string?> WaitForFinalCompletionAsync(
+        string requestKey,
+        TimeSpan timeout,
+        Func<Task<string?>>? missedResultCheck = null,
+        CancellationToken cancellationToken = default );
 }

--- a/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
@@ -37,6 +37,12 @@ public interface ISagaStateManager {
     /// <param name="lookupKey">The deduplication key (e.g., "isrc:USRC12345678").</param>
     /// <param name="lookupType">Type of lookup being performed.</param>
     /// <param name="lookupValue">The raw lookup value.</param>
+    /// <param name="originPriority">
+    /// Priority of the originating request. When provided, it is recorded as the saga's
+    /// origin priority if one has not been recorded yet (first writer wins). When null,
+    /// no origin priority is written and the saga defaults to
+    /// <see cref="QueuePriority.Background"/> until a worker records one.
+    /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The saga state, either existing or newly created.</returns>
     Task<LookupSagaState> GetOrCreateAsync(
@@ -44,6 +50,7 @@ public interface ISagaStateManager {
         string lookupKey,
         LookupRequestType lookupType,
         string lookupValue,
+        QueuePriority? originPriority = null,
         CancellationToken cancellationToken = default
     );
 
@@ -207,6 +214,22 @@ public interface ISagaStateManager {
     /// <param name="rateLimitInfo">List of rate-limited provider information.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     Task SetRateLimitInfoAsync( string sagaId, List<ProviderRateLimitInfo> rateLimitInfo, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Atomically marks a saga as having had its secondary lookups queued.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The coordinator can receive both a <c>saga:completed</c> and a <c>complete:{key}</c>
+    /// event for the same completion and race itself into queueing each secondary lookup
+    /// twice. This marker is a set-if-not-exists operation so exactly one caller wins the
+    /// right to queue secondaries.
+    /// </para>
+    /// </remarks>
+    /// <param name="sagaId">The saga identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if this caller set the marker (and should queue secondaries); false if it was already set.</returns>
+    Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Initializes provider states for all enabled providers at the start of a saga.

--- a/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
+++ b/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
@@ -86,6 +86,18 @@ public sealed record LookupSagaState {
     public List<ProviderRateLimitInfo>? RateLimitInfo { get; init; }
 
     /// <summary>
+    /// Gets the priority of the request that originated this saga. Secondary lookups
+    /// inherit this so bulk-origin sagas (e.g. JetStream firehose) never compete with
+    /// interactive lookups.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="QueuePriority.Background"/> for sagas persisted before
+    /// this field existed so they are never promoted to interactive.
+    /// </remarks>
+    [JsonPropertyName( "originPriority" )]
+    public QueuePriority OriginPriority { get; init; } = QueuePriority.Background;
+
+    /// <summary>
     /// Gets the set of providers that have not yet completed their lookups.
     /// </summary>
     [JsonIgnore]

--- a/src/BridgeBeats.Contracts/Records/MediaLinkResultRecord.cs
+++ b/src/BridgeBeats.Contracts/Records/MediaLinkResultRecord.cs
@@ -20,13 +20,16 @@ public sealed record MediaLinkResultRecord : AtProtoRecord {
     /// </summary>
     /// <param name="results">Collection of lookup results from each provider.</param>
     /// <param name="lookedUpAt">ISO 8601 timestamp of when this lookup was performed.</param>
+    /// <param name="isPartial">Whether this record holds partial results (some providers still pending).</param>
     [JsonConstructor]
     public MediaLinkResultRecord(
         ICollection<ProviderResultRecord> results,
-        DateTimeOffset lookedUpAt
+        DateTimeOffset lookedUpAt,
+        bool isPartial = false
     ) : base( ) {
         Results = results ?? throw new ArgumentNullException( nameof( results ) );
         LookedUpAt = lookedUpAt;
+        IsPartial = isPartial;
     }
 
     /// <summary>
@@ -42,4 +45,12 @@ public sealed record MediaLinkResultRecord : AtProtoRecord {
     [JsonPropertyName( "lookedUpAt" )]
     [JsonRequired]
     public DateTimeOffset LookedUpAt { get; init; }
+
+    /// <summary>
+    /// Whether this record holds partial results (some providers still pending).
+    /// Omitted from storage when false so existing records remain unchanged.
+    /// </summary>
+    [JsonPropertyName( "isPartial" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingDefault )]
+    public bool IsPartial { get; init; }
 }

--- a/src/BridgeBeats.Contracts/Records/QueueSettings.cs
+++ b/src/BridgeBeats.Contracts/Records/QueueSettings.cs
@@ -21,6 +21,13 @@ public sealed record QueueSettings {
     public int JobExpirationMinutes { get; init; } = 60;
 
     /// <summary>
+    /// Gets the total time budget (in seconds) an interactive caller waits for a complete
+    /// lookup result before returning the best available partial result.
+    /// </summary>
+    [JsonPropertyName( "interactiveWaitSeconds" )]
+    public int InteractiveWaitSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Gets the priority weighting configuration.
     /// </summary>
     [JsonPropertyName( "weights" )]

--- a/src/BridgeBeats.Contracts/Records/QueuedLookupRequest.cs
+++ b/src/BridgeBeats.Contracts/Records/QueuedLookupRequest.cs
@@ -81,4 +81,15 @@ public sealed record QueuedLookupRequest : IQueueableRequest {
     [JsonPropertyName( "rateLimitedEndpoint" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string? RateLimitedEndpoint { get; init; }
+
+    /// <summary>
+    /// Gets the priority of the originating request, persisted into the saga so
+    /// secondary lookups inherit the origin's urgency.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="QueuePriority.Background"/> so in-flight messages
+    /// serialized before this field existed are never promoted to interactive.
+    /// </remarks>
+    [JsonPropertyName( "originPriority" )]
+    public QueuePriority OriginPriority { get; init; } = QueuePriority.Background;
 }

--- a/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
@@ -287,7 +287,8 @@ public static class ServiceExtensions {
                     s.GetRequiredService<IProviderQueueResolver<QueuedLookupRequest>>( ),
                     s.GetRequiredService<IATProtoStorageService>( ),
                     enabledProviders,
-                    s.GetRequiredService<ILogger<LookupOrchestrator>>( )
+                    s.GetRequiredService<ILogger<LookupOrchestrator>>( ),
+                    s.GetService<IOptions<QueueSettings>>( )?.Value
                 )
             );
 

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/CachingMediaLinkService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/CachingMediaLinkService.cs
@@ -73,7 +73,7 @@ public sealed partial class CachingMediaLinkService(
     }
 
     /// <summary>
-    /// Adds rate limit information to the result's messages if this is a partial result.
+    /// Adds rate limit or pending-provider information to the result's messages if this is a partial result.
     /// Creates a lightweight result with messages when no data is available but rate limiting occurred.
     /// </summary>
     private MediaLinkResult? AddPartialMessage( LookupResult lookupResult ) {
@@ -99,14 +99,23 @@ public sealed partial class CachingMediaLinkService(
             return null;
         }
 
-        if (lookupResult.IsPartial && lookupResult.RateLimitedProviders is { Count: > 0 }) {
+        if (lookupResult.IsPartial) {
+            // Keep the DTO honest for downstream consumers (web UI, bot, cache)
+            lookupResult.Result.IsPartial = true;
             lookupResult.Result.Messages ??= [];
 
-            foreach (ProviderRateLimitInfo rateLimitInfo in lookupResult.RateLimitedProviders) {
-                string message = $"{rateLimitInfo.Provider} is temporarily unavailable. Results will be updated when available (retry after {rateLimitInfo.RetryAfter:u}).";
-                lookupResult.Result.Messages.Add( message );
+            if (lookupResult.RateLimitedProviders is { Count: > 0 }) {
+                foreach (ProviderRateLimitInfo rateLimitInfo in lookupResult.RateLimitedProviders) {
+                    string message = $"{rateLimitInfo.Provider} is temporarily unavailable. Results will be updated when available (retry after {rateLimitInfo.RetryAfter:u}).";
+                    lookupResult.Result.Messages.Add( message );
 
-                LogPartialResultReturned( _logger, lookupResult.SagaId ?? string.Empty, rateLimitInfo.Provider, rateLimitInfo.RetryAfter );
+                    LogPartialResultReturned( _logger, lookupResult.SagaId ?? string.Empty, rateLimitInfo.Provider, rateLimitInfo.RetryAfter );
+                }
+            } else {
+                // Partial because secondary provider lookups are still pending
+                lookupResult.Result.Messages.Add( "Additional provider results are still being fetched. Look up this link again shortly for the complete set of links." );
+
+                LogPendingPartialReturned( _logger, lookupResult.SagaId ?? string.Empty );
             }
         }
 
@@ -123,6 +132,15 @@ public sealed partial class CachingMediaLinkService(
         Level = LogLevel.Information,
         Message = "Partial result returned for saga {SagaId}. {Provider} rate-limited until {RetryAfter}" )]
     private static partial void LogPartialResultReturned( ILogger logger, string sagaId, SupportedProviders provider, DateTimeOffset retryAfter );
+
+    /// <summary>
+    /// Logs that a partial result was returned with secondary provider lookups still pending.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.PendingPartialResultReturned,
+        Level = LogLevel.Information,
+        Message = "Partial result returned for saga {SagaId} with secondary provider lookups still pending" )]
+    private static partial void LogPendingPartialReturned( ILogger logger, string sagaId );
 
     #endregion LoggerMessage Definitions
 }

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
@@ -21,8 +21,9 @@ namespace BridgeBeats.Services.LinkResolver;
 /// 3. If in-flight, subscribe to completion notification
 /// 4. Otherwise, create saga, queue initial provider lookup
 /// 5. Wait for initial result via Pub/Sub
-/// 6. On result, spawn secondary provider lookups at Background priority
-/// 7. Return result to caller (partial if rate-limited)
+/// 6. On a partial result (secondary lookups pending), keep waiting with the
+///    remaining time budget until the final result is published
+/// 7. Return result to caller (partial only when rate-limited or the budget is exhausted)
 /// </para>
 /// </remarks>
 /// <remarks>
@@ -35,7 +36,8 @@ public sealed partial class LookupOrchestrator(
     IProviderQueueResolver<QueuedLookupRequest> queueResolver,
     IATProtoStorageService atProtoStorage,
     HashSet<SupportedProviders> enabledProviders,
-    ILogger<LookupOrchestrator> logger
+    ILogger<LookupOrchestrator> logger,
+    QueueSettings? settings = null
 ) : ILookupOrchestrator {
     private readonly IMediaLinkCacheRepository _cache = cache
                                                         ?? throw new ArgumentNullException( nameof( cache ) );
@@ -52,8 +54,24 @@ public sealed partial class LookupOrchestrator(
     private readonly ILogger<LookupOrchestrator> _logger = logger
                                                          ?? throw new ArgumentNullException( nameof( logger ) );
 
-    private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds( 30 );
+    private readonly TimeSpan _interactiveWaitTimeout = TimeSpan.FromSeconds( (settings ?? new QueueSettings( )).InteractiveWaitSeconds );
+
     private static readonly TimeSpan s_deduplicationLockDuration = TimeSpan.FromMinutes( 5 );
+
+    /// <summary>
+    /// Target wait budget across all links of a single content lookup, kept under the
+    /// Discord bot's 120s HTTP client timeout (see BridgeBeats.Worker.Discord Program.cs)
+    /// so the server-side budget, not the transport, is the binding constraint. Note the
+    /// per-link floor below takes precedence, so messages with more than 18 links can
+    /// exceed this target (and beyond ~24 links may exceed the bot's transport timeout).
+    /// </summary>
+    private static readonly TimeSpan s_maxContentWaitBudget = TimeSpan.FromSeconds( 90 );
+
+    /// <summary>
+    /// Floor for the scaled per-link wait budget so every link gets a usable wait window.
+    /// Takes precedence over <see cref="s_maxContentWaitBudget"/> for very link-heavy messages.
+    /// </summary>
+    private static readonly TimeSpan s_minPerLinkWaitBudget = TimeSpan.FromSeconds( 5 );
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<LookupResult> LookupByContentAsync( string content ) {
@@ -61,7 +79,10 @@ public sealed partial class LookupOrchestrator(
             yield break;
         }
 
+        // Collect unique links for enabled providers up front so the per-link wait
+        // budget can be scaled to the number of links
         HashSet<string> processedLinks = new( StringComparer.OrdinalIgnoreCase );
+        List<(string Link, SupportedProviders Provider)> links = [];
 
         foreach (string link in ValidHttpsLink( ).GetGroupValues( content, "Url" )) {
             if (!processedLinks.Add( link )) {
@@ -74,7 +95,25 @@ public sealed partial class LookupOrchestrator(
                 continue;
             }
 
-            LookupResult result = await LookupByUrlAsync( link, provider.Value );
+            links.Add( (link, provider.Value) );
+        }
+
+        if (links.Count == 0) {
+            yield break;
+        }
+
+        // Links resolve sequentially, each waiting up to the interactive budget; scale
+        // the per-link budget so the total stays under s_maxContentWaitBudget (a Discord
+        // multi-link message must finish before the bot's HTTP transport gives up)
+        TimeSpan perLinkBudget = TimeSpan.FromTicks(
+            Math.Min( _interactiveWaitTimeout.Ticks, s_maxContentWaitBudget.Ticks / links.Count )
+        );
+        if (perLinkBudget < s_minPerLinkWaitBudget) {
+            perLinkBudget = s_minPerLinkWaitBudget;
+        }
+
+        foreach ((string link, SupportedProviders provider) in links) {
+            LookupResult result = await LookupByUrlAsync( link, provider, perLinkBudget );
             yield return result;
         }
     }
@@ -154,7 +193,7 @@ public sealed partial class LookupOrchestrator(
         );
     }
 
-    private async Task<LookupResult> LookupByUrlAsync( string url, SupportedProviders provider ) {
+    private async Task<LookupResult> LookupByUrlAsync( string url, SupportedProviders provider, TimeSpan? waitBudget = null ) {
         string lookupKey = $"{LookupRequestType.UriLookup}:{HashUtility.HashUrl( url )}";
 
         return await PerformLookupAsync(
@@ -163,7 +202,8 @@ public sealed partial class LookupOrchestrator(
             lookupValue: url,
             cacheCheck: ( ) => _cache.TryGetCachedResultAsync( url ),
             isAlbum: false, // Will be determined by the lookup
-            initialProvider: provider
+            initialProvider: provider,
+            waitBudget: waitBudget
         );
     }
 
@@ -175,16 +215,20 @@ public sealed partial class LookupOrchestrator(
         bool isAlbum = false,
         string? title = null,
         string? artist = null,
-        SupportedProviders? initialProvider = null
+        SupportedProviders? initialProvider = null,
+        TimeSpan? waitBudget = null
     ) {
-        // Step 1: Check cache
+        TimeSpan waitTimeout = waitBudget ?? _interactiveWaitTimeout;
+
+        // Step 1: Check cache. Partial results are reported stale by the cache so they
+        // fall through to the dedup/wait logic below instead of masquerading as final.
         (MediaLinkResult result, string recordUri, bool isStale)? cached = await cacheCheck( );
 
         if (cached.HasValue && !cached.Value.isStale) {
             LogCacheHit( _logger, lookupKey );
             return new LookupResult {
                 Result = cached.Value.result,
-                IsPartial = false
+                IsPartial = cached.Value.result.IsPartial
             };
         }
 
@@ -194,27 +238,32 @@ public sealed partial class LookupOrchestrator(
         if (!dedup.Acquired && dedup.AlreadyInFlight) {
             LogRequestAlreadyInFlight( _logger, lookupKey );
 
-            // Wait for the other instance to complete
-            string? resultUri = await _deduplicator.WaitForCompletionAsync( lookupKey, s_defaultTimeout );
+            string inFlightSagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+            DateTimeOffset deadline = DateTimeOffset.UtcNow + waitTimeout;
 
-            // Check for rate-limited sentinel
+            // When the in-flight saga already stored a result, skip the blind wait and go
+            // straight to the final-result wait, which honors the rate-limit escape hatch
+            // and time budget (during a rate-limit window no publish would ever arrive)
+            LookupSagaState? inFlightSaga = await _sagaManager.GetAsync( inFlightSagaId );
+            string? storedResultUri = inFlightSaga?.FinalResultUri ?? inFlightSaga?.PartialResultUri;
+            if (!string.IsNullOrEmpty( storedResultUri )) {
+                LogInFlightSagaHasStoredResult( _logger, inFlightSagaId );
+                return await WaitForFinalResultAsync( lookupKey, inFlightSagaId, storedResultUri, deadline );
+            }
+
+            // Wait for the other instance to complete
+            string? resultUri = await _deduplicator.WaitForCompletionAsync( lookupKey, waitTimeout );
+
+            // Check for rate-limited sentinel - return any stored partial data
+            // alongside the rate-limit info instead of dropping it
             if (resultUri == LookupConstants.RateLimitedSentinel) {
-                string rateLimitSagaId = ISagaStateManager.GenerateSagaId( lookupKey );
-                LookupSagaState? rateLimitedSaga = await _sagaManager.GetAsync( rateLimitSagaId );
-                return new LookupResult {
-                    Result = null,
-                    IsPartial = true,
-                    SagaId = rateLimitSagaId,
-                    RateLimitedProviders = rateLimitedSaga?.RateLimitInfo
-                };
+                return await BuildRateLimitedPartialAsync( inFlightSagaId );
             }
 
             if (!string.IsNullOrEmpty( resultUri )) {
-                MediaLinkResult? completedResult = await _atProtoStorage.GetMediaLinkResultAsync( resultUri );
-                return new LookupResult {
-                    Result = completedResult,
-                    IsPartial = false
-                };
+                // The published result may be partial (secondary lookups pending) -
+                // keep waiting for the final with the remaining time budget
+                return await WaitForFinalResultAsync( lookupKey, inFlightSagaId, resultUri, deadline );
             }
 
             // Timeout or failure - check cache again, might have been populated
@@ -222,7 +271,8 @@ public sealed partial class LookupOrchestrator(
             if (cached.HasValue) {
                 return new LookupResult {
                     Result = cached.Value.result,
-                    IsPartial = false
+                    IsPartial = cached.Value.result.IsPartial,
+                    SagaId = cached.Value.result.IsPartial ? inFlightSagaId : null
                 };
             }
 
@@ -239,7 +289,8 @@ public sealed partial class LookupOrchestrator(
                 isAlbum,
                 title,
                 artist,
-                initialProvider
+                initialProvider,
+                waitTimeout
             );
         } catch (Exception ex) {
             LogLookupError( _logger, ex, lookupKey );
@@ -258,20 +309,38 @@ public sealed partial class LookupOrchestrator(
         bool isAlbum,
         string? title,
         string? artist,
-        SupportedProviders? initialProvider
+        SupportedProviders? initialProvider,
+        TimeSpan waitTimeout
     ) {
         // Generate deterministic saga ID from lookup key
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
 
-        // Create saga
-        _ = await _sagaManager.GetOrCreateAsync( sagaId, lookupKey, lookupType, lookupValue );
+        // Create saga (or resume an in-progress one, e.g. when a cached partial sent us back here)
+        LookupSagaState saga = await _sagaManager.GetOrCreateAsync( sagaId, lookupKey, lookupType, lookupValue );
+
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + waitTimeout;
+
+        // Resumed saga that already stored a result: resolve it directly instead of re-queueing
+        string? knownResultUri = saga.FinalResultUri ?? saga.PartialResultUri;
+        if (!string.IsNullOrEmpty( knownResultUri )) {
+            LogSagaResumedWithResult( _logger, sagaId );
+
+            // Release the just-acquired in-flight lock before waiting: this path enqueues
+            // no work, so nothing else would release it (the coordinator runs in another
+            // process and its release is ownership-checked). Publishing the known URI
+            // hands the stored result to callers already blocked in WaitForCompletionAsync.
+            await _deduplicator.ReleaseAsync( lookupKey, knownResultUri );
+
+            return await WaitForFinalResultAsync( lookupKey, sagaId, knownResultUri, deadline );
+        }
 
         // Determine which provider to queue first
         SupportedProviders firstProvider = initialProvider ?? _enabledProviders.First();
 
         // For direct lookups (ISRC/UPC without initialProvider), initialize all enabled providers
         // For URL lookups (with initialProvider), only initialize the first provider
-        // Secondary provider lookups will create their own separate sagas
+        // The saga coordinator adds the remaining providers to the SAME saga once the
+        // initial result yields an external ID for secondary lookups
         List<SupportedProviders> providersToInitialize = initialProvider.HasValue
             ? [firstProvider]
             : [.. _enabledProviders];
@@ -283,77 +352,220 @@ public sealed partial class LookupOrchestrator(
             await _sagaManager.SetInitialProviderAsync( sagaId, initialProvider.Value );
         }
 
-        // Queue the initial provider lookup at Interactive priority
+        // Queue the initial provider lookup at Interactive priority,
+        // unless the resumed saga already has this provider queued or completed
+        if (!saga.ProviderStates.ContainsKey( firstProvider )) {
+            QueuedLookupRequest request = new( ) {
+                RequestId = Guid.NewGuid( ).ToString( "N" ),
+                Provider = firstProvider,
+                LookupType = lookupType,
+                LookupValue = lookupValue,
+                SagaId = sagaId,
+                IsAlbum = isAlbum,
+                Title = title,
+                Artist = artist,
+                // Interactive origin is persisted into the saga so secondary lookups
+                // spawned by the coordinator inherit the caller's urgency
+                OriginPriority = QueuePriority.Interactive
+            };
 
-        QueuedLookupRequest request = new( ) {
-            RequestId = Guid.NewGuid( ).ToString( "N" ),
-            Provider = firstProvider,
-            LookupType = lookupType,
-            LookupValue = lookupValue,
-            SagaId = sagaId,
-            IsAlbum = isAlbum,
-            Title = title,
-            Artist = artist
-        };
+            IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue( firstProvider );
+            await queue.EnqueueAsync( request, QueuePriority.Interactive );
 
-        IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue( firstProvider );
-        await queue.EnqueueAsync( request, QueuePriority.Interactive );
-
-        LogSagaCreated( _logger, sagaId, firstProvider, lookupType, lookupValue );
+            LogSagaCreated( _logger, sagaId, firstProvider, lookupType, lookupValue );
+        }
 
         // Wait for initial result via deduplicator subscription
-        string? resultUri = await _deduplicator.WaitForCompletionAsync( lookupKey, s_defaultTimeout );
+        string? resultUri = await _deduplicator.WaitForCompletionAsync( lookupKey, waitTimeout );
 
-        // Check for rate-limited sentinel
+        // Check for rate-limited sentinel - return any stored partial data alongside the
+        // rate-limit info (the partial write may land moments after the sentinel)
         if (resultUri == LookupConstants.RateLimitedSentinel) {
-            LookupSagaState? rateLimitedSaga = await _sagaManager.GetAsync( sagaId );
-            return new LookupResult {
-                Result = null,
-                IsPartial = true,
-                SagaId = sagaId,
-                RateLimitedProviders = rateLimitedSaga?.RateLimitInfo
-            };
+            return await BuildRateLimitedPartialAsync( sagaId );
         }
 
         if (!string.IsNullOrEmpty( resultUri )) {
-            // Initial lookup completed, fetch result
-            MediaLinkResult? result = await _atProtoStorage.GetMediaLinkResultAsync( resultUri );
-
-            // Check if saga is complete or has pending providers
-            LookupSagaState? updatedSaga = await _sagaManager.GetAsync( sagaId );
-
-            return updatedSaga is not null
-                ? new LookupResult {
-                    Result = result,
-                    IsPartial = updatedSaga.IsPartial,
-                    SagaId = updatedSaga.IsPartial ? sagaId : null,
-                    RateLimitedProviders = updatedSaga.RateLimitInfo
-                }
-                : new LookupResult {
-                    Result = result,
-                    IsPartial = false
-                };
+            // Initial lookup completed - the published result may be partial (secondary
+            // lookups pending), so keep waiting for the final with the remaining budget
+            return await WaitForFinalResultAsync( lookupKey, sagaId, resultUri, deadline );
         }
 
-        // Timeout - check if we have any result
+        // Timeout - check if we have any result. ISRC/UPC direct lookups never write a
+        // partial, so the final result URI must be honored too.
         LookupSagaState? saga2 = await _sagaManager.GetAsync( sagaId );
 
-        if (saga2?.PartialResultUri is not null) {
-            MediaLinkResult? partialResult = await _atProtoStorage.GetMediaLinkResultAsync( saga2.PartialResultUri );
-            return new LookupResult {
-                Result = partialResult,
-                IsPartial = true,
-                SagaId = sagaId,
-                RateLimitedProviders = saga2.RateLimitInfo
-            };
+        string? storedResultUri = saga2?.FinalResultUri ?? saga2?.PartialResultUri;
+        if (storedResultUri is not null) {
+            MediaLinkResult? storedResult = await _atProtoStorage.GetMediaLinkResultAsync( storedResultUri );
+            return !string.IsNullOrEmpty( saga2!.FinalResultUri )
+                ? new LookupResult { Result = storedResult, IsPartial = false }
+                : CreatePartialResult( storedResult, sagaId, saga2 );
         }
 
         // No result yet
         return new LookupResult {
             Result = null,
             IsPartial = true,
-            SagaId = sagaId
+            SagaId = sagaId,
+            RateLimitedProviders = GetActiveRateLimits( saga2 )
         };
+    }
+
+    /// <summary>
+    /// Resolves a completion notification into a final result, re-waiting with the remaining
+    /// time budget while the published result is only partial (secondary lookups pending).
+    /// </summary>
+    /// <remarks>
+    /// Returns a partial result immediately when every pending provider is rate-limited
+    /// (waiting cannot help) and honestly flags the result partial when the budget runs out.
+    /// </remarks>
+    /// <param name="lookupKey">The deduplication lookup key (completion channel suffix).</param>
+    /// <param name="sagaId">The deterministic saga ID for the lookup.</param>
+    /// <param name="resultUri">The result URI received from the completion channel.</param>
+    /// <param name="deadline">Absolute point in time at which waiting stops.</param>
+    private async Task<LookupResult> WaitForFinalResultAsync(
+        string lookupKey,
+        string sagaId,
+        string resultUri,
+        DateTimeOffset deadline
+    ) {
+        while (true) {
+            LookupSagaState? saga = await _sagaManager.GetAsync( sagaId );
+
+            // Prefer the final result URI once available (it may differ from the partial's)
+            if (!string.IsNullOrEmpty( saga?.FinalResultUri )) {
+                resultUri = saga.FinalResultUri;
+            }
+
+            MediaLinkResult? result = await _atProtoStorage.GetMediaLinkResultAsync( resultUri );
+
+            // Saga state missing (expired/deleted) - trust the stored result's own flag
+            if (saga is null) {
+                return new LookupResult {
+                    Result = result,
+                    IsPartial = result?.IsPartial ?? false,
+                    SagaId = result?.IsPartial == true ? sagaId : null
+                };
+            }
+
+            bool isFinal = !string.IsNullOrEmpty( saga.FinalResultUri )
+                        || (saga.IsComplete && !saga.IsPartial);
+
+            if (isFinal) {
+                return new LookupResult {
+                    Result = result,
+                    IsPartial = false
+                };
+            }
+
+            // When every pending provider is rate-limited, waiting cannot help -
+            // return the partial with rate-limit info immediately (approved escape hatch).
+            // Expired rate-limit entries are ignored so an imminent full result is still
+            // waited for instead of returning a stale partial.
+            if (AllPendingProvidersRateLimited( saga )) {
+                LogReturningRateLimitedPartial( _logger, sagaId );
+                return CreatePartialResult( result, sagaId, saga );
+            }
+
+            TimeSpan remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero) {
+                LogWaitBudgetExhausted( _logger, sagaId );
+                return CreatePartialResult( result, sagaId, saga );
+            }
+
+            LogWaitingForFinalResult( _logger, sagaId, remaining.TotalSeconds );
+
+            // Subscribe before re-reading saga state (inside the deduplicator) so a final
+            // result or rate-limit sentinel published in the gap is never missed
+            string? nextUri = await _deduplicator.WaitForFinalCompletionAsync(
+                lookupKey,
+                remaining,
+                async ( ) => {
+                    LookupSagaState? gapSaga = await _sagaManager.GetAsync( sagaId );
+                    if (!string.IsNullOrEmpty( gapSaga?.FinalResultUri )) {
+                        return gapSaga.FinalResultUri;
+                    }
+
+                    // A rate-limit condition arising in the gap is equally unrecoverable
+                    // by waiting - surface the sentinel so the escape hatch applies
+                    return gapSaga is not null && AllPendingProvidersRateLimited( gapSaga )
+                        ? LookupConstants.RateLimitedSentinel
+                        : null;
+                }
+            );
+
+            if (nextUri == LookupConstants.RateLimitedSentinel) {
+                return await BuildRateLimitedPartialAsync( sagaId, result );
+            }
+
+            if (string.IsNullOrEmpty( nextUri )) {
+                // Timed out - re-check once in case the final landed without a notification
+                saga = await _sagaManager.GetAsync( sagaId );
+                if (!string.IsNullOrEmpty( saga?.FinalResultUri )) {
+                    resultUri = saga.FinalResultUri;
+                    continue;
+                }
+
+                LogWaitBudgetExhausted( _logger, sagaId );
+                return CreatePartialResult( result, sagaId, saga );
+            }
+
+            resultUri = nextUri;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a rate-limit sentinel into the best available partial response: the saga's
+    /// stored result (final preferred over partial) is fetched so available provider links
+    /// are returned alongside the rate-limit info instead of being dropped.
+    /// </summary>
+    /// <param name="sagaId">The deterministic saga ID for the lookup.</param>
+    /// <param name="knownResult">An already-fetched result to reuse instead of re-fetching.</param>
+    private async Task<LookupResult> BuildRateLimitedPartialAsync( string sagaId, MediaLinkResult? knownResult = null ) {
+        LookupSagaState? saga = await _sagaManager.GetAsync( sagaId );
+
+        MediaLinkResult? result = knownResult;
+        string? storedResultUri = saga?.FinalResultUri ?? saga?.PartialResultUri;
+        if (result is null && !string.IsNullOrEmpty( storedResultUri )) {
+            result = await _atProtoStorage.GetMediaLinkResultAsync( storedResultUri );
+        }
+
+        LogReturningRateLimitedPartial( _logger, sagaId );
+        return CreatePartialResult( result, sagaId, saga );
+    }
+
+    /// <summary>
+    /// Creates a partial <see cref="LookupResult"/> carrying the saga's unexpired rate-limit info.
+    /// </summary>
+    private static LookupResult CreatePartialResult( MediaLinkResult? result, string sagaId, LookupSagaState? saga )
+        => new( ) {
+            Result = result,
+            IsPartial = true,
+            SagaId = sagaId,
+            RateLimitedProviders = GetActiveRateLimits( saga )
+        };
+
+    /// <summary>
+    /// Filters the saga's rate-limit info down to entries whose retry-after has not yet
+    /// lapsed, so expired limits neither trigger the escape hatch nor produce stale
+    /// "retry after" user messaging. Returns null when nothing is actively rate-limited.
+    /// </summary>
+    private static List<ProviderRateLimitInfo>? GetActiveRateLimits( LookupSagaState? saga ) {
+        List<ProviderRateLimitInfo>? activeRateLimits = saga?.RateLimitInfo?
+            .Where( r => r.RetryAfter > DateTimeOffset.UtcNow )
+            .ToList( );
+
+        return activeRateLimits is { Count: > 0 } ? activeRateLimits : null;
+    }
+
+    /// <summary>
+    /// Determines whether every pending provider is covered by an unexpired rate limit,
+    /// meaning waiting longer cannot produce additional results.
+    /// </summary>
+    private static bool AllPendingProvidersRateLimited( LookupSagaState saga ) {
+        List<ProviderRateLimitInfo>? activeRateLimits = GetActiveRateLimits( saga );
+        return activeRateLimits is not null
+            && saga.PendingProviders.All( p => activeRateLimits.Any( r => r.Provider == p ) );
     }
 
     private static SupportedProviders? DetermineProviderFromUrl( string url ) {
@@ -414,6 +626,51 @@ public sealed partial class LookupOrchestrator(
         Level = LogLevel.Information,
         Message = "Created saga {SagaId} and queued initial lookup for {Provider} ({LookupType}:{LookupValue})" )]
     private static partial void LogSagaCreated( ILogger logger, string sagaId, SupportedProviders provider, LookupRequestType lookupType, string lookupValue );
+
+    /// <summary>
+    /// Logs that an in-flight saga already stored a result, so the final-result wait is used directly.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.OrchestratorInFlightSagaHasStoredResult,
+        Level = LogLevel.Debug,
+        Message = "In-flight saga {SagaId} already stored a result, waiting for the final result directly" )]
+    private static partial void LogInFlightSagaHasStoredResult( ILogger logger, string sagaId );
+
+    /// <summary>
+    /// Logs that an existing saga with a stored result was resumed.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.OrchestratorSagaResumedWithResult,
+        Level = LogLevel.Debug,
+        Message = "Resumed saga {SagaId} with an existing stored result, resolving directly" )]
+    private static partial void LogSagaResumedWithResult( ILogger logger, string sagaId );
+
+    /// <summary>
+    /// Logs that the orchestrator keeps waiting for the final result of a partial saga.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.OrchestratorWaitingForFinalResult,
+        Level = LogLevel.Debug,
+        Message = "Saga {SagaId} is partial, waiting up to {RemainingSeconds:F1}s for the final result" )]
+    private static partial void LogWaitingForFinalResult( ILogger logger, string sagaId, double remainingSeconds );
+
+    /// <summary>
+    /// Logs that a partial result is returned because all pending providers are rate-limited.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.OrchestratorReturningRateLimitedPartial,
+        Level = LogLevel.Information,
+        Message = "All pending providers for saga {SagaId} are rate-limited, returning partial result" )]
+    private static partial void LogReturningRateLimitedPartial( ILogger logger, string sagaId );
+
+    /// <summary>
+    /// Logs that the interactive wait budget was exhausted before the final result arrived.
+    /// </summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.LinkResolver.OrchestratorWaitBudgetExhausted,
+        Level = LogLevel.Information,
+        Message = "Wait budget exhausted for saga {SagaId}, returning best available partial result" )]
+    private static partial void LogWaitBudgetExhausted( ILogger logger, string sagaId );
 
     #endregion LoggerMessage Definitions
 }

--- a/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
@@ -133,6 +133,7 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
             $"{request.LookupType}:{request.LookupValue}",
             request.LookupType,
             request.LookupValue,
+            request.OriginPriority,
             ct
         );
 
@@ -240,11 +241,19 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
 
         // Mark saga as partial and record rate limit info for user notification
         await _sagaManager.SetIsPartialAsync( request.SagaId, true, ct );
-        await _sagaManager.SetRateLimitInfoAsync(
-            request.SagaId,
-            [new ProviderRateLimitInfo( _provider, retryAfter, endpoint )],
-            ct
-        );
+
+        // Merge with rate limit info recorded by other providers so no entry is lost -
+        // the orchestrator's all-pending-providers-rate-limited escape hatch depends on
+        // every rate-limited provider being present. This is a read-modify-write (the
+        // saga manager has no atomic merge); a lost update under concurrent writes only
+        // degrades to the previous overwrite behavior.
+        LookupSagaState? sagaForRateLimit = await _sagaManager.GetAsync( request.SagaId, ct );
+        List<ProviderRateLimitInfo> mergedRateLimitInfo = sagaForRateLimit?.RateLimitInfo is not null
+            ? [.. sagaForRateLimit.RateLimitInfo.Where( r => r.Provider != _provider )]
+            : [];
+        mergedRateLimitInfo.Add( new ProviderRateLimitInfo( _provider, retryAfter, endpoint ) );
+
+        await _sagaManager.SetRateLimitInfoAsync( request.SagaId, mergedRateLimitInfo, ct );
 
         // Publish rate-limited sentinel so waiting clients know this is a partial result
         await PublishRateLimitSentinelAsync( request.SagaId, ct );

--- a/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
@@ -419,13 +419,15 @@ public sealed partial class RedisMediaLinkCache : IMediaLinkCacheRepository {
 
     /// <summary>
     /// Checks if a result is stale based on the cache days configuration.
+    /// Partial results are always stale-eligible so callers re-enter the lookup path
+    /// and wait for the complete result instead of serving the partial as final.
     /// </summary>
     private (MediaLinkResult result, string recordUri, bool isStale) CheckRecordFreshness(
         MediaLinkResult result,
         string recordUri
     ) {
         DateTime expirationDate = DateTime.UtcNow.AddDays( -_cacheDays );
-        bool isStale = result.LookedUpAt < expirationDate;
+        bool isStale = result.IsPartial || result.LookedUpAt < expirationDate;
         return (result, recordUri, isStale);
     }
 

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -465,6 +465,16 @@ public static class LogEventIds {
             /// </summary>
             public const int RedisSagaStateManagerRemovedFromPendingIndex = 1314;
 
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogOriginPrioritySet"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerOriginPrioritySet = 1315;
+
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogSecondariesQueuedMarker"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerSecondariesQueuedMarker = 1316;
+
             // RedisRequestDeduplicator (1350-1374)
 
             /// <summary>
@@ -496,6 +506,16 @@ public static class LogEventIds {
             /// EventId for <see cref="RedisRequestDeduplicator.LogWaitTimeout"/>.
             /// </summary>
             public const int RedisRequestDeduplicatorWaitTimeout = 1355;
+
+            /// <summary>
+            /// EventId for <see cref="RedisRequestDeduplicator.LogFinalCompletedBeforeSubscription"/>.
+            /// </summary>
+            public const int RedisRequestDeduplicatorFinalCompletedBeforeSubscription = 1356;
+
+            /// <summary>
+            /// EventId for <see cref="RedisRequestDeduplicator.LogFinalWaitTimeout"/>.
+            /// </summary>
+            public const int RedisRequestDeduplicatorFinalWaitTimeout = 1357;
 
             // RedisRateLimitTracker (1375-1399)
 
@@ -1323,6 +1343,11 @@ public static class LogEventIds {
             /// </summary>
             public const int PartialResultReturned = 3300;
 
+            /// <summary>
+            /// EventId for <see cref="CachingMediaLinkService.LogPendingPartialReturned"/>.
+            /// </summary>
+            public const int PendingPartialResultReturned = 3301;
+
             // LookupOrchestrator (3350-3399)
 
             /// <summary>
@@ -1344,6 +1369,31 @@ public static class LogEventIds {
             /// EventId for <see cref="LookupOrchestrator.LogSagaCreated"/>.
             /// </summary>
             public const int OrchestratorSagaCreated = 3353;
+
+            /// <summary>
+            /// EventId for <see cref="LookupOrchestrator.LogSagaResumedWithResult"/>.
+            /// </summary>
+            public const int OrchestratorSagaResumedWithResult = 3354;
+
+            /// <summary>
+            /// EventId for <see cref="LookupOrchestrator.LogWaitingForFinalResult"/>.
+            /// </summary>
+            public const int OrchestratorWaitingForFinalResult = 3355;
+
+            /// <summary>
+            /// EventId for <see cref="LookupOrchestrator.LogReturningRateLimitedPartial"/>.
+            /// </summary>
+            public const int OrchestratorReturningRateLimitedPartial = 3356;
+
+            /// <summary>
+            /// EventId for <see cref="LookupOrchestrator.LogWaitBudgetExhausted"/>.
+            /// </summary>
+            public const int OrchestratorWaitBudgetExhausted = 3357;
+
+            /// <summary>
+            /// EventId for <see cref="LookupOrchestrator.LogInFlightSagaHasStoredResult"/>.
+            /// </summary>
+            public const int OrchestratorInFlightSagaHasStoredResult = 3358;
         }
 
         /// <summary>

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestDeduplicator.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestDeduplicator.cs
@@ -191,6 +191,65 @@ public sealed partial class RedisRequestDeduplicator(
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<string?> WaitForFinalCompletionAsync(
+        string requestKey,
+        TimeSpan timeout,
+        Func<Task<string?>>? missedResultCheck = null,
+        CancellationToken cancellationToken = default
+    ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( requestKey );
+
+        string channelKey = $"{CompleteChannelPrefix}{requestKey}";
+        ISubscriber subscriber = _redis.GetSubscriber( );
+
+        RedisChannel channel = RedisChannel.Literal( channelKey );
+
+        // Subscribe to completion channel using ChannelMessageQueue for async iteration
+        ChannelMessageQueue messageQueue = await subscriber.SubscribeAsync( channel );
+
+        try {
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+            cts.CancelAfter( timeout );
+
+            // The result may have been published in the gap between the caller reading state
+            // and this subscription becoming active - re-check durable state now that we
+            // are guaranteed to observe any future publish.
+            if (missedResultCheck is not null) {
+                string? missedResult = await missedResultCheck( );
+                if (!string.IsNullOrEmpty( missedResult )) {
+                    if (_logger.IsEnabled( LogLevel.Debug )) {
+                        string sanitizedRequestKey = requestKey.SanitizeForLogging( );
+                        LogFinalCompletedBeforeSubscription( _logger, sanitizedRequestKey );
+                    }
+                    return missedResult;
+                }
+            }
+
+            // Wait for a non-empty message or timeout. Unlike WaitForCompletionAsync, the
+            // absence of the in-flight lock means nothing here: it is deleted when the
+            // partial result is released while the saga keeps running.
+            try {
+                await foreach (ChannelMessage message in messageQueue.WithCancellation( cts.Token )) {
+                    string result = message.Message.ToString( );
+                    if (!string.IsNullOrEmpty( result )) {
+                        return result;
+                    }
+                }
+                return null;
+            } catch (OperationCanceledException) {
+                if (_logger.IsEnabled( LogLevel.Debug )) {
+                    string sanitizedRequestKey = requestKey.SanitizeForLogging( );
+                    LogFinalWaitTimeout( _logger, sanitizedRequestKey );
+                }
+                return null;
+            }
+        } finally {
+            // Always unsubscribe
+            messageQueue.Unsubscribe( );
+        }
+    }
+
     /// <summary>
     /// Generates a request key from lookup type and value.
     /// </summary>
@@ -241,6 +300,18 @@ public sealed partial class RedisRequestDeduplicator(
         Level = LogLevel.Debug,
         Message = "Timeout waiting for completion of {RequestKey}" )]
     internal static partial void LogWaitTimeout( ILogger logger, string requestKey );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisRequestDeduplicatorFinalCompletedBeforeSubscription,
+        Level = LogLevel.Debug,
+        Message = "Final result for {RequestKey} was already available before subscription was active" )]
+    internal static partial void LogFinalCompletedBeforeSubscription( ILogger logger, string requestKey );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisRequestDeduplicatorFinalWaitTimeout,
+        Level = LogLevel.Debug,
+        Message = "Timeout waiting for final completion of {RequestKey}" )]
+    internal static partial void LogFinalWaitTimeout( ILogger logger, string requestKey );
 
     #endregion
 }

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -58,6 +58,8 @@ public sealed partial class RedisSagaStateManager(
     private const string FieldIsPartial = "isPartial";
     private const string FieldInitialProvider = "initialProvider";
     private const string FieldRateLimitInfo = "rateLimitInfo";
+    private const string FieldOriginPriority = "originPriority";
+    private const string FieldSecondariesQueued = "secondariesQueued";
 
     // Hash field names for provider state
     private const string FieldIsComplete = "isComplete";
@@ -72,6 +74,7 @@ public sealed partial class RedisSagaStateManager(
         string lookupKey,
         LookupRequestType lookupType,
         string lookupValue,
+        QueuePriority? originPriority = null,
         CancellationToken cancellationToken = default
     ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
@@ -88,6 +91,15 @@ public sealed partial class RedisSagaStateManager(
         if (exists) {
             // Extend TTL and return existing state
             _ = await db.KeyExpireAsync( key, ttl );
+
+            // Record the origin priority if none has been recorded yet (first writer wins).
+            // Sagas created by the orchestrator before a worker processes the first request
+            // have no origin priority field; the first request's priority becomes the origin.
+            if (originPriority.HasValue &&
+                await db.HashSetAsync( key, FieldOriginPriority, originPriority.Value.ToString( ), When.NotExists )) {
+                LogOriginPrioritySet( _logger, originPriority.Value, sagaId );
+            }
+
             LookupSagaState? existingState = await GetAsync( sagaId, cancellationToken );
 
             if (existingState is not null) {
@@ -97,7 +109,7 @@ public sealed partial class RedisSagaStateManager(
         }
 
         // Create new saga
-        HashEntry[] sagaHash = [
+        List<HashEntry> sagaHashEntries = [
             new HashEntry( FieldLookupKey, lookupKey ),
             new HashEntry( FieldLookupType, lookupType.ToString() ),
             new HashEntry( FieldLookupValue, lookupValue ),
@@ -106,7 +118,11 @@ public sealed partial class RedisSagaStateManager(
             new HashEntry( FieldFinalResultUri, RedisValue.EmptyString )
         ];
 
-        await db.HashSetAsync( key, sagaHash );
+        if (originPriority.HasValue) {
+            sagaHashEntries.Add( new HashEntry( FieldOriginPriority, originPriority.Value.ToString( ) ) );
+        }
+
+        await db.HashSetAsync( key, [.. sagaHashEntries] );
         _ = await db.KeyExpireAsync( key, ttl );
 
         // Add to pending index for efficient polling
@@ -122,7 +138,8 @@ public sealed partial class RedisSagaStateManager(
             CreatedAt = DateTimeOffset.UtcNow,
             ProviderStates = [],
             PartialResultUri = null,
-            FinalResultUri = null
+            FinalResultUri = null,
+            OriginPriority = originPriority ?? QueuePriority.Background
         };
     }
 
@@ -163,6 +180,7 @@ public sealed partial class RedisSagaStateManager(
         _ = fields.TryGetValue( FieldIsPartial, out string? isPartialStr );
         _ = fields.TryGetValue( FieldInitialProvider, out string? initialProviderStr );
         _ = fields.TryGetValue( FieldRateLimitInfo, out string? rateLimitInfoJson );
+        _ = fields.TryGetValue( FieldOriginPriority, out string? originPriorityStr );
 
         DateTimeOffset createdAt = !string.IsNullOrEmpty( createdAtStr )
             ? DateTimeOffset.Parse( createdAtStr )
@@ -179,6 +197,13 @@ public sealed partial class RedisSagaStateManager(
             ? System.Text.Json.JsonSerializer.Deserialize<List<ProviderRateLimitInfo>>( rateLimitInfoJson )
             : null;
 
+        // Missing field (sagas persisted before this field existed) defaults to Background
+        // so old sagas are never promoted to interactive.
+        QueuePriority originPriority = !string.IsNullOrEmpty( originPriorityStr ) &&
+            Enum.TryParse<QueuePriority>( originPriorityStr, out QueuePriority parsedPriority )
+                ? parsedPriority
+                : QueuePriority.Background;
+
         // Load provider states
         Dictionary<SupportedProviders, ProviderLookupState> providerStates = await LoadProviderStatesAsync( db, sagaId );
 
@@ -193,7 +218,8 @@ public sealed partial class RedisSagaStateManager(
             FinalResultUri = string.IsNullOrEmpty( finalUri ) ? null : finalUri,
             IsPartial = isPartial,
             InitialProvider = initialProvider,
-            RateLimitInfo = rateLimitInfo
+            RateLimitInfo = rateLimitInfo,
+            OriginPriority = originPriority
         };
     }
 
@@ -339,6 +365,24 @@ public sealed partial class RedisSagaStateManager(
     }
 
     /// <inheritdoc/>
+    public async Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+
+        string key = GetSagaKey( sagaId );
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+
+        // HSETNX: only the first caller creates the field, making the
+        // queue-secondaries decision atomic across racing coordinator handlers.
+        bool acquired = await db.HashSetAsync( key, FieldSecondariesQueued, true.ToString( ), When.NotExists );
+        _ = await db.KeyExpireAsync( key, ttl );
+
+        LogSecondariesQueuedMarker( _logger, sagaId, acquired );
+
+        return acquired;
+    }
+
+    /// <inheritdoc/>
     public async Task InitializeProviderStatesAsync( string sagaId, IEnumerable<SupportedProviders> providers, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
         ArgumentNullException.ThrowIfNull( providers );
@@ -347,6 +391,15 @@ public sealed partial class RedisSagaStateManager(
         TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
 
         foreach (SupportedProviders provider in providers) {
+            string key = GetProviderKey( sagaId, provider );
+
+            // Idempotent: never overwrite existing provider state. A resumed saga may
+            // already have completed or in-progress providers that must be preserved.
+            if (await db.KeyExistsAsync( key )) {
+                _ = await db.KeyExpireAsync( key, ttl );
+                continue;
+            }
+
             // Create initial pending state for each provider
             ProviderLookupState pendingState = new(
                 Provider: provider,
@@ -357,7 +410,6 @@ public sealed partial class RedisSagaStateManager(
                 ErrorMessage: null
             );
 
-            string key = GetProviderKey( sagaId, provider );
             HashEntry[] providerHash = [
                 new HashEntry( FieldIsComplete, pendingState.IsComplete.ToString() ),
                 new HashEntry( FieldIsSuccess, pendingState.IsSuccess.ToString() ),
@@ -589,6 +641,18 @@ public sealed partial class RedisSagaStateManager(
         Level = LogLevel.Debug,
         Message = "Removed saga {SagaId} from pending index" )]
     internal static partial void LogRemovedFromPendingIndex( ILogger logger, string sagaId );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerOriginPrioritySet,
+        Level = LogLevel.Debug,
+        Message = "Set originPriority={Priority} for saga {SagaId}" )]
+    internal static partial void LogOriginPrioritySet( ILogger logger, QueuePriority priority, string sagaId );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerSecondariesQueuedMarker,
+        Level = LogLevel.Debug,
+        Message = "Secondaries-queued marker for saga {SagaId}: acquired={Acquired}" )]
+    internal static partial void LogSecondariesQueuedMarker( ILogger logger, string sagaId, bool acquired );
 
     #endregion
 }

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -395,31 +395,26 @@ public sealed partial class RedisSagaStateManager(
 
             // Idempotent: never overwrite existing provider state. A resumed saga may
             // already have completed or in-progress providers that must be preserved.
-            if (await db.KeyExistsAsync( key )) {
-                _ = await db.KeyExpireAsync( key, ttl );
-                continue;
-            }
-
-            // Create initial pending state for each provider
-            ProviderLookupState pendingState = new(
-                Provider: provider,
-                IsComplete: false,
-                IsSuccess: false,
-                ResultJson: null,
-                CompletedAt: null,
-                ErrorMessage: null
-            );
-
+            // The KeyNotExists condition makes the pending-state write commit atomically
+            // only when no state exists yet, so a concurrent UpdateProviderStateAsync
+            // cannot be regressed back to pending.
             HashEntry[] providerHash = [
-                new HashEntry( FieldIsComplete, pendingState.IsComplete.ToString() ),
-                new HashEntry( FieldIsSuccess, pendingState.IsSuccess.ToString() ),
+                new HashEntry( FieldIsComplete, false.ToString() ),
+                new HashEntry( FieldIsSuccess, false.ToString() ),
                 new HashEntry( FieldResultJson, string.Empty ),
                 new HashEntry( FieldCompletedAt, string.Empty ),
                 new HashEntry( FieldErrorMessage, string.Empty )
             ];
 
-            await db.HashSetAsync( key, providerHash );
-            _ = await db.KeyExpireAsync( key, ttl );
+            ITransaction transaction = db.CreateTransaction( );
+            _ = transaction.AddCondition( Condition.KeyNotExists( key ) );
+            _ = transaction.HashSetAsync( key, providerHash );
+            _ = transaction.KeyExpireAsync( key, ttl );
+
+            if (!await transaction.ExecuteAsync( )) {
+                // Provider state already exists — leave it untouched and refresh the TTL.
+                _ = await db.KeyExpireAsync( key, ttl );
+            }
         }
 
         if (_logger.IsEnabled( LogLevel.Debug )) {

--- a/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
@@ -154,7 +154,8 @@ public partial class ATProtoStorageService(
 
         return new MediaLinkResultRecord(
             results: providerResults,
-            lookedUpAt: DateTimeOffset.UtcNow
+            lookedUpAt: DateTimeOffset.UtcNow,
+            isPartial: result.IsPartial
         );
     }
 
@@ -165,7 +166,8 @@ public partial class ATProtoStorageService(
     /// <returns>A MediaLinkResult with parsed providers, or null if no valid providers were found.</returns>
     private static MediaLinkResult? ConvertFromRecord( MediaLinkResultRecord record ) {
         MediaLinkResult result = new( ) {
-            LookedUpAt = record.LookedUpAt.UtcDateTime
+            LookedUpAt = record.LookedUpAt.UtcDateTime,
+            IsPartial = record.IsPartial
         };
 
         foreach (ProviderResultRecord providerResult in record.Results) {

--- a/src/BridgeBeats.Web/Views/Shared/_LookupResultCard.cshtml
+++ b/src/BridgeBeats.Web/Views/Shared/_LookupResultCard.cshtml
@@ -79,5 +79,17 @@
                 </a>
             }
         </div>
+        @if (Model.Result.IsPartial || Model.Result.Messages is { Count: > 0 }) {
+            <div class="alert alert-warning embed-partial-notice mb-0 mt-2" role="status">
+                @if (Model.Result.IsPartial) {
+                    <strong>Incomplete results</strong>
+                }
+                @if (Model.Result.Messages is { Count: > 0 }) {
+                    foreach (var message in Model.Result.Messages) {
+                        <div>@message</div>
+                    }
+                }
+            </div>
+        }
     </div>
 </div>

--- a/src/BridgeBeats.Web/Views/Shared/_LookupResults.cshtml
+++ b/src/BridgeBeats.Web/Views/Shared/_LookupResults.cshtml
@@ -78,6 +78,18 @@
                             </a>
                         }
                     </div>
+                    @if (item.Result.IsPartial || item.Result.Messages is { Count: > 0 }) {
+                        <div class="alert alert-warning embed-partial-notice mb-0 mt-2" role="status">
+                            @if (item.Result.IsPartial) {
+                                <strong>Incomplete results</strong>
+                            }
+                            @if (item.Result.Messages is { Count: > 0 }) {
+                                foreach (var message in item.Result.Messages) {
+                                    <div>@message</div>
+                                }
+                            }
+                        </div>
+                    }
                 </div>
             </div>
         }

--- a/src/BridgeBeats.Worker.Discord/Program.cs
+++ b/src/BridgeBeats.Worker.Discord/Program.cs
@@ -53,6 +53,11 @@ public static class Program {
         _ = builder.Services.AddHttpClient<BridgeBeatsApiClient>( client => {
             // The base address will be set via Aspire service discovery
             client.BaseAddress = new Uri( "http://bridgebeats" );
+            // Multi-link lookups wait server-side for up to 90s in total (see
+            // LookupOrchestrator.LookupByContentAsync) - keep the transport timeout above
+            // that so the server-side budget, not HttpClient's default 100s, is the
+            // binding constraint
+            client.Timeout = TimeSpan.FromSeconds( 120 );
             client.DefaultRequestHeaders.Add( "User-Agent", "BridgeBeats-Discord-Worker/1.0" );
             if (!string.IsNullOrWhiteSpace( internalServiceKey )) {
                 client.DefaultRequestHeaders.Add( "X-Service-Key", internalServiceKey );

--- a/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
@@ -273,14 +273,17 @@ public sealed partial class JetStreamWatcherService(
             return;
         }
 
-        // Create the lookup request with a saga ID for coordinating cross-provider lookups
+        // Create the lookup request with a saga ID for coordinating cross-provider lookups.
+        // Bulk origin priority is persisted into the saga so secondary lookups spawned by
+        // the coordinator stay out of the interactive lane.
         QueuedLookupRequest request = new( ) {
             RequestId = Guid.NewGuid( ).ToString( "N" ),
             Provider = provider.Value,
             LookupType = lookupType,
             LookupValue = normalizedLink,
             SagaId = GenerateSagaId( normalizedLink ),
-            IsAlbum = isAlbum
+            IsAlbum = isAlbum,
+            OriginPriority = QueuePriority.Bulk
         };
 
         // Fire-and-forget: enqueue at bulk priority

--- a/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
@@ -259,4 +259,9 @@ public static class LogEventIds {
     /// EventId for <see cref="SagaCoordinatorBackgroundService.LogSecondariesAlreadyQueued"/>.
     /// </summary>
     public const int SecondariesAlreadyQueued = 5052;
+
+    /// <summary>
+    /// EventId for <see cref="SagaCoordinatorBackgroundService.LogNoSecondariesEnqueued"/>.
+    /// </summary>
+    public const int NoSecondariesEnqueued = 5053;
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
@@ -249,4 +249,14 @@ public static class LogEventIds {
     /// EventId for <see cref="SagaCoordinatorBackgroundService.LogWaitingForSecondaryLookups"/>.
     /// </summary>
     public const int WaitingForSecondaryLookups = 5050;
+
+    /// <summary>
+    /// EventId for <see cref="SagaCoordinatorBackgroundService.LogMaterializedCachedProvider"/>.
+    /// </summary>
+    public const int MaterializedCachedProvider = 5051;
+
+    /// <summary>
+    /// EventId for <see cref="SagaCoordinatorBackgroundService.LogSecondariesAlreadyQueued"/>.
+    /// </summary>
+    public const int SecondariesAlreadyQueued = 5052;
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -444,7 +444,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
     /// </list>
     /// Secondary lookups are added to the original saga, not separate sagas.
     /// </remarks>
-    /// <returns>True if secondary lookups were queued (caller should wait), false if ready to finalize.</returns>
+    /// <returns>True if secondary lookups are pending (caller should write a partial and wait), false if ready to finalize.</returns>
     private async Task<bool> CheckCacheAndQueueSecondaryLookupsAsync(
         MediaLinkResult result,
         LookupSagaState originalSaga,
@@ -534,26 +534,31 @@ public sealed partial class SagaCoordinatorBackgroundService(
             return false;
         }
 
-        // Atomically claim the right to queue secondaries. The worker publishes both
-        // saga:completed and complete:{key}, so both handlers can race through here before
-        // InitializeProviderStatesAsync runs and enqueue every secondary twice. The loser
-        // still reports "secondaries pending" so its caller defers finalization.
-        bool markerAcquired = await _sagaManager.TryMarkSecondariesQueuedAsync( originalSaga.SagaId, ct );
-        if (!markerAcquired) {
-            LogSecondariesAlreadyQueued( _logger, originalSaga.SagaId );
-            return true;
-        }
-
-        // Add the new providers to the ORIGINAL saga (don't create separate sagas)
+        // Add the new providers to the ORIGINAL saga (don't create separate sagas) and mark
+        // the saga partial so waiting callers can distinguish the upcoming partial result
+        // from a final one and keep waiting for the secondary lookups. Both writes are
+        // idempotent and deliberately run BEFORE the marker claim below: once either racing
+        // handler reports "secondaries pending" (causing its caller to publish the partial
+        // and release waiters), the saga is already guaranteed to read as incomplete and
+        // partial. Otherwise the marker loser could publish while IsPartial is still false
+        // and no pending states exist, letting a waiting orchestrator mistake the
+        // one-provider result for a final one (isFinal = IsComplete && !IsPartial).
         await _sagaManager.InitializeProviderStatesAsync( originalSaga.SagaId, providersToQueue, ct );
-
-        // Mark the saga partial so waiting callers can distinguish the upcoming partial
-        // result from a final one and keep waiting for the secondary lookups.
         await _sagaManager.SetIsPartialAsync( originalSaga.SagaId, true, ct );
 
         if (_logger.IsEnabled( LogLevel.Information )) {
             string providerNames = string.Join( ", ", providersToQueue );
             LogAddedProvidersToSaga( _logger, originalSaga.SagaId, providerNames );
+        }
+
+        // Atomically claim the right to enqueue secondaries - the only non-idempotent step.
+        // The worker publishes both saga:completed and complete:{key}, so both handlers can
+        // race through here and would otherwise enqueue every secondary twice. The loser
+        // still reports "secondaries pending" so its caller defers finalization.
+        bool markerAcquired = await _sagaManager.TryMarkSecondariesQueuedAsync( originalSaga.SagaId, ct );
+        if (!markerAcquired) {
+            LogSecondariesAlreadyQueued( _logger, originalSaga.SagaId );
+            return true;
         }
 
         // Interactive priority only when the saga originated from an interactive caller
@@ -597,8 +602,18 @@ public sealed partial class SagaCoordinatorBackgroundService(
             }
         }
 
-        // Return true if we queued any secondary lookups (caller should wait for completion)
-        return queuedCount > 0;
+        if (queuedCount == 0) {
+            // Every enqueue failed. Pending provider states and the partial flag are already
+            // set, so finalizing now would publish a result that is missing providers as
+            // complete and overwrite richer cached data. Waiters receive the honest partial
+            // instead; the cache marks partial results stale, so the lookup is retried once
+            // the saga expires.
+            LogNoSecondariesEnqueued( _logger, originalSaga.SagaId, externalId );
+        }
+
+        // Pending provider states exist and the saga is marked partial, so the caller must
+        // defer finalization even when some (or all) enqueues failed.
+        return true;
     }
 
     #region LoggerMessage Methods
@@ -959,6 +974,13 @@ public sealed partial class SagaCoordinatorBackgroundService(
         Level = LogLevel.Debug,
         Message = "Secondary lookups already queued for saga {SagaId} by a concurrent handler, deferring finalization" )]
     private static partial void LogSecondariesAlreadyQueued( ILogger logger, string sagaId );
+
+    /// <summary>Logs that no secondary lookups could be enqueued despite pending provider states.</summary>
+    [LoggerMessage(
+        EventId = LogEventIds.NoSecondariesEnqueued,
+        Level = LogLevel.Warning,
+        Message = "Failed to enqueue any secondary lookups for saga {SagaId} with external ID {ExternalId}; deferring finalization so waiters receive a partial result and the lookup is retried after the saga expires" )]
+    private static partial void LogNoSecondariesEnqueued( ILogger logger, string sagaId, string externalId );
 
     #endregion
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
@@ -65,6 +66,14 @@ public sealed partial class SagaCoordinatorBackgroundService(
     private static readonly TimeSpan s_pollingInterval = TimeSpan.FromSeconds( 30 );
     private static readonly TimeSpan s_minimumSagaAge = TimeSpan.FromSeconds( 15 );
     private const int PollingBatchLimit = 100;
+
+    // Must match the serialization the provider workers use for ProviderLookupState.ResultJson
+    // (QueueProcessorBackgroundService) so SagaResultCombiner can deserialize materialized
+    // cached results identically.
+    private static readonly JsonSerializerOptions s_jsonOptions = new( ) {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
 
     /// <inheritdoc/>
     protected override async Task ExecuteAsync( CancellationToken stoppingToken ) {
@@ -281,6 +290,21 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 ct.ThrowIfCancellationRequested( );
 
                 try {
+                    // Run the same check as the Pub/Sub handlers - a completion missed by
+                    // Pub/Sub must not finalize a one-provider result as complete while
+                    // other providers still need secondary lookups
+                    MediaLinkResult? result = _resultCombiner.CombineResults( saga );
+                    if (result is not null) {
+                        bool queuedSecondaryLookups = await CheckCacheAndQueueSecondaryLookupsAsync( result, saga, ct );
+                        if (queuedSecondaryLookups) {
+                            // Write initial result as partial and notify waiters immediately
+                            // while secondary lookups continue in the background
+                            LogWaitingForSecondaryLookups( _logger, saga.SagaId );
+                            await WritePartialResultAsync( saga, ct );
+                            continue;
+                        }
+                    }
+
                     // Check if saga is partial and needs partial result written first
                     if (saga.IsPartial && string.IsNullOrEmpty( saga.PartialResultUri )) {
                         LogWritingPartialDuringPolling( _logger, saga.SagaId );
@@ -327,6 +351,9 @@ public sealed partial class SagaCoordinatorBackgroundService(
 
             // Update saga with final result URI
             await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
+
+            // Clear the partial flag - the saga now represents a complete result
+            await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
 
             // Update Redis cache
             _ = await _cacheRepository.CacheResultAsync( finalResult, ct );
@@ -464,8 +491,33 @@ public sealed partial class SagaCoordinatorBackgroundService(
 
         // Add providers with cached data
         if (cached.HasValue && !cached.Value.isStale) {
-            foreach (SupportedProviders provider in cached.Value.cachedResult.Results.Keys) {
+            foreach ((SupportedProviders provider, MusicLookupResult cachedProviderResult) in cached.Value.cachedResult.Results) {
                 _ = providersWithData.Add( provider );
+
+                // Materialize the cached result into the saga as a completed provider state.
+                // The final result is assembled from saga provider states only, and the
+                // ATProto record (deterministic rkey) plus cache pointers are written as a
+                // full replace - without this, cached providers' data would be dropped and
+                // a richer existing record overwritten by a poorer one.
+                if (!originalSaga.ProviderStates.ContainsKey( provider )) {
+                    ProviderLookupState cachedState = new(
+                        Provider: provider,
+                        IsComplete: true,
+                        IsSuccess: true,
+                        ResultJson: JsonSerializer.Serialize( cachedProviderResult, s_jsonOptions ),
+                        CompletedAt: DateTimeOffset.UtcNow,
+                        ErrorMessage: null
+                    );
+
+                    await _sagaManager.UpdateProviderStateAsync( originalSaga.SagaId, cachedState, ct );
+
+                    // Keep the in-memory saga consistent so the partial/final result
+                    // written by the caller includes the materialized data
+                    originalSaga.ProviderStates[provider] = cachedState;
+
+                    string providerStr = provider.ToString( );
+                    LogMaterializedCachedProvider( _logger, providerStr, originalSaga.SagaId, externalId );
+                }
             }
 
             if (_logger.IsEnabled( LogLevel.Debug )) {
@@ -482,12 +534,35 @@ public sealed partial class SagaCoordinatorBackgroundService(
             return false;
         }
 
+        // Atomically claim the right to queue secondaries. The worker publishes both
+        // saga:completed and complete:{key}, so both handlers can race through here before
+        // InitializeProviderStatesAsync runs and enqueue every secondary twice. The loser
+        // still reports "secondaries pending" so its caller defers finalization.
+        bool markerAcquired = await _sagaManager.TryMarkSecondariesQueuedAsync( originalSaga.SagaId, ct );
+        if (!markerAcquired) {
+            LogSecondariesAlreadyQueued( _logger, originalSaga.SagaId );
+            return true;
+        }
+
         // Add the new providers to the ORIGINAL saga (don't create separate sagas)
         await _sagaManager.InitializeProviderStatesAsync( originalSaga.SagaId, providersToQueue, ct );
+
+        // Mark the saga partial so waiting callers can distinguish the upcoming partial
+        // result from a final one and keep waiting for the secondary lookups.
+        await _sagaManager.SetIsPartialAsync( originalSaga.SagaId, true, ct );
+
         if (_logger.IsEnabled( LogLevel.Information )) {
             string providerNames = string.Join( ", ", providersToQueue );
             LogAddedProvidersToSaga( _logger, originalSaga.SagaId, providerNames );
         }
+
+        // Interactive priority only when the saga originated from an interactive caller
+        // who is actively waiting for these secondary results to complete the saga (see
+        // LookupOrchestrator wait-for-final logic). Bulk/background-origin sagas (e.g.
+        // JetStream firehose) queue at Background so they stay out of the interactive lane.
+        QueuePriority secondaryPriority = originalSaga.OriginPriority == QueuePriority.Interactive
+            ? QueuePriority.Interactive
+            : QueuePriority.Background;
 
         // Queue lookups for each provider using the ORIGINAL saga ID
         int queuedCount = 0;
@@ -503,11 +578,13 @@ public sealed partial class SagaCoordinatorBackgroundService(
                     SagaId = originalSaga.SagaId,  // Use original saga ID!
                     IsAlbum = isAlbum,
                     Title = firstResult.Title,
-                    Artist = firstResult.Artist
+                    Artist = firstResult.Artist,
+                    OriginPriority = originalSaga.OriginPriority
                 };
 
                 IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue(provider);
-                await queue.EnqueueAsync( secondaryRequest, QueuePriority.Background, ct );
+
+                await queue.EnqueueAsync( secondaryRequest, secondaryPriority, ct );
 
                 string lookupTypeStr = lookupType.ToString( );
                 string providerStr = provider.ToString( );
@@ -868,6 +945,20 @@ public sealed partial class SagaCoordinatorBackgroundService(
         Level = LogLevel.Information,
         Message = "Waiting for secondary lookups to complete for saga {SagaId}, deferring finalization" )]
     private static partial void LogWaitingForSecondaryLookups( ILogger logger, string sagaId );
+
+    /// <summary>Logs that a cached provider result was materialized into the saga.</summary>
+    [LoggerMessage(
+        EventId = LogEventIds.MaterializedCachedProvider,
+        Level = LogLevel.Information,
+        Message = "Materialized cached {Provider} result into saga {SagaId} for external ID {ExternalId}" )]
+    private static partial void LogMaterializedCachedProvider( ILogger logger, string provider, string sagaId, string externalId );
+
+    /// <summary>Logs that another handler already queued the secondary lookups for the saga.</summary>
+    [LoggerMessage(
+        EventId = LogEventIds.SecondariesAlreadyQueued,
+        Level = LogLevel.Debug,
+        Message = "Secondary lookups already queued for saga {SagaId} by a concurrent handler, deferring finalization" )]
+    private static partial void LogSecondariesAlreadyQueued( ILogger logger, string sagaId );
 
     #endregion
 }


### PR DESCRIPTION
This pull request primarily adds and updates integration and unit tests to improve coverage and clarify expected behaviors in the caching and saga management logic. The most significant changes include new tests for handling partial results, origin priority persistence in sagas, and ensuring correct message generation for partial results. Additionally, there are minor refactorings for parameter naming consistency.

**New and enhanced test coverage:**

* Added a test to ensure the cache marks partial results as stale, prompting callers to retry for a complete result (`CheckRecordFreshness_ReturnsStale_WhenResultIsPartial`).
* Added tests to verify that saga creation and resumption correctly persist and update the request's origin priority, ensuring first-writer-wins and proper defaults (`GetOrCreateAsync_PersistsOriginPriority_FirstWriterWins`, `GetOrCreateAsync_WithoutOriginPriority_DefaultsToBackgroundUntilRecorded`).
* Added a test to ensure that only the first caller can mark secondaries as queued in a saga, preventing race conditions (`TryMarkSecondariesQueuedAsync_OnlyFirstCallerWins`).
* Added a test to verify that the request's origin priority is threaded through to saga creation in the queue processor service (`ProcessMessage_WithBulkOriginPriority_ShouldPassOriginPriorityToSagaCreation`).

**Partial result and message handling improvements:**

* Updated and added tests to ensure that when a lookup result is partial, the returned DTO is flagged as partial and a pending-provider message is generated even if no providers are rate-limited (`GetInfoByISRCAsync_WhenPartialButNoRateLimitedProviders_ShouldAddPendingMessage`, `GetInfoByISRCAsync_WhenPartial_ShouldFlagResultPartial`) [[1]](diffhunk://#diff-0b5b88594891f90f114c7679b7ca8e9006921d55d0422133b6752aa7d79133b7L434-R438) [[2]](diffhunk://#diff-0b5b88594891f90f114c7679b7ca8e9006921d55d0422133b6752aa7d79133b7L455-R485).

**Test code consistency:**

* Refactored test method calls to use the named parameter `cancellationToken` instead of passing the cancellation token as a positional argument, improving readability and maintainability across several integration test files [[1]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L93-R93) [[2]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L123-R123) [[3]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L132-R132) [[4]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L170-R170) [[5]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L213-R213) [[6]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L265-R265) [[7]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L295-R295) [[8]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L323-R323) [[9]](diffhunk://#diff-002e4002466ef580386afaf11b8b4fe46785fbc23d0649c9899d78828d2833f8L405-R405) [[10]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L94-R94) [[11]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L145-R145) [[12]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L182-R182) [[13]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L217-R217) [[14]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L252-R252) [[15]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L362-R362) [[16]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L387-R387) [[17]](diffhunk://#diff-372a4f68f27f3da7f820e893d10bd1e3944b512dab0869f732d9fb31bd41a880L419-R419).