### PR TITLE
Use CAR file to get statistics.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -312,7 +312,7 @@ See [.editorconfig](.editorconfig) for complete style rules and the [Copilot Ins
 
 ## Testing Guidelines
 
-All code changes should include appropriate tests. BridgeBeats uses MSTest with Moq and FluentAssertions.
+All code changes should include appropriate tests. BridgeBeats uses MSTest with Moq.
 
 ### Test Organization
 
@@ -324,7 +324,6 @@ All code changes should include appropriate tests. BridgeBeats uses MSTest with 
 
 - Use **MSTest** attributes: `[TestClass]`, `[TestMethod]`, `[TestInitialize]`, `[TestCleanup]`
 - Use **Moq** for mocking dependencies
-- Use **FluentAssertions** for readable assertions (e.g., `result.Should().NotBeNull()`)
 - Use **WebApplicationFactory** for integration testing web endpoints
 - Test both success and failure scenarios
 - Name tests clearly to describe what they test

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,6 @@
 ### Testing Framework
 - **MSTest** - Primary testing framework
 - **Moq** - Mocking framework
-- **FluentAssertions** - Assertion library
 - **Microsoft.AspNetCore.Mvc.Testing** - Integration testing for web endpoints
 
 ### External APIs
@@ -161,7 +160,6 @@ BridgeBeats/
 ### Testing Practices
 - Use **MSTest** attributes: `[TestClass]`, `[TestMethod]`, `[TestInitialize]`, `[TestCleanup]`
 - Use **Moq** for mocking dependencies
-- Use **FluentAssertions** for readable assertions (e.g., `result.Should().NotBeNull()`)
 - Use **WebApplicationFactory** for integration testing web endpoints
 - Test both success and failure scenarios
 - Validate configuration at startup to catch issues early

--- a/Tests/Integration/CarVsListRecordsParityTests.cs
+++ b/Tests/Integration/CarVsListRecordsParityTests.cs
@@ -1,0 +1,143 @@
+using System.Net.Http;
+using System.Text.Json;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Core.Infrastructure.Storage;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>
+/// Parity test: verifies that CAR-based enumeration yields the same AT-URI set and
+/// LookedUpAt values as a one-off listRecords loop against the production PDS.
+/// </summary>
+/// <remarks>
+/// This test requires live PDS access and is intentionally excluded from automated runs.
+/// Configure PDS access via environment variables or user-secrets before running:
+///   BRIDGEBEATS_TEST_PDS_URI — e.g. https://pds.bridgebeats.link
+///   BRIDGEBEATS_TEST_USER_DID — e.g. did:plc:xxxxx
+/// Run manually with: dotnet test --filter TestCategory=Integration
+/// </remarks>
+[TestClass]
+[TestCategory( "Integration" )]
+public class CarVsListRecordsParityTests {
+
+    private const string PdsUriEnvVar = "BRIDGEBEATS_TEST_PDS_URI";
+    private const string UserDidEnvVar = "BRIDGEBEATS_TEST_USER_DID";
+    private const string CollectionNsid = "link.bridgebeats.lookup";
+
+    /// <summary>Gets or sets the test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>
+    /// Validates that CAR-based enumeration produces the same AT-URI set as paginated listRecords.
+    /// </summary>
+    [TestMethod]
+    [Ignore( "Live PDS test — run manually with: dotnet test --filter TestCategory=Integration" )]
+    public async Task CarEnumeration_VsListRecords_YieldsSameAtUriSet( ) {
+        // Read operator configuration from environment
+        string? pdsUriStr = Environment.GetEnvironmentVariable( PdsUriEnvVar );
+        string? userDid = Environment.GetEnvironmentVariable( UserDidEnvVar );
+
+        if (string.IsNullOrWhiteSpace( pdsUriStr ) || string.IsNullOrWhiteSpace( userDid )) {
+            Assert.Inconclusive(
+                $"Live PDS test requires environment variables {PdsUriEnvVar} and {UserDidEnvVar}. " +
+                "Set them before running with: dotnet test --filter TestCategory=Integration" );
+            return;
+        }
+
+        Uri pdsUri = new( pdsUriStr.TrimEnd( '/' ) );
+
+        // ── CAR-based path ────────────────────────────────────────────────────
+        Mock<IATProtoSessionManager> sessionMock = new( );
+        Mock<IHttpClientFactory> factoryMock = new( );
+        using HttpClient httpClient = new( ) { Timeout = TimeSpan.FromMinutes( 10 ) };
+        _ = factoryMock
+            .Setup( f => f.CreateClient( ATProtoStorageService.ATProtoSyncHttpClientName ) )
+            .Returns( httpClient );
+
+        ATProtoStorageService service = new(
+            sessionMock.Object,
+            NullLogger<ATProtoStorageService>.Instance,
+            factoryMock.Object
+        );
+
+        Dictionary<string, DateTimeOffset> carAtUris = [];
+        await foreach ((string atUri, MediaLinkResult result) in
+            service.ListAllRecordsAsync( pdsUri, userDid, TestContext.CancellationToken )) {
+            carAtUris[atUri] = result.LookedUpAt;
+        }
+
+        // ── listRecords pagination path ───────────────────────────────────────
+        Dictionary<string, DateTimeOffset> listAtUris = [];
+        string? cursor = null;
+        using HttpClient listClient = new( ) { Timeout = TimeSpan.FromMinutes( 5 ) };
+
+        do {
+            string url = $"{pdsUri}/xrpc/com.atproto.repo.listRecords" +
+                         $"?repo={Uri.EscapeDataString( userDid )}" +
+                         $"&collection={Uri.EscapeDataString( CollectionNsid )}" +
+                         "&limit=100" +
+                         (cursor is null ? "" : $"&cursor={Uri.EscapeDataString( cursor )}");
+
+            using HttpResponseMessage resp = await listClient.GetAsync( url, TestContext.CancellationToken );
+            _ = resp.EnsureSuccessStatusCode( );
+
+            using JsonDocument doc = JsonDocument.Parse( await resp.Content.ReadAsStringAsync( TestContext.CancellationToken ) );
+            JsonElement root = doc.RootElement;
+
+            if (root.TryGetProperty( "records", out JsonElement records )) {
+                foreach (JsonElement record in records.EnumerateArray( )) {
+                    string uri = record.GetProperty( "uri" ).GetString( ) ?? "";
+                    DateTimeOffset lookedUpAt = DateTimeOffset.MinValue;
+
+                    if (record.TryGetProperty( "value", out JsonElement val ) &&
+                        val.TryGetProperty( "lookedUpAt", out JsonElement lat )) {
+                        _ = DateTimeOffset.TryParse( lat.GetString( ), out lookedUpAt );
+                    }
+
+                    listAtUris[uri] = lookedUpAt;
+                }
+            }
+
+            cursor = null;
+            if (root.TryGetProperty( "cursor", out JsonElement cursorEl )) {
+                cursor = cursorEl.GetString( );
+            }
+        } while (cursor is not null);
+
+        // ── Parity assertions ─────────────────────────────────────────────────
+        // Both must contain the same AT-URI set
+        HashSet<string> carSet = [.. carAtUris.Keys];
+        HashSet<string> listSet = [.. listAtUris.Keys];
+
+        HashSet<string> onlyInCar = [.. carSet.Except( listSet )];
+        HashSet<string> onlyInList = [.. listSet.Except( carSet )];
+
+        Assert.IsEmpty( onlyInCar,
+            $"AT-URIs in CAR but not in listRecords: {string.Join( ", ", onlyInCar.Take( 10 ) )}" );
+        Assert.IsEmpty( onlyInList,
+            $"AT-URIs in listRecords but not in CAR: {string.Join( ", ", onlyInList.Take( 10 ) )}" );
+
+        // LookedUpAt values must match for every record
+        List<string> mismatchedLookedUpAt = [];
+        foreach ((string uri, DateTimeOffset carLookedUpAt) in carAtUris) {
+            if (listAtUris.TryGetValue( uri, out DateTimeOffset listLookedUpAt )) {
+                if (Math.Abs( (carLookedUpAt - listLookedUpAt).TotalSeconds ) > 1) {
+                    mismatchedLookedUpAt.Add( $"{uri}: CAR={carLookedUpAt:O} list={listLookedUpAt:O}" );
+                }
+            }
+        }
+
+        Assert.IsEmpty( mismatchedLookedUpAt,
+            $"LookedUpAt mismatches ({mismatchedLookedUpAt.Count}): {string.Join( ", ", mismatchedLookedUpAt.Take( 5 ) )}" );
+
+        TestContext.WriteLine( $"Parity verified: {carAtUris.Count} records match between CAR and listRecords." );
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
+++ b/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
@@ -1,0 +1,444 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Core.Infrastructure.Storage;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Tests.Unit.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ATProtoStorageService.ListAllRecordsAsync"/> using
+/// a mocked HTTP layer (no real network calls).
+/// </summary>
+[TestClass]
+public class ATProtoStorageServiceListRecordsTests {
+
+    /// <summary>Gets or sets the test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    private Mock<IATProtoSessionManager> _sessionManagerMock = null!;
+    private Mock<ILogger<ATProtoStorageService>> _loggerMock = null!;
+    private Mock<HttpMessageHandler> _httpHandlerMock = null!;
+    private Mock<IHttpClientFactory> _httpClientFactoryMock = null!;
+    private HttpClient _httpClient = null!;
+
+    private const string TestDid = "did:plc:testuser12345";
+    private static readonly Uri s_testPdsUri = new( "https://pds.test.example" );
+
+    [TestInitialize]
+    public void Initialize( ) {
+        _sessionManagerMock = new Mock<IATProtoSessionManager>( );
+        _loggerMock = new Mock<ILogger<ATProtoStorageService>>( );
+        _ = _loggerMock.Setup( x => x.IsEnabled( It.IsAny<LogLevel>( ) ) ).Returns( true );
+
+        _httpHandlerMock = new Mock<HttpMessageHandler>( );
+        _httpClient = new HttpClient( _httpHandlerMock.Object );
+
+        _httpClientFactoryMock = new Mock<IHttpClientFactory>( );
+        _ = _httpClientFactoryMock
+            .Setup( f => f.CreateClient( ATProtoStorageService.ATProtoSyncHttpClientName ) )
+            .Returns( _httpClient );
+    }
+
+    [TestCleanup]
+    public void Cleanup( ) {
+        _httpClient?.Dispose( );
+    }
+
+    // ─── Happy-path tests ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_ThreeLookupAndOnePlaylistRecord_ReturnsThreeTuplesWithCorrectAtUris( ) {
+        // Arrange: 3 lookup + 1 playlist record in the CAR.
+        // The playlist record must be filtered out by the service (collection = link.bridgebeats.lookup only).
+        BridgeBeats.Contracts.Records.MediaLinkResultRecord r1 = MakeRecord( "Track 1" );
+        BridgeBeats.Contracts.Records.MediaLinkResultRecord r2 = MakeRecord( "Track 2" );
+        BridgeBeats.Contracts.Records.MediaLinkResultRecord r3 = MakeRecord( "Track 3" );
+        BridgeBeats.Contracts.Records.MediaLinkResultRecord playlist = MakeRecord( "My Playlist" );
+
+        // Build the CAR manually to include a record in the playlist collection alongside lookups
+        byte[] rec1Bytes = TestCarBuilder.BuildRecordBlock( r1 );
+        byte[] rec2Bytes = TestCarBuilder.BuildRecordBlock( r2 );
+        byte[] rec3Bytes = TestCarBuilder.BuildRecordBlock( r3 );
+        byte[] playlistBytes = TestCarBuilder.BuildRecordBlock( playlist );
+
+        byte[] cid1 = TestCarBuilder.ComputeCidBytes( rec1Bytes );
+        byte[] cid2 = TestCarBuilder.ComputeCidBytes( rec2Bytes );
+        byte[] cid3 = TestCarBuilder.ComputeCidBytes( rec3Bytes );
+        byte[] plCid = TestCarBuilder.ComputeCidBytes( playlistBytes );
+
+        // Keys sorted: link.bridgebeats.lookup/rkey1 < link.bridgebeats.lookup/rkey2 <
+        //              link.bridgebeats.lookup/rkey3 < link.bridgebeats.playlist/pl1
+        // Apply prefix compression with p=0 for the first, share prefix for subsequent
+        string k1 = "link.bridgebeats.lookup/rkey1";
+        string k2 = "link.bridgebeats.lookup/rkey2";
+        string k3 = "link.bridgebeats.lookup/rkey3";
+        string kpl = "link.bridgebeats.playlist/pl1";
+
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [
+                new TestCarBuilder.MstEntry( 0, k1, cid1 ),
+                new TestCarBuilder.MstEntry( CommonPrefix( k1, k2 ), k2[CommonPrefix( k1, k2 )..], cid2 ),
+                new TestCarBuilder.MstEntry( CommonPrefix( k2, k3 ), k3[CommonPrefix( k2, k3 )..], cid3 ),
+                new TestCarBuilder.MstEntry( CommonPrefix( k3, kpl ), kpl[CommonPrefix( k3, kpl )..], plCid )
+            ]
+        );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( TestDid, mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparerLocal.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [cid1] = rec1Bytes,
+            [cid2] = rec2Bytes,
+            [cid3] = rec3Bytes,
+            [plCid] = playlistBytes
+        };
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+
+        SetupHttpSuccess( carBytes );
+        ATProtoStorageService service = CreateService( );
+
+        // Act
+        List<(string AtUri, MediaLinkResult Result)> results = [];
+        await foreach ((string atUri, MediaLinkResult result) in
+            service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) {
+            results.Add( (atUri, result) );
+        }
+
+        // Assert: exactly 3 tuples with correct AT-URI format; playlist filtered out
+        Assert.HasCount( 3, results );
+        Assert.IsTrue( results.All( r => r.AtUri.StartsWith( $"at://{TestDid}/link.bridgebeats.lookup/", StringComparison.Ordinal ) ) );
+
+        // Verify exactly one HTTP request was made
+        _httpHandlerMock.Protected( ).Verify(
+            "SendAsync",
+            Times.Once( ),
+            ItExpr.IsAny<HttpRequestMessage>( ),
+            ItExpr.IsAny<CancellationToken>( )
+        );
+    }
+
+    private static int CommonPrefix( string a, string b ) {
+        int len = Math.Min( a.Length, b.Length );
+        int i = 0;
+        while (i < len && a[i] == b[i]) { i++; }
+        return i;
+    }
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_EmptyRepo_YieldsNoResults( ) {
+        // Arrange
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords( TestDid, "link.bridgebeats.lookup", [] );
+        SetupHttpSuccess( carBytes );
+        ATProtoStorageService service = CreateService( );
+
+        // Act
+        List<(string AtUri, MediaLinkResult Result)> results = [];
+        await foreach ((string atUri, MediaLinkResult result) in
+            service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) {
+            results.Add( (atUri, result) );
+        }
+
+        // Assert
+        Assert.IsEmpty( results );
+
+        _httpHandlerMock.Protected( ).Verify(
+            "SendAsync",
+            Times.Once( ),
+            ItExpr.IsAny<HttpRequestMessage>( ),
+            ItExpr.IsAny<CancellationToken>( )
+        );
+    }
+
+    // ─── Error propagation tests ──────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_Http500Response_ThrowsHttpRequestException( ) {
+        // Arrange
+        SetupHttpError( HttpStatusCode.InternalServerError );
+        ATProtoStorageService service = CreateService( );
+
+        // Act & Assert: download failure must throw (no fallback, no silent empty yield)
+        _ = await Assert.ThrowsExactlyAsync<HttpRequestException>( async ( ) => {
+            await foreach ((string _, MediaLinkResult _) in
+                service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) {
+                // Enumerate to trigger the download
+            }
+        } );
+    }
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_MalformedCarBytes_ThrowsCarParseException( ) {
+        // Arrange: return garbage bytes that won't parse as a valid CAR
+        byte[] garbage = [0xFF, 0xFE, 0xFD, 0x00, 0x01, 0x02];
+        SetupHttpSuccess( garbage );
+        ATProtoStorageService service = CreateService( );
+
+        // Act & Assert
+        _ = await Assert.ThrowsExactlyAsync<CarParseException>( async ( ) => {
+            await foreach ((string _, MediaLinkResult _) in
+                service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) { }
+        } );
+    }
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_OneBadRecordAmongGood_SkipsBadAndYieldsRest( ) {
+        // Arrange: build a CAR with one good record and one block that is valid DAG-CBOR
+        // but fails MediaLinkResultRecord deserialization (lookedUpAt is an integer, not an ISO 8601 string).
+        BridgeBeats.Contracts.Records.MediaLinkResultRecord goodRecord = MakeRecord( "Good Track" );
+        byte[] goodBytes = TestCarBuilder.BuildRecordBlock( goodRecord );
+        byte[] goodCid = TestCarBuilder.ComputeCidBytes( goodBytes );
+
+        // Build a malformed DAG-CBOR block: lookedUpAt is a number, not a string — valid CBOR, invalid record
+        byte[] badBytes = BuildMalformedRecordBlock( );
+        byte[] badCid = TestCarBuilder.ComputeCidBytes( badBytes );
+
+        // Keys sorted lexicographically: "link.bridgebeats.lookup/bad_rkey_alpha" < "link.bridgebeats.lookup/good_rkey_beta"
+        // They share the 24-char prefix "link.bridgebeats.lookup/"
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [
+                new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/bad_rkey_alpha", badCid ),
+                new TestCarBuilder.MstEntry( 24, "good_rkey_beta", goodCid )
+            ]
+        );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( TestDid, mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparerLocal.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [goodCid] = goodBytes,
+            [badCid] = badBytes
+        };
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+
+        SetupHttpSuccess( carBytes );
+        ATProtoStorageService service = CreateService( );
+
+        // Act
+        List<(string AtUri, MediaLinkResult Result)> results = [];
+        await foreach ((string atUri, MediaLinkResult result) in
+            service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) {
+            results.Add( (atUri, result) );
+        }
+
+        // Assert: only the good record returned; bad record skipped via LogCarRecordSkipped path
+        Assert.HasCount( 1, results );
+        Assert.IsTrue( results[0].AtUri.Contains( "good_rkey_beta", StringComparison.Ordinal ) );
+    }
+
+    /// <summary>
+    /// Builds a DAG-CBOR block that is structurally valid CBOR but fails
+    /// <see cref="BridgeBeats.Contracts.Records.MediaLinkResultRecord"/> deserialization
+    /// because <c>lookedUpAt</c> is an integer rather than an ISO 8601 string.
+    /// </summary>
+    private static byte[] BuildMalformedRecordBlock( ) {
+        System.Formats.Cbor.CborWriter writer = new( System.Formats.Cbor.CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+        // lookedUpAt as integer — valid CBOR, but System.Text.Json cannot parse it as DateTimeOffset
+        writer.WriteTextString( "lookedUpAt" );
+        writer.WriteInt32( 9999999 );
+        // results array — empty but present
+        writer.WriteTextString( "results" );
+        writer.WriteStartArray( null );
+        writer.WriteEndArray( );
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
+    private sealed class ByteArrayKeyComparerLocal : System.Collections.Generic.IEqualityComparer<byte[]> {
+        internal static readonly ByteArrayKeyComparerLocal Instance = new( );
+        public bool Equals( byte[]? x, byte[]? y ) => x is not null && y is not null && x.AsSpan( ).SequenceEqual( y );
+        public int GetHashCode( byte[] obj ) {
+            System.HashCode hc = new( );
+            hc.AddBytes( obj );
+            return hc.ToHashCode( );
+        }
+    }
+
+    [TestMethod]
+    public async Task ListAllRecordsAsync_InvalidDid_ThrowsArgumentException( ) {
+        // Arrange: invalid DID format
+        ATProtoStorageService service = CreateService( );
+
+        // Act & Assert: should throw before making any HTTP call
+        _ = await Assert.ThrowsExactlyAsync<ArgumentException>( async ( ) => {
+            await foreach ((string _, MediaLinkResult _) in
+                service.ListAllRecordsAsync( s_testPdsUri, "not-a-valid-did", TestContext.CancellationToken )) { }
+        } );
+
+        // No HTTP call should have been made
+        _httpHandlerMock.Protected( ).Verify(
+            "SendAsync",
+            Times.Never( ),
+            ItExpr.IsAny<HttpRequestMessage>( ),
+            ItExpr.IsAny<CancellationToken>( )
+        );
+    }
+
+    // ─── CancellationToken propagation ───────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that cancelling the token passed to ListAllRecordsAsync propagates
+    /// OperationCanceledException and NOT a CarParseException wrapping the cancellation.
+    /// Failure-first evidence: if the cancellation were swallowed by the CarParseException catch
+    /// in FetchAllViaCarAsync, this test would fail (no exception thrown, or wrong exception type).
+    /// </summary>
+    [TestMethod]
+    public async Task ListAllRecordsAsync_CancelledToken_PropagatesOperationCanceledException( ) {
+        // Arrange: build a valid CAR so the parse path is exercised, then cancel before iteration completes.
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            TestDid,
+            "link.bridgebeats.lookup",
+            [("rkey1", MakeRecord( "Track 1" ))]
+        );
+        SetupHttpSuccess( carBytes );
+        ATProtoStorageService service = CreateService( );
+
+        using CancellationTokenSource cts = new( );
+        cts.Cancel( ); // pre-cancelled
+
+        // Act & Assert
+        _ = await Assert.ThrowsExactlyAsync<OperationCanceledException>( async ( ) => {
+            await foreach ((string _, MediaLinkResult _) in
+                service.ListAllRecordsAsync( s_testPdsUri, TestDid, cts.Token )) { }
+        } );
+    }
+
+    // ─── SEC-005 regression: rkey validation ─────────────────────────────────
+
+    /// <summary>
+    /// SEC-005 regression: an rkey containing control characters or path separators must be
+    /// skipped (with a warning) rather than passed to BuildLookupRecordUri or logged verbatim.
+    /// The good record in the same CAR must still be returned.
+    /// Failure-first evidence: without IsValidRkey in FetchAllViaCarAsync, the invalid rkey
+    /// would reach ATProtoUriHelper.BuildLookupRecordUri (potentially constructing a malformed URI)
+    /// and be logged verbatim (log injection risk). The test would return 2 results instead of 1.
+    /// </summary>
+    [TestMethod]
+    public async Task ListAllRecordsAsync_RkeyWithControlChars_SkipsInvalidRkeyAndYieldsGoodRecord( ) {
+        // Arrange: build a CAR with one good rkey and one rkey containing a slash (invalid).
+        // The invalid rkey is "bad\x01rkey" (contains control char 0x01).
+        byte[] goodCarBytes = TestCarBuilder.BuildCarWithRawRkey(
+            "link.bridgebeats.lookup",
+            "valid-rkey-123"
+        );
+
+        // Merge the invalid-rkey block into a single CAR by building both entries in one MST node.
+        byte[] recGoodBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Good" ) );
+        byte[] recBadBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Bad" ) );
+        byte[] cidGood = TestCarBuilder.ComputeCidBytes( recGoodBytes );
+        byte[] cidBad = TestCarBuilder.ComputeCidBytes( recBadBytes );
+
+        // Keys must be sorted. "link.bridgebeats.lookup/good-rkey" < "link.bridgebeats.lookup/\x01bad"
+        // is not guaranteed, so use unique keys with known sort order.
+        string keyGood = "link.bridgebeats.lookup/good-rkey";
+        string keyBad = "link.bridgebeats.lookup/bad\x01rkey"; // contains control char
+
+        // Sort entries lexicographically
+        (string, byte[])[] sorted = [(keyGood, cidGood), (keyBad, cidBad)];
+        System.Array.Sort( sorted, ( a, b ) => string.Compare( a.Item1, b.Item1, StringComparison.Ordinal ) );
+
+        List<TestCarBuilder.MstEntry> mstEntries = [];
+        string prev = "";
+        foreach ((string k, byte[] c) in sorted) {
+            int p = CommonPrefix( prev, k );
+            mstEntries.Add( new TestCarBuilder.MstEntry( p, k[p..], c ) );
+            prev = k;
+        }
+
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode( null, mstEntries );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( TestDid, mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparerLocal.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [cidGood] = recGoodBytes,
+            [cidBad] = recBadBytes
+        };
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+
+        SetupHttpSuccess( carBytes );
+        ATProtoStorageService service = CreateService( );
+
+        // Act
+        List<(string AtUri, MediaLinkResult Result)> results = [];
+        await foreach ((string atUri, MediaLinkResult result) in
+            service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken )) {
+            results.Add( (atUri, result) );
+        }
+
+        // Assert: only the record with a valid rkey is returned; the one with control chars is skipped
+        Assert.HasCount( 1, results );
+        Assert.IsTrue( results[0].AtUri.Contains( "good-rkey", StringComparison.Ordinal ) );
+    }
+
+    // ─── Helper methods ───────────────────────────────────────────────────────
+
+    private ATProtoStorageService CreateService( ) =>
+        new(
+            _sessionManagerMock.Object,
+            _loggerMock.Object,
+            _httpClientFactoryMock.Object
+        );
+
+    private void SetupHttpSuccess( byte[] carBytes ) {
+        _ = _httpHandlerMock
+            .Protected( )
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>( ),
+                ItExpr.IsAny<CancellationToken>( )
+            )
+            .ReturnsAsync( new HttpResponseMessage( HttpStatusCode.OK ) {
+                Content = new ByteArrayContent( carBytes ) {
+                    Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue( "application/vnd.ipld.car" ) }
+                }
+            } );
+    }
+
+    private void SetupHttpError( HttpStatusCode statusCode ) {
+        _ = _httpHandlerMock
+            .Protected( )
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>( ),
+                ItExpr.IsAny<CancellationToken>( )
+            )
+            .ReturnsAsync( new HttpResponseMessage( statusCode ) );
+    }
+
+    private static BridgeBeats.Contracts.Records.MediaLinkResultRecord MakeRecord( string title ) =>
+        new(
+            results: [
+                new BridgeBeats.Contracts.Records.ProviderResultRecord(
+                    provider: "spotify",
+                    artist: "Test Artist",
+                    title: title,
+                    url: "https://open.spotify.com/track/x",
+                    marketRegion: "US",
+                    externalId: "ISRC123",
+                    artUrl: null,
+                    isAlbum: false
+                )
+            ],
+            lookedUpAt: new DateTimeOffset( 2024, 3, 1, 12, 0, 0, TimeSpan.Zero )
+        );
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
+++ b/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
@@ -330,14 +330,7 @@ public class ATProtoStorageServiceListRecordsTests {
     /// </summary>
     [TestMethod]
     public async Task ListAllRecordsAsync_RkeyWithControlChars_SkipsInvalidRkeyAndYieldsGoodRecord( ) {
-        // Arrange: build a CAR with one good rkey and one rkey containing a slash (invalid).
-        // The invalid rkey is "bad\x01rkey" (contains control char 0x01).
-        byte[] goodCarBytes = TestCarBuilder.BuildCarWithRawRkey(
-            "link.bridgebeats.lookup",
-            "valid-rkey-123"
-        );
-
-        // Merge the invalid-rkey block into a single CAR by building both entries in one MST node.
+        // Arrange: build a single CAR containing one good rkey and one rkey containing a control char (0x01, invalid).
         byte[] recGoodBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Good" ) );
         byte[] recBadBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Bad" ) );
         byte[] cidGood = TestCarBuilder.ComputeCidBytes( recGoodBytes );

--- a/Tests/Unit/AccountControllerTests.cs
+++ b/Tests/Unit/AccountControllerTests.cs
@@ -4,11 +4,10 @@ using BridgeBeats.Web.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-
-#pragma warning disable CS1591
 
 namespace BridgeBeats.Tests.Unit;
 
@@ -21,13 +20,21 @@ public class AccountControllerTests {
 
     /// <summary>
     /// When <c>FindByEmailAsync</c> returns null (pre-check passes) but <c>CreateAsync</c> throws a
-    /// <see cref="DbUpdateException"/> whose inner exception message contains the unique-email
-    /// constraint text, <c>Register</c> must return 400 with the DuplicateEmail description.
+    /// <see cref="DbUpdateException"/> whose inner exception is a <see cref="SqliteException"/> with
+    /// error code 19 and a message containing "AspNetUsers.NormalizedEmail", <c>Register</c> must
+    /// return 400 with the DuplicateEmail description.
     ///
-    /// Failure-first evidence: before adding the try/catch, the <see cref="DbUpdateException"/>
-    /// propagates unhandled and the controller returns 500. After adding the catch, it returns 400.
-    /// Verified by removing the catch block: the test fails with "Expected BadRequestObjectResult
-    /// but got type DbUpdateException thrown" because the exception propagates past the action.
+    /// The catch filter in AccountController.Register is:
+    ///   catch (DbUpdateException dbEx)
+    ///     when (dbEx.InnerException is SqliteException sqliteEx
+    ///           &amp;&amp; sqliteEx.SqliteErrorCode == 19
+    ///           &amp;&amp; sqliteEx.Message.Contains("AspNetUsers.NormalizedEmail", OrdinalIgnoreCase))
+    ///
+    /// Failure-first evidence: with the inner exception as InvalidOperationException (old test shape),
+    /// the catch filter's type check (is SqliteException) evaluates to false, the exception propagates
+    /// unhandled, and the test fails with "Expected BadRequestObjectResult but DbUpdateException was
+    /// thrown." After replacing with SqliteException(error code 19, NormalizedEmail message),
+    /// the filter matches and the controller returns 400.
     /// </summary>
     [TestMethod]
     public async Task Register_DbUniqueConstraintViolation_Returns400WithDuplicateEmailError( ) {
@@ -35,10 +42,12 @@ public class AccountControllerTests {
         string email = "race@example.com";
 
         // Pre-check returns null (simulates: concurrent insertion won the race after the pre-check ran).
-        // CreateAsync throws with the exact SQLite unique-constraint message that the catch guard matches.
+        // CreateAsync throws a DbUpdateException whose inner SqliteException matches all three guard
+        // conditions: type SqliteException, error code 19, message contains AspNetUsers.NormalizedEmail.
+        // Constructor: SqliteException(string message, int errorCode)
         DbUpdateException dbEx = new(
             "An error occurred while saving the entity changes.",
-            new InvalidOperationException( "UNIQUE constraint failed: AspNetUsers.NormalizedEmail" ) );
+            new SqliteException( "SQLite Error 19: 'UNIQUE constraint failed: AspNetUsers.NormalizedEmail'.", 19 ) );
 
         FakeUserManager userManager = new(
             findByEmailResult: null,
@@ -65,29 +74,34 @@ public class AccountControllerTests {
         IActionResult result = await controller.Register( request );
 
         // Assert
-        Assert.IsInstanceOfType( result, typeof( BadRequestObjectResult ),
-            "A DbUpdateException with unique-email constraint text must produce 400" );
+        _ = Assert.IsInstanceOfType<BadRequestObjectResult>( result,
+            "A DbUpdateException with a SqliteException inner (code 19, NormalizedEmail column) must produce 400" );
     }
 
     /// <summary>
-    /// Verifies that a <see cref="DbUpdateException"/> whose inner exception does NOT contain the
-    /// unique-email constraint text is not swallowed — it propagates so the caller sees a 500.
-    /// This ensures the catch is narrowly scoped and does not hide unrelated DB errors.
+    /// Verifies the column-match narrowness of the catch filter: a <see cref="DbUpdateException"/>
+    /// whose inner <see cref="SqliteException"/> has error code 19 but whose message names a DIFFERENT
+    /// column (AspNetUsers.ApiKeyHash, not AspNetUsers.NormalizedEmail) must propagate — it is not
+    /// swallowed by the email-specific catch guard.
     ///
-    /// Failure-first evidence: the <c>when</c> filter on the catch means a different constraint
-    /// message is not caught. Removing the <c>when</c> filter would cause any DbUpdateException to
-    /// produce a 400, masking real errors. Verified by removing the filter: the test fails because
-    /// the controller now returns 400 instead of re-throwing.
+    /// The catch filter requires all three conditions to hold simultaneously:
+    ///   type SqliteException ✓, error code 19 ✓, message contains "AspNetUsers.NormalizedEmail" ✗
+    /// The third condition fails, so the guard evaluates to false and the exception re-throws.
+    ///
+    /// Failure-first evidence: the filter is already present in the controller; this test verifies it
+    /// does NOT fire for the wrong column. If the column-name check were removed from the filter, the
+    /// catch would swallow this exception and return 400, causing this test to fail with
+    /// "Expected DbUpdateException but got BadRequestObjectResult."
     /// </summary>
     [TestMethod]
-    public async Task Register_UnrelatedDbException_Propagates( ) {
+    public async Task Register_SqliteExceptionWrongColumn_Propagates( ) {
         // Arrange
         string email = "race@example.com";
 
-        // Different constraint — NOT the email unique index; must propagate past the catch guard.
+        // SqliteException code 19, but the message names a DIFFERENT column — must not be caught.
         DbUpdateException dbEx = new(
             "An error occurred while saving the entity changes.",
-            new InvalidOperationException( "UNIQUE constraint failed: AspNetUsers.ApiKeyHash" ) );
+            new SqliteException( "SQLite Error 19: 'UNIQUE constraint failed: AspNetUsers.ApiKeyHash'.", 19 ) );
 
         FakeUserManager userManager = new(
             findByEmailResult: null,
@@ -110,7 +124,57 @@ public class AccountControllerTests {
 
         RegisterRequest request = new( email, "ValidPassword123!" );
 
-        // Act + Assert — unrelated DbUpdateException must not be caught by the email guard
+        // Act + Assert — wrong-column SqliteException must propagate past the email catch guard
+        _ = await Assert.ThrowsExactlyAsync<DbUpdateException>( ( ) => controller.Register( request ) );
+    }
+
+    /// <summary>
+    /// Verifies the type narrowness of the catch filter: a <see cref="DbUpdateException"/> whose
+    /// inner exception is NOT a <see cref="SqliteException"/> (e.g. <see cref="InvalidOperationException"/>)
+    /// must propagate even when its message contains the NormalizedEmail column name.
+    ///
+    /// The catch filter requires all three conditions to hold simultaneously:
+    ///   type SqliteException ✗ (InvalidOperationException), error code 19 n/a, NormalizedEmail text n/a
+    /// The first condition fails, so the guard evaluates to false and the exception re-throws.
+    ///
+    /// Failure-first evidence: this is the old test shape that reproduced the CI failure. Before the
+    /// controller's catch was tightened to require SqliteException, this same inner exception (an
+    /// InvalidOperationException with the NormalizedEmail message) was matched by the broader filter
+    /// and returned 400. After tightening, the type check fails and the exception propagates — which
+    /// is the correct behavior this test asserts.
+    /// </summary>
+    [TestMethod]
+    public async Task Register_NonSqliteInnerException_Propagates( ) {
+        // Arrange
+        string email = "race@example.com";
+
+        // Inner exception is InvalidOperationException, not SqliteException — must not be caught.
+        DbUpdateException dbEx = new(
+            "An error occurred while saving the entity changes.",
+            new InvalidOperationException( "UNIQUE constraint failed: AspNetUsers.NormalizedEmail" ) );
+
+        FakeUserManager userManager = new(
+            findByEmailResult: null,
+            createAsyncException: dbEx
+        );
+
+        Mock<SignInManager<ApplicationUser>> signInManagerMock = BuildSignInManagerMock( userManager );
+
+        ApiKeyHasher hasher = new( "test_salt" );
+        AccountController controller = new(
+            userManager,
+            signInManagerMock.Object,
+            NullLogger<AccountController>.Instance,
+            hasher
+        ) {
+            ControllerContext = new ControllerContext {
+                HttpContext = new DefaultHttpContext( )
+            }
+        };
+
+        RegisterRequest request = new( email, "ValidPassword123!" );
+
+        // Act + Assert — non-SqliteException inner must propagate past the type-gated catch guard
         _ = await Assert.ThrowsExactlyAsync<DbUpdateException>( ( ) => controller.Register( request ) );
     }
 
@@ -130,30 +194,20 @@ public class AccountControllerTests {
     /// <c>FindByEmailAsync</c> and <c>CreateAsync</c> without Castle.DynamicProxy proxying, which
     /// is unreliable for abstract-constructored types with nullable parameters.
     /// </summary>
-    private sealed class FakeUserManager : UserManager<ApplicationUser> {
-        private readonly ApplicationUser? _findByEmailResult;
-        private readonly Exception? _createAsyncException;
-
-        public FakeUserManager(
-            ApplicationUser? findByEmailResult,
-            Exception? createAsyncException
-        ) : base(
-            new NoOpUserStore( ),
-            null!, null!, null!, null!, null!,
-            new IdentityErrorDescriber( ),
-            null!, null!
-        ) {
-            _findByEmailResult = findByEmailResult;
-            _createAsyncException = createAsyncException;
-        }
-
+    private sealed class FakeUserManager(
+        ApplicationUser? findByEmailResult,
+        Exception? createAsyncException
+    ) : UserManager<ApplicationUser>(
+        new NoOpUserStore( ),
+        null!, null!, null!, null!, null!,
+        new IdentityErrorDescriber( ),
+        null!, null!
+    ) {
         public override Task<ApplicationUser?> FindByEmailAsync( string email )
-            => Task.FromResult( _findByEmailResult );
+            => Task.FromResult( findByEmailResult );
 
         public override Task<IdentityResult> CreateAsync( ApplicationUser user, string password ) {
-            if (_createAsyncException is not null) {
-                throw _createAsyncException;
-            }
+            if (createAsyncException is not null) throw createAsyncException;
             return Task.FromResult( IdentityResult.Success );
         }
 
@@ -199,5 +253,3 @@ public class AccountControllerTests {
         }
     }
 }
-
-#pragma warning restore CS1591

--- a/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
+++ b/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
@@ -366,19 +366,18 @@ public class CacheBootstrapBackgroundServiceTests {
                 It.IsAny<Expiration>( ),
                 It.IsAny<StackExchange.Redis.ValueCondition>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
-                ( _, v, _, _, _ ) => {
-                    string json = v.ToString( );
-                    lock (writtenJsons) { writtenJsons.Add( json ); }
-                    try {
-                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
-                        bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
-                        bool hasLastRunTime = d2.RootElement.GetProperty( "LastRunTime" ).ValueKind != System.Text.Json.JsonValueKind.Null;
-                        if (!isRunning && hasLastRunTime) {
-                            _ = completionTcs.TrySetResult( );
-                        }
-                    } catch { }
-                } )
+            .Callback( ( RedisKey _, RedisValue v, Expiration _, StackExchange.Redis.ValueCondition _, CommandFlags _ ) => {
+                string json = v.ToString( );
+                lock (writtenJsons) { writtenJsons.Add( json ); }
+                try {
+                    System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                    bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
+                    bool hasLastRunTime = d2.RootElement.GetProperty( "LastRunTime" ).ValueKind != System.Text.Json.JsonValueKind.Null;
+                    if (!isRunning && hasLastRunTime) {
+                        _ = completionTcs.TrySetResult( );
+                    }
+                } catch { }
+            } )
             .ReturnsAsync( true );
 
         SetupRecordList( [CreateTestRecord( "at://test/1" )] );
@@ -437,17 +436,16 @@ public class CacheBootstrapBackgroundServiceTests {
                 It.IsAny<Expiration>( ),
                 It.IsAny<StackExchange.Redis.ValueCondition>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
-                ( _, v, _, _, _ ) => {
-                    string json = v.ToString( );
-                    writtenJsons.Add( json );
-                    try {
-                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
-                        if (d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( )) {
-                            _ = startTcs.TrySetResult( );
-                        }
-                    } catch { }
-                } )
+            .Callback( ( RedisKey _, RedisValue v, Expiration _, StackExchange.Redis.ValueCondition _, CommandFlags _ ) => {
+                string json = v.ToString( );
+                writtenJsons.Add( json );
+                try {
+                    System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                    if (d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( )) {
+                        _ = startTcs.TrySetResult( );
+                    }
+                } catch { }
+            } )
             .ReturnsAsync( true );
 
         SetupEmptyRecordList( );
@@ -503,19 +501,18 @@ public class CacheBootstrapBackgroundServiceTests {
                 It.IsAny<Expiration>( ),
                 It.IsAny<StackExchange.Redis.ValueCondition>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
-                ( _, v, _, _, _ ) => {
-                    string json = v.ToString( );
-                    writtenJsons.Add( json );
-                    try {
-                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
-                        bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
-                        bool hasNextScheduled = d2.RootElement.GetProperty( "NextScheduledRun" ).ValueKind != System.Text.Json.JsonValueKind.Null;
-                        if (!isRunning && hasNextScheduled) {
-                            _ = errorCompletionTcs.TrySetResult( );
-                        }
-                    } catch { }
-                } )
+            .Callback( ( RedisKey _, RedisValue v, Expiration _, StackExchange.Redis.ValueCondition _, CommandFlags _ ) => {
+                string json = v.ToString( );
+                writtenJsons.Add( json );
+                try {
+                    System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                    bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
+                    bool hasNextScheduled = d2.RootElement.GetProperty( "NextScheduledRun" ).ValueKind != System.Text.Json.JsonValueKind.Null;
+                    if (!isRunning && hasNextScheduled) {
+                        _ = errorCompletionTcs.TrySetResult( );
+                    }
+                } catch { }
+            } )
             .ReturnsAsync( true );
 
         _ = _atProtoStorageMock

--- a/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
+++ b/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
@@ -18,6 +18,7 @@ public class CacheBootstrapBackgroundServiceTests {
     private Mock<IATProtoStorageService> _atProtoStorageMock = null!;
     private Mock<IMediaLinkCacheRepository> _cacheRepositoryMock = null!;
     private Mock<IConnectionMultiplexer> _redisMock = null!;
+    private Mock<IDatabase> _redisDatabaseMock = null!;
     private Mock<ILogger<CacheBootstrapBackgroundService>> _loggerMock = null!;
     private CacheBootstrapSettings _settings = null!;
 
@@ -37,10 +38,22 @@ public class CacheBootstrapBackgroundServiceTests {
         _atProtoStorageMock = new Mock<IATProtoStorageService>( );
         _cacheRepositoryMock = new Mock<IMediaLinkCacheRepository>( );
         _redisMock = new Mock<IConnectionMultiplexer>( );
+        _redisDatabaseMock = new Mock<IDatabase>( );
         _loggerMock = new Mock<ILogger<CacheBootstrapBackgroundService>>( );
 
         // Setup Redis mock to return empty endpoints (avoids null reference in diagnostics)
         _ = _redisMock.Setup( r => r.GetEndPoints( It.IsAny<bool>( ) ) ).Returns( [] );
+
+        // Wire database mock; default read returns null (no prior status)
+        _ = _redisMock
+            .Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
+            .Returns( _redisDatabaseMock.Object );
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringGetAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( RedisValue.Null );
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringSetAsync( It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<Expiration>( ), It.IsAny<StackExchange.Redis.ValueCondition>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( true );
 
         _settings = new CacheBootstrapSettings(
             s_testPdsUri,
@@ -70,6 +83,7 @@ public class CacheBootstrapBackgroundServiceTests {
     /// <summary>
     /// Verifies that <see cref="CacheBootstrapBackgroundService"/> bootstraps the cache by loading
     /// records from ATProto storage and populating the cache repository on startup.
+    /// Converted from Task.Delay(100) to TCS-signaling to eliminate flake risk on slow CI.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -80,13 +94,27 @@ public class CacheBootstrapBackgroundServiceTests {
             CreateTestRecord( "at://test/2" ),
             CreateTestRecord( "at://test/3" )
         ];
+
+        // Signal when all 3 records have been processed by AddInputLinksAsync
+        TaskCompletionSource allProcessedTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        int[] callCount = [0];
+        _ = _cacheRepositoryMock
+            .Setup( x => x.AddInputLinksAsync( It.IsAny<string>( ), It.IsAny<MediaLinkResult>( ) ) )
+            .Callback<string, MediaLinkResult>( ( _, _ ) => {
+                if (System.Threading.Interlocked.Increment( ref callCount[0] ) >= 3) {
+                    _ = allProcessedTcs.TrySetResult( );
+                }
+            } )
+            .Returns( Task.CompletedTask );
+
         SetupRecordList( records );
         CacheBootstrapBackgroundService service = CreateService( );
 
-        // Act - Start and immediately cancel
+        // Act
         using CancellationTokenSource cts = new( );
         Task executeTask = service.StartAsync( cts.Token );
-        await Task.Delay( 100, TestContext.CancellationToken ); // Give time for bootstrap to complete
+
+        await allProcessedTcs.Task.WaitAsync( TestContext.CancellationToken );
         await cts.CancelAsync( );
         await executeTask;
 
@@ -100,18 +128,25 @@ public class CacheBootstrapBackgroundServiceTests {
     /// <summary>
     /// Verifies that <see cref="CacheBootstrapBackgroundService"/> completes successfully when
     /// the ATProto storage contains no records to bootstrap.
+    /// Converted from Task.Delay(100) to TCS-signaling to eliminate flake risk on slow CI.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task ExecuteAsync_WithEmptyCollection_ShouldCompleteWithoutErrors( ) {
-        // Arrange
-        SetupEmptyRecordList( );
+        // Arrange: signal when ListAllRecordsAsync is called (first run completed when it returns)
+        TaskCompletionSource listCalledTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _atProtoStorageMock
+            .Setup( x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback<Uri, string, CancellationToken>( ( _, _, _ ) => listCalledTcs.TrySetResult( ) )
+            .Returns( AsyncEnumerable.Empty<(string, MediaLinkResult)>( ) );
+
         CacheBootstrapBackgroundService service = CreateService( );
 
         // Act
         using CancellationTokenSource cts = new( );
         Task executeTask = service.StartAsync( cts.Token );
-        await Task.Delay( 100, TestContext.CancellationToken );
+
+        await listCalledTcs.Task.WaitAsync( TestContext.CancellationToken );
         await cts.CancelAsync( );
         await executeTask;
 
@@ -125,6 +160,7 @@ public class CacheBootstrapBackgroundServiceTests {
     /// <summary>
     /// Verifies that <see cref="CacheBootstrapBackgroundService"/> continues processing remaining
     /// records when individual record caching fails, ensuring fault tolerance.
+    /// Converted from Task.Delay(100) to TCS-signaling to eliminate flake risk on slow CI.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -137,12 +173,25 @@ public class CacheBootstrapBackgroundServiceTests {
         ];
         SetupRecordList( records );
 
-        // Setup first record to fail
+        // Signal when the third AddInputLinksAsync call completes (all 3 attempted)
+        TaskCompletionSource allAttemptedTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        int[] attemptCount = [0];
+
         _ = _cacheRepositoryMock
             .Setup( x => x.AddInputLinksAsync( "at://test/1", It.IsAny<MediaLinkResult>( ) ) )
+            .Callback<string, MediaLinkResult>( ( _, _ ) => {
+                if (System.Threading.Interlocked.Increment( ref attemptCount[0] ) >= 3) {
+                    _ = allAttemptedTcs.TrySetResult( );
+                }
+            } )
             .ThrowsAsync( new InvalidOperationException( "Simulated failure" ) );
         _ = _cacheRepositoryMock
             .Setup( x => x.AddInputLinksAsync( It.Is<string>( s => s != "at://test/1" ), It.IsAny<MediaLinkResult>( ) ) )
+            .Callback<string, MediaLinkResult>( ( _, _ ) => {
+                if (System.Threading.Interlocked.Increment( ref attemptCount[0] ) >= 3) {
+                    _ = allAttemptedTcs.TrySetResult( );
+                }
+            } )
             .Returns( Task.CompletedTask );
 
         CacheBootstrapBackgroundService service = CreateService( );
@@ -150,7 +199,8 @@ public class CacheBootstrapBackgroundServiceTests {
         // Act
         using CancellationTokenSource cts = new( );
         Task executeTask = service.StartAsync( cts.Token );
-        await Task.Delay( 100, TestContext.CancellationToken );
+
+        await allAttemptedTcs.Task.WaitAsync( TestContext.CancellationToken );
         await cts.CancelAsync( );
         await executeTask;
 
@@ -184,18 +234,25 @@ public class CacheBootstrapBackgroundServiceTests {
     /// <summary>
     /// Verifies that <see cref="CacheBootstrapBackgroundService"/> passes the correct PDS URI
     /// and user DID from settings when listing records from ATProto storage.
+    /// Converted from Task.Delay(100) to TCS-signaling to eliminate flake risk on slow CI.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task ExecuteAsync_ShouldPassCorrectParametersToListAllRecords( ) {
-        // Arrange
-        SetupEmptyRecordList( );
+        // Arrange: signal when ListAllRecordsAsync is called with the expected parameters
+        TaskCompletionSource listCalledTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _atProtoStorageMock
+            .Setup( x => x.ListAllRecordsAsync( s_testPdsUri, TestUserDid, It.IsAny<CancellationToken>( ) ) )
+            .Callback<Uri, string, CancellationToken>( ( _, _, _ ) => listCalledTcs.TrySetResult( ) )
+            .Returns( AsyncEnumerable.Empty<(string, MediaLinkResult)>( ) );
+
         CacheBootstrapBackgroundService service = CreateService( );
 
         // Act
         using CancellationTokenSource cts = new( );
         Task executeTask = service.StartAsync( cts.Token );
-        await Task.Delay( 100, TestContext.CancellationToken );
+
+        await listCalledTcs.Task.WaitAsync( TestContext.CancellationToken );
         await cts.CancelAsync( );
         await executeTask;
 
@@ -284,6 +341,207 @@ public class CacheBootstrapBackgroundServiceTests {
             URL = "https://open.spotify.com/track/test"
         } );
         return (atUri, result);
+    }
+
+    #endregion
+
+    #region Status Write Tests
+
+    /// <summary>
+    /// Verifies that a completed run writes a full status object with all fields populated.
+    /// Uses a deterministic TaskCompletionSource rather than a fixed-time delay to avoid
+    /// flaky behavior on slow CI.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RunBootstrap_OnCompletion_WritesFullStatusWithAllFields( ) {
+        // Use TCS to signal as soon as a completion write (IsRunning=false, LastRunTime≠null) lands.
+        TaskCompletionSource completionTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        List<string> writtenJsons = [];
+
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringSetAsync(
+                It.IsAny<RedisKey>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<Expiration>( ),
+                It.IsAny<StackExchange.Redis.ValueCondition>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
+                ( _, v, _, _, _ ) => {
+                    string json = v.ToString( );
+                    lock (writtenJsons) { writtenJsons.Add( json ); }
+                    try {
+                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                        bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
+                        bool hasLastRunTime = d2.RootElement.GetProperty( "LastRunTime" ).ValueKind != System.Text.Json.JsonValueKind.Null;
+                        if (!isRunning && hasLastRunTime) {
+                            _ = completionTcs.TrySetResult( );
+                        }
+                    } catch { }
+                } )
+            .ReturnsAsync( true );
+
+        SetupRecordList( [CreateTestRecord( "at://test/1" )] );
+        CacheBootstrapBackgroundService service = CreateService( );
+
+        using CancellationTokenSource cts = new( );
+        Task executeTask = service.StartAsync( cts.Token );
+
+        // Wait until the completion write arrives, then cancel
+        await completionTcs.Task.WaitAsync( TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await executeTask;
+
+        Assert.IsNotEmpty( writtenJsons );
+
+        string lastJson = writtenJsons[^1];
+        System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse( lastJson );
+        System.Text.Json.JsonElement root = doc.RootElement;
+
+        Assert.IsFalse( root.GetProperty( "IsRunning" ).GetBoolean( ) );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "LastRunTime" ).ValueKind );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "LastSuccessCount" ).ValueKind );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "NextScheduledRun" ).ValueKind );
+    }
+
+    /// <summary>
+    /// Verifies that the start-of-run status write preserves completed-run fields
+    /// from a previous run rather than clearing them.
+    /// Uses a deterministic TaskCompletionSource to avoid flaky fixed-time delays.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RunBootstrap_OnStart_PreservesPreviousCompletedRunFields( ) {
+        CacheBootstrapStatus previousStatus = new( ) {
+            IsRunning = false,
+            LastRunTime = DateTimeOffset.UtcNow.AddHours( -6 ),
+            LastSuccessCount = 500,
+            LastErrorCount = 2,
+            LastDurationSeconds = 120.5,
+            RedisKeyCount = 1234567,
+            NextScheduledRun = DateTimeOffset.UtcNow.AddHours( 6 )
+        };
+        string previousJson = System.Text.Json.JsonSerializer.Serialize( previousStatus );
+
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringGetAsync( CacheBootstrapStatus.RedisKey, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisValue)previousJson );
+
+        // Signal when the first write (IsRunning=true) arrives
+        TaskCompletionSource startTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        List<string> writtenJsons = [];
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringSetAsync(
+                It.IsAny<RedisKey>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<Expiration>( ),
+                It.IsAny<StackExchange.Redis.ValueCondition>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
+                ( _, v, _, _, _ ) => {
+                    string json = v.ToString( );
+                    writtenJsons.Add( json );
+                    try {
+                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                        if (d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( )) {
+                            _ = startTcs.TrySetResult( );
+                        }
+                    } catch { }
+                } )
+            .ReturnsAsync( true );
+
+        SetupEmptyRecordList( );
+        CacheBootstrapBackgroundService service = CreateService( );
+
+        using CancellationTokenSource cts = new( );
+        Task executeTask = service.StartAsync( cts.Token );
+
+        await startTcs.Task.WaitAsync( TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await executeTask;
+
+        Assert.IsNotEmpty( writtenJsons );
+        string startJson = writtenJsons[0];
+        System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse( startJson );
+        System.Text.Json.JsonElement root = doc.RootElement;
+
+        Assert.IsTrue( root.GetProperty( "IsRunning" ).GetBoolean( ) );
+        Assert.AreEqual( 500, root.GetProperty( "LastSuccessCount" ).GetInt32( ) );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "LastDurationSeconds" ).ValueKind );
+    }
+
+    /// <summary>
+    /// Verifies that a fatal error during ListAllRecordsAsync preserves the prior completed-run
+    /// fields in Redis rather than clobbering them with zero counts.
+    /// Uses a deterministic TaskCompletionSource to avoid flaky fixed-time delays.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RunBootstrap_WhenListAllRecordsThrows_PreservesPriorCompletedRunFields( ) {
+        CacheBootstrapStatus priorRun = new( ) {
+            IsRunning = false,
+            LastRunTime = DateTimeOffset.UtcNow.AddHours( -6 ),
+            LastSuccessCount = 247404,
+            LastErrorCount = 0,
+            LastDurationSeconds = 4565.9,
+            RedisKeyCount = 2882803,
+            NextScheduledRun = DateTimeOffset.UtcNow.AddHours( 6 )
+        };
+        string priorJson = System.Text.Json.JsonSerializer.Serialize( priorRun );
+
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringGetAsync( CacheBootstrapStatus.RedisKey, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisValue)priorJson );
+
+        // Signal when the error-path completion write (IsRunning=false, NextScheduledRun present) lands
+        TaskCompletionSource errorCompletionTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        List<string> writtenJsons = [];
+        _ = _redisDatabaseMock
+            .Setup( d => d.StringSetAsync(
+                It.IsAny<RedisKey>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<Expiration>( ),
+                It.IsAny<StackExchange.Redis.ValueCondition>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisKey, RedisValue, Expiration, StackExchange.Redis.ValueCondition, CommandFlags>(
+                ( _, v, _, _, _ ) => {
+                    string json = v.ToString( );
+                    writtenJsons.Add( json );
+                    try {
+                        System.Text.Json.JsonDocument d2 = System.Text.Json.JsonDocument.Parse( json );
+                        bool isRunning = d2.RootElement.GetProperty( "IsRunning" ).GetBoolean( );
+                        bool hasNextScheduled = d2.RootElement.GetProperty( "NextScheduledRun" ).ValueKind != System.Text.Json.JsonValueKind.Null;
+                        if (!isRunning && hasNextScheduled) {
+                            _ = errorCompletionTcs.TrySetResult( );
+                        }
+                    } catch { }
+                } )
+            .ReturnsAsync( true );
+
+        _ = _atProtoStorageMock
+            .Setup( x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Throws( new InvalidOperationException( "Simulated CAR parse failure" ) );
+
+        CacheBootstrapBackgroundService service = CreateService( );
+
+        using CancellationTokenSource cts = new( );
+        Task executeTask = service.StartAsync( cts.Token );
+
+        await errorCompletionTcs.Task.WaitAsync( TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await executeTask;
+
+        Assert.IsNotEmpty( writtenJsons );
+
+        string lastJson = writtenJsons[^1];
+        System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse( lastJson );
+        System.Text.Json.JsonElement root = doc.RootElement;
+
+        Assert.IsFalse( root.GetProperty( "IsRunning" ).GetBoolean( ) );
+        Assert.AreEqual( 247404, root.GetProperty( "LastSuccessCount" ).GetInt32( ) );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "LastRunTime" ).ValueKind );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "LastDurationSeconds" ).ValueKind );
+        Assert.AreNotEqual( System.Text.Json.JsonValueKind.Null, root.GetProperty( "NextScheduledRun" ).ValueKind );
     }
 
     #endregion

--- a/Tests/Unit/CarRepoReaderTests.cs
+++ b/Tests/Unit/CarRepoReaderTests.cs
@@ -1,0 +1,144 @@
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Tests.Unit.Helpers;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="CarRepoReader.EnumerateCollection"/>.
+/// </summary>
+[TestClass]
+public class CarRepoReaderTests {
+
+    /// <summary>Gets or sets the test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    private static MediaLinkResultRecord MakeRecord( string title ) =>
+        new(
+            results: [
+                new ProviderResultRecord(
+                    provider: "spotify",
+                    artist: "Artist",
+                    title: title,
+                    url: "https://open.spotify.com/track/x",
+                    marketRegion: "US"
+                )
+            ],
+            lookedUpAt: new DateTimeOffset( 2024, 6, 1, 0, 0, 0, TimeSpan.Zero )
+        );
+
+    [TestMethod]
+    public void EnumerateCollection_MixedCollections_FiltersToRequestedCollection( ) {
+        // Build a repo with both lookup records and playlist records
+        // They share the same CAR but are in different collections
+        byte[] lookupRecord1Bytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Lookup Track 1" ) );
+        byte[] lookupRecord2Bytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Lookup Track 2" ) );
+        byte[] playlistRecordBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( "Playlist" ) );
+
+        byte[] lookupCid1 = TestCarBuilder.ComputeCidBytes( lookupRecord1Bytes );
+        byte[] lookupCid2 = TestCarBuilder.ComputeCidBytes( lookupRecord2Bytes );
+        byte[] playlistCid = TestCarBuilder.ComputeCidBytes( playlistRecordBytes );
+
+        // MST entries for two collections
+        List<TestCarBuilder.MstEntry> entries = [
+            new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/key1", lookupCid1 ),
+            new TestCarBuilder.MstEntry( 0, "link.bridgebeats.playlist/pl1", playlistCid ),
+            new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/key2", lookupCid2 )
+        ];
+
+        // Sort entries by key (required for MST)
+        entries.Sort( ( a, b ) => string.Compare( a.KeySuffix, b.KeySuffix, StringComparison.Ordinal ) );
+
+        // Apply prefix compression
+        List<TestCarBuilder.MstEntry> compressed = [];
+        string prevKey = "";
+        foreach (TestCarBuilder.MstEntry e in entries) {
+            int prefixLen = CommonPrefixLength( prevKey, e.KeySuffix );
+            compressed.Add( new TestCarBuilder.MstEntry( prefixLen, e.KeySuffix[prefixLen..], e.ValueCidBytes ) );
+            prevKey = e.KeySuffix;
+        }
+
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode( null, compressed );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [lookupCid1] = lookupRecord1Bytes,
+            [lookupCid2] = lookupRecord2Bytes,
+            [playlistCid] = playlistRecordBytes
+        };
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        ReadOnlyMemory<byte> carMemory = carBytes;
+
+        // Act: enumerate only the lookup collection
+        List<(string Rkey, System.Text.Json.Nodes.JsonNode Record)> lookupResults = [
+            .. CarRepoReader.EnumerateCollection( carMemory, "link.bridgebeats.lookup", TestContext.CancellationToken ).Records
+        ];
+
+        // Assert: only 2 lookup records returned, playlist filtered out
+        Assert.HasCount( 2, lookupResults );
+        // Both should have rkeys from the lookup collection
+        Assert.IsTrue( lookupResults.All( r => !r.Rkey.Contains( "pl1" ) ) );
+    }
+
+    [TestMethod]
+    public void EnumerateCollection_EmptyRepo_YieldsNothing( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            []
+        );
+
+        List<(string Rkey, System.Text.Json.Nodes.JsonNode Record)> results = [
+            .. CarRepoReader.EnumerateCollection( carBytes, "link.bridgebeats.lookup", TestContext.CancellationToken ).Records
+        ];
+
+        Assert.IsEmpty( results );
+    }
+
+    [TestMethod]
+    public void EnumerateCollection_LookupRecords_YieldsCorrectRkeys( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            [
+                ("rkey_alpha", MakeRecord( "Alpha" )),
+                ("rkey_beta", MakeRecord( "Beta" ))
+            ]
+        );
+
+        List<(string Rkey, System.Text.Json.Nodes.JsonNode Record)> results = [
+            .. CarRepoReader.EnumerateCollection( carBytes, "link.bridgebeats.lookup", TestContext.CancellationToken ).Records
+        ];
+
+        Assert.HasCount( 2, results );
+        List<string> rkeys = [.. results.Select( r => r.Rkey ).OrderBy( s => s )];
+        Assert.AreEqual( "rkey_alpha", rkeys[0] );
+        Assert.AreEqual( "rkey_beta", rkeys[1] );
+    }
+
+    private static int CommonPrefixLength( string a, string b ) {
+        int len = Math.Min( a.Length, b.Length );
+        int i = 0;
+        while (i < len && a[i] == b[i]) { i++; }
+        return i;
+    }
+
+    private sealed class ByteArrayKeyComparer : System.Collections.Generic.IEqualityComparer<byte[]> {
+        internal static readonly ByteArrayKeyComparer Instance = new( );
+        public bool Equals( byte[]? x, byte[]? y ) => x is not null && y is not null && x.AsSpan( ).SequenceEqual( y );
+        public int GetHashCode( byte[] obj ) {
+            System.HashCode hc = new( );
+            hc.AddBytes( obj );
+            return hc.ToHashCode( );
+        }
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/CarV1ReaderTests.cs
+++ b/Tests/Unit/CarV1ReaderTests.cs
@@ -1,0 +1,178 @@
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Tests.Unit.Helpers;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="CarV1Reader.Read"/>.
+/// </summary>
+[TestClass]
+public class CarV1ReaderTests {
+
+    private static readonly MediaLinkResultRecord s_testRecord = new(
+        results: [
+            new ProviderResultRecord(
+                provider: "spotify",
+                artist: "Test Artist",
+                title: "Test Track",
+                url: "https://open.spotify.com/track/abc",
+                marketRegion: "US"
+            )
+        ],
+        lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
+    );
+
+    [TestMethod]
+    public void Read_ValidCar_ReturnsCarFile( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test123",
+            "link.bridgebeats.lookup",
+            [("rkey1", s_testRecord)]
+        );
+
+        CarFile carFile = CarV1Reader.Read( carBytes );
+
+        Assert.IsNotNull( carFile );
+        Assert.IsNotEmpty( carFile.Blocks );
+    }
+
+    /// <summary>
+    /// An empty repo emits exactly 2 blocks: the commit block and the empty MST root node.
+    /// The test name "ZeroBlocks" was a misnomer; this test pins the empty-repo block shape.
+    /// </summary>
+    [TestMethod]
+    public void Read_ValidCar_EmptyRepo_HasCommitAndMstRoot_Succeeds( ) {
+        // Empty repo: no record blocks, just an MST root node and commit
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:emptyrepo",
+            "link.bridgebeats.lookup",
+            []
+        );
+
+        CarFile carFile = CarV1Reader.Read( carBytes );
+
+        Assert.IsNotNull( carFile );
+        // Empty repo = commit block + empty MST node = exactly 2 blocks
+        Assert.HasCount( 2, carFile.Blocks );
+    }
+
+    [TestMethod]
+    public void Read_DigestMismatch_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test123",
+            "link.bridgebeats.lookup",
+            [("rkey1", s_testRecord)]
+        );
+
+        // Corrupt a byte in the block data area (past the header)
+        // Find a position well into the file to corrupt a block payload
+        byte[] corrupted = (byte[])carBytes.Clone( );
+        int corruptPos = corrupted.Length - 10;
+        corrupted[corruptPos] ^= 0xFF;
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( corrupted ) );
+    }
+
+    [TestMethod]
+    public void Read_TruncatedSection_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test123",
+            "link.bridgebeats.lookup",
+            [("rkey1", s_testRecord)]
+        );
+
+        // Truncate to half
+        byte[] truncated = carBytes[..(carBytes.Length / 2)];
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( truncated ) );
+    }
+
+    [TestMethod]
+    public void Read_Version2Header_ThrowsCarParseException( ) {
+        // Build a fake CAR header with version=2
+        byte[] fakeCarBytes = BuildCarWithVersion( 2 );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( fakeCarBytes ) );
+    }
+
+    [TestMethod]
+    public void Read_CidV0InSections_ThrowsCarParseException( ) {
+        // Build a valid CAR but inject a CIDv0 prefix into a section
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test123",
+            "link.bridgebeats.lookup",
+            [("rkey1", s_testRecord)]
+        );
+
+        // Find the first section (after the header) and patch the first byte to 0x12 (CIDv0)
+        // We need to find where sections start. Parse the header length first.
+        byte[] patched = (byte[])carBytes.Clone( );
+        int offset = 0;
+        _ = Varint.TryRead( patched.AsSpan( ), out ulong headerLen, out int headerLenBytes );
+        offset += headerLenBytes + (int)headerLen;
+
+        // Now at the first section. Read the section length varint.
+        _ = Varint.TryRead( patched.AsSpan( offset ), out ulong _, out int sectionLenBytes );
+        offset += sectionLenBytes;
+
+        // patch first byte of CID to 0x12 (CIDv0 marker)
+        patched[offset] = 0x12;
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( patched ) );
+    }
+
+    // ─── Duplicate CID: last-write-wins semantics ─────────────────────────────
+
+    /// <summary>
+    /// Verifies that a CAR containing a block section emitted twice for the same CID
+    /// succeeds, with the dictionary retaining exactly one entry (last-write-wins).
+    /// Content-addressed blocks are immutable, so both writes have identical content.
+    /// </summary>
+    [TestMethod]
+    public void Read_DuplicateCidSection_LastWriteWins( ) {
+        byte[] carBytes = TestCarBuilder.BuildCarWithDuplicateCid( out string duplicatedCidHex );
+
+        // Should not throw — duplicate CIDs are legal in CAR v1
+        CarFile carFile = CarV1Reader.Read( carBytes );
+
+        Assert.IsNotNull( carFile );
+        // The duplicated block must appear exactly once in the dictionary
+        Assert.IsTrue( carFile.Blocks.ContainsKey( duplicatedCidHex ) );
+    }
+
+    // ─── >2MB block section ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a block section declaring a length > 2 MB is rejected with CarParseException.
+    /// </summary>
+    [TestMethod]
+    public void Read_OversizedBlockSection_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildCarWithOversizedBlockSection( );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( carBytes ) );
+    }
+
+    private static byte[] BuildCarWithVersion( int version ) {
+        using System.IO.MemoryStream ms = new( );
+
+        // Build header with specified version
+        System.Formats.Cbor.CborWriter w = new( System.Formats.Cbor.CborConformanceMode.Lax );
+        w.WriteStartMap( null );
+        w.WriteTextString( "roots" );
+        w.WriteStartArray( null );
+        w.WriteEndArray( );
+        w.WriteTextString( "version" );
+        w.WriteInt32( version );
+        w.WriteEndMap( );
+        byte[] header = w.Encode( );
+
+        TestCarBuilder.WriteVarint( ms, (ulong)header.Length );
+        ms.Write( header );
+        return ms.ToArray( );
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/CarV1ReaderTests.cs
+++ b/Tests/Unit/CarV1ReaderTests.cs
@@ -155,6 +155,36 @@ public class CarV1ReaderTests {
         _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( carBytes ) );
     }
 
+    // ─── Hardening: oversized CID rejected ───────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a CAR header whose tag-42 root CID byte string is 37 bytes (one byte longer
+    /// than the required 36) is rejected with CarParseException rather than silently accepted.
+    /// Failure-first evidence: before Fix 1 (exact-length check), the old &lt; guard accepted any
+    /// span &gt;= 36 bytes, so this test would have passed without an exception being thrown.
+    /// </summary>
+    [TestMethod]
+    public void Read_OversizedCidBytes_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildCarWithOversizedCidInHeader( );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( carBytes ) );
+    }
+
+    // ─── Hardening: missing version field rejected ────────────────────────────
+
+    /// <summary>
+    /// Verifies that a CAR header whose DAG-CBOR map omits the "version" key entirely is rejected
+    /// with CarParseException even though "roots" is present and valid.
+    /// Failure-first evidence: before Fix 2 (version-presence check), a header without "version"
+    /// was accepted as v1, so this test would have completed without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Read_HeaderMissingVersion_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildCarWithHeaderMissingVersion( );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => CarV1Reader.Read( carBytes ) );
+    }
+
     private static byte[] BuildCarWithVersion( int version ) {
         using System.IO.MemoryStream ms = new( );
 

--- a/Tests/Unit/DagCborConverterTests.cs
+++ b/Tests/Unit/DagCborConverterTests.cs
@@ -1,0 +1,215 @@
+using System.Formats.Cbor;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Tests.Unit.Helpers;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DagCborConverter.ToJsonNode"/> including the $type contingency check.
+/// </summary>
+[TestClass]
+public class DagCborConverterTests {
+
+    // ─── Contingency test — write first, per brief ────────────────────────────
+
+    /// <summary>
+    /// Validates that a DAG-CBOR record block for MediaLinkResultRecord deserializes
+    /// correctly through ToJsonNode → JsonSerializer, resolving the $type contingency.
+    /// </summary>
+    [TestMethod]
+    public void ToJsonNode_RecordBlock_DeserializesToMediaLinkResultRecord( ) {
+        // Arrange: build a real DAG-CBOR record block using TestCarBuilder
+        MediaLinkResultRecord original = new(
+            results: [
+                new ProviderResultRecord(
+                    provider: "spotify",
+                    artist: "Test Artist",
+                    title: "Test Track",
+                    url: "https://open.spotify.com/track/abc123",
+                    marketRegion: "US",
+                    externalId: "ISRC123456789",
+                    artUrl: null,
+                    isAlbum: false
+                )
+            ],
+            lookedUpAt: new DateTimeOffset( 2024, 3, 15, 12, 0, 0, TimeSpan.Zero )
+        );
+        byte[] cborBytes = TestCarBuilder.BuildRecordBlock( original );
+
+        // Act: convert to JsonNode then deserialize
+        JsonNode? node = DagCborConverter.ToJsonNode( cborBytes );
+        Assert.IsNotNull( node );
+
+        // Strip $type if present (atproto may include it; System.Text.Json ignores unknown props by default)
+        if (node is JsonObject obj && obj.ContainsKey( "$type" )) {
+            _ = obj.Remove( "$type" );
+        }
+
+        string json = node.ToJsonString( );
+        MediaLinkResultRecord? deserialized = JsonSerializer.Deserialize<MediaLinkResultRecord>( json );
+
+        // Assert: round-trips correctly
+        Assert.IsNotNull( deserialized );
+        Assert.HasCount( 1, deserialized.Results );
+        ProviderResultRecord firstResult = deserialized.Results.First( );
+        Assert.AreEqual( "spotify", firstResult.Provider );
+        Assert.AreEqual( "Test Artist", firstResult.Artist );
+        Assert.AreEqual( "Test Track", firstResult.Title );
+        Assert.AreEqual( "https://open.spotify.com/track/abc123", firstResult.Url );
+        Assert.AreEqual( "US", firstResult.MarketRegion );
+        Assert.AreEqual( "ISRC123456789", firstResult.ExternalId );
+        Assert.IsFalse( firstResult.IsAlbum );
+        Assert.AreEqual(
+            new DateTimeOffset( 2024, 3, 15, 12, 0, 0, TimeSpan.Zero ),
+            deserialized.LookedUpAt );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_IsoDateString_RoundTripsAsString( ) {
+        // Arrange
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteStartMap( null );
+        w.WriteTextString( "ts" );
+        w.WriteTextString( "2024-03-15T12:00:00.0000000+00:00" );
+        w.WriteEndMap( );
+        byte[] bytes = w.Encode( );
+
+        // Act
+        JsonNode? node = DagCborConverter.ToJsonNode( bytes );
+
+        // Assert
+        Assert.IsNotNull( node );
+        Assert.AreEqual( "2024-03-15T12:00:00.0000000+00:00", node["ts"]?.GetValue<string>( ) );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_Tag42Link_ReturnsDollarLinkObject( ) {
+        // Arrange: a map with a tag-42 CID link
+        byte[] recordBytes = System.Text.Encoding.UTF8.GetBytes( "dummy block" );
+        byte[] cidBytes = TestCarBuilder.ComputeCidBytes( recordBytes );
+        byte[] linkBytes = TestCarBuilder.MakeLinkBytes( cidBytes );
+
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteStartMap( null );
+        w.WriteTextString( "data" );
+        w.WriteTag( (CborTag)42 );
+        w.WriteByteString( linkBytes );
+        w.WriteEndMap( );
+        byte[] bytes = w.Encode( );
+
+        // Act
+        JsonNode? node = DagCborConverter.ToJsonNode( bytes );
+
+        // Assert
+        Assert.IsNotNull( node );
+        JsonNode? dataNode = node["data"];
+        Assert.IsNotNull( dataNode );
+        Assert.IsNotNull( dataNode["$link"] );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_ByteString_ReturnsDollarBytesObject( ) {
+        // Arrange
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteByteString( new byte[] { 0xDE, 0xAD, 0xBE, 0xEF } );
+        byte[] bytes = w.Encode( );
+
+        // Act
+        JsonNode? node = DagCborConverter.ToJsonNode( bytes );
+
+        // Assert
+        Assert.IsNotNull( node );
+        Assert.IsNotNull( node["$bytes"] );
+        Assert.AreEqual( Convert.ToBase64String( new byte[] { 0xDE, 0xAD, 0xBE, 0xEF } ), node["$bytes"]?.GetValue<string>( ) );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_NestedStructures_RoundTrips( ) {
+        // Arrange: nested array inside map
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteStartMap( null );
+        w.WriteTextString( "items" );
+        w.WriteStartArray( null );
+        w.WriteTextString( "alpha" );
+        w.WriteUInt64( 42 );
+        w.WriteBoolean( true );
+        w.WriteEndArray( );
+        w.WriteEndMap( );
+        byte[] bytes = w.Encode( );
+
+        // Act
+        JsonNode? node = DagCborConverter.ToJsonNode( bytes );
+
+        // Assert
+        Assert.IsNotNull( node );
+        JsonArray? arr = node["items"] as JsonArray;
+        Assert.IsNotNull( arr );
+        Assert.AreEqual( 3, arr.Count );
+        Assert.AreEqual( "alpha", arr[0]?.GetValue<string>( ) );
+        Assert.AreEqual( 42UL, arr[1]?.GetValue<ulong>( ) );
+        Assert.IsTrue( arr[2]?.GetValue<bool>( ) );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_UnsupportedTag_ThrowsCarParseException( ) {
+        // Arrange
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteTag( (CborTag)1 ); // epoch-based datetime — not supported
+        w.WriteInt64( 1000000 );
+        byte[] bytes = w.Encode( );
+
+        // Act & Assert
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => DagCborConverter.ToJsonNode( bytes ) );
+    }
+
+    [TestMethod]
+    public void ToJsonNode_NullValue_ReturnsNull( ) {
+        // Arrange
+        CborWriter w = new( CborConformanceMode.Lax );
+        w.WriteNull( );
+        byte[] bytes = w.Encode( );
+
+        // Act
+        JsonNode? node = DagCborConverter.ToJsonNode( bytes );
+
+        // Assert
+        Assert.IsNull( node );
+    }
+
+    // ─── SEC-002 regression: depth guard converts deep nesting to CarParseException ──
+
+    /// <summary>
+    /// SEC-002 regression: a block with 33 levels of nested arrays (1 byte each) exceeds
+    /// the MaxDepth=32 guard and must throw CarParseException, NOT crash the test host
+    /// with an uncatchable StackOverflow.
+    /// Failure-first evidence: without the depth check in ReadValue/ReadMap/ReadArray,
+    /// this test would StackOverflow (crashing the test host) rather than catching CarParseException.
+    /// </summary>
+    [TestMethod]
+    public void ToJsonNode_DeeplyNestedCbor_ThrowsCarParseException( ) {
+        // 33 levels of nested single-element arrays exceeds MaxDepth=32.
+        byte[] deepBytes = TestCarBuilder.BuildDeeplyNestedCborBytes( 33 );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => DagCborConverter.ToJsonNode( deepBytes ) );
+    }
+
+    /// <summary>
+    /// Verifies that nesting at exactly MaxDepth (32) does not throw.
+    /// </summary>
+    [TestMethod]
+    public void ToJsonNode_NestingAtMaxDepth_DoesNotThrow( ) {
+        // 32 levels of nesting is exactly at the limit — should succeed.
+        byte[] deepBytes = TestCarBuilder.BuildDeeplyNestedCborBytes( 32 );
+
+        // Should not throw
+        JsonNode? node = DagCborConverter.ToJsonNode( deepBytes );
+        Assert.IsNotNull( node ); // outermost array
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/Helpers/TestCarBuilder.cs
+++ b/Tests/Unit/Helpers/TestCarBuilder.cs
@@ -1,6 +1,5 @@
 using System.Formats.Cbor;
 using System.Security.Cryptography;
-using System.Text.Json.Serialization;
 using BridgeBeats.Contracts.Records;
 
 #pragma warning disable CS1591

--- a/Tests/Unit/Helpers/TestCarBuilder.cs
+++ b/Tests/Unit/Helpers/TestCarBuilder.cs
@@ -1,0 +1,630 @@
+using System.Formats.Cbor;
+using System.Security.Cryptography;
+using System.Text.Json.Serialization;
+using BridgeBeats.Contracts.Records;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit.Helpers;
+
+/// <summary>
+/// Builds synthetic CAR v1 files for unit testing without requiring binary fixtures.
+/// DAG-CBOR key ordering follows the deterministic spec: length-first, then lexicographic.
+/// All CIDs are real sha256 digests over the corresponding block bytes.
+/// </summary>
+internal static class TestCarBuilder {
+
+    // CIDv1 dag-cbor sha256 prefix: version=0x01, codec=0x71, hash-fn=0x12, hash-len=0x20
+    private static readonly byte[] s_cidPrefix = [0x01, 0x71, 0x12, 0x20];
+
+    // ─── Public record type for MST node entries ─────────────────────────────
+
+    internal sealed record MstEntry(
+        int PrefixLen,
+        string KeySuffix,
+        byte[] ValueCidBytes,
+        byte[]? RightChildCidBytes = null
+    );
+
+    // ─── CID helpers ─────────────────────────────────────────────────────────
+
+    internal static byte[] ComputeCidBytes( ReadOnlySpan<byte> blockBytes ) {
+        byte[] digest = SHA256.HashData( blockBytes );
+        byte[] cidBytes = new byte[4 + 32];
+        s_cidPrefix.CopyTo( cidBytes, 0 );
+        digest.CopyTo( cidBytes, 4 );
+        return cidBytes;
+    }
+
+    /// <summary>
+    /// Wraps CID bytes in the tag-42 DAG-CBOR link encoding used in MST node entries.
+    /// Format: byte string of [0x00, ...cidBytes]
+    /// </summary>
+    internal static byte[] MakeLinkBytes( byte[] cidBytes ) {
+        byte[] linkBytes = new byte[1 + cidBytes.Length];
+        linkBytes[0] = 0x00; // multibase prefix
+        cidBytes.CopyTo( linkBytes, 1 );
+        return linkBytes;
+    }
+
+    // ─── Varint encoding ─────────────────────────────────────────────────────
+
+    internal static void WriteVarint( MemoryStream stream, ulong value ) {
+        while (value >= 0x80) {
+            stream.WriteByte( (byte)((value & 0x7F) | 0x80) );
+            value >>= 7;
+        }
+        stream.WriteByte( (byte)value );
+    }
+
+    // ─── Block builders ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Serializes a <see cref="MediaLinkResultRecord"/> to DAG-CBOR bytes.
+    /// </summary>
+    internal static byte[] BuildRecordBlock( MediaLinkResultRecord record ) {
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        // DAG-CBOR canonical key order: length-first, then lexicographic.
+        // Key lengths: results(7) < isPartial(9) < lookedUpAt(10)
+        // Write results first, then isPartial (only when true), then lookedUpAt.
+
+        WriteCborTextString( writer, "results" );
+        writer.WriteStartArray( null );
+        foreach (ProviderResultRecord r in record.Results) {
+            BuildProviderResultBlock( writer, r );
+        }
+        writer.WriteEndArray( );
+
+        if (record.IsPartial) {
+            WriteCborTextString( writer, "isPartial" );
+            writer.WriteBoolean( true );
+        }
+
+        WriteCborTextString( writer, "lookedUpAt" );
+        WriteCborTextString( writer, record.LookedUpAt.ToString( "O" ) );
+
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
+    private static void BuildProviderResultBlock( CborWriter writer, ProviderResultRecord r ) {
+        writer.WriteStartMap( null );
+
+        // Write fields in DAG-CBOR key order: length-first, then lexicographic within the same length.
+        // Key lengths: url(3), title(5), artUrl(6), artist(6), isAlbum(7), provider(8), externalId(10), marketRegion(12)
+        // Sorted order: url(3) < title(5) < artUrl(6)=artist(6)[lex] < isAlbum(7) < provider(8) < externalId(10) < marketRegion(12)
+
+        WriteCborTextString( writer, "url" );
+        WriteCborTextString( writer, r.Url );
+
+        WriteCborTextString( writer, "title" );
+        WriteCborTextString( writer, r.Title );
+
+        if (r.ArtUrl is not null) {
+            // artUrl (6) before artist (6) — lexicographic tie-break: 'artUrl' < 'artist'
+            WriteCborTextString( writer, "artUrl" );
+            WriteCborTextString( writer, r.ArtUrl );
+        }
+
+        WriteCborTextString( writer, "artist" );
+        WriteCborTextString( writer, r.Artist );
+
+        if (r.IsAlbum.HasValue) {
+            WriteCborTextString( writer, "isAlbum" );
+            writer.WriteBoolean( r.IsAlbum.Value );
+        }
+
+        WriteCborTextString( writer, "provider" );
+        WriteCborTextString( writer, r.Provider );
+
+        if (r.ExternalId is not null) {
+            WriteCborTextString( writer, "externalId" );
+            WriteCborTextString( writer, r.ExternalId );
+        }
+
+        WriteCborTextString( writer, "marketRegion" );
+        WriteCborTextString( writer, r.MarketRegion );
+
+        writer.WriteEndMap( );
+    }
+
+    /// <summary>
+    /// Builds an MST node block with optional left subtree and a list of entries.
+    /// </summary>
+    internal static byte[] BuildMstNode( byte[]? leftCidBytes, IReadOnlyList<MstEntry> entries ) {
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        // e field (entries array) — key "e" length 1
+        WriteCborTextString( writer, "e" );
+        writer.WriteStartArray( null );
+        foreach (MstEntry entry in entries) {
+            writer.WriteStartMap( null );
+            // k (1), p (1), t (1), v (1) — all length 1, alphabetic: k < p < t < v
+            WriteCborTextString( writer, "k" );
+            writer.WriteByteString( System.Text.Encoding.UTF8.GetBytes( entry.KeySuffix ) );
+
+            WriteCborTextString( writer, "p" );
+            writer.WriteInt32( entry.PrefixLen );
+
+            WriteCborTextString( writer, "t" );
+            if (entry.RightChildCidBytes is not null) {
+                writer.WriteTag( (CborTag)42 );
+                writer.WriteByteString( MakeLinkBytes( entry.RightChildCidBytes ) );
+            } else {
+                writer.WriteNull( );
+            }
+
+            WriteCborTextString( writer, "v" );
+            writer.WriteTag( (CborTag)42 );
+            writer.WriteByteString( MakeLinkBytes( entry.ValueCidBytes ) );
+
+            writer.WriteEndMap( );
+        }
+        writer.WriteEndArray( );
+
+        // l field — key "l" length 1 (comes after "e" alphabetically)
+        WriteCborTextString( writer, "l" );
+        if (leftCidBytes is not null) {
+            writer.WriteTag( (CborTag)42 );
+            writer.WriteByteString( MakeLinkBytes( leftCidBytes ) );
+        } else {
+            writer.WriteNull( );
+        }
+
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
+    /// <summary>
+    /// Builds a commit block pointing to the MST root.
+    /// </summary>
+    /// <param name="did">The DID of the repo owner.</param>
+    /// <param name="mstRootCidBytes">CID bytes for the MST root node.</param>
+    /// <param name="version">Commit version field value (default 3).</param>
+    internal static byte[] BuildCommit( string did, byte[] mstRootCidBytes, int version = 3 ) {
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        // Keys by length: rev(3), did(3), sig(3), data(4), prev(4), version(7)
+        // rev (3), did (3), sig (3) — alphabetical: did < rev < sig
+        // data (4), prev (4) — alphabetical: data < prev
+        // version (7)
+
+        WriteCborTextString( writer, "did" );
+        WriteCborTextString( writer, did );
+
+        WriteCborTextString( writer, "rev" );
+        WriteCborTextString( writer, "3" );
+
+        WriteCborTextString( writer, "sig" );
+        writer.WriteByteString( new byte[64] ); // placeholder signature
+
+        WriteCborTextString( writer, "data" );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( MakeLinkBytes( mstRootCidBytes ) );
+
+        WriteCborTextString( writer, "prev" );
+        writer.WriteNull( );
+
+        WriteCborTextString( writer, "version" );
+        writer.WriteInt32( version );
+
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
+    // ─── Security test helpers ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a CAR where a single MST node is referenced twice: once as the left child (l)
+    /// of a parent node and once as the right child (t) of an entry in that same parent node.
+    /// This is a "doubling DAG" pattern that a valid MST tree prohibits.
+    /// Without cycle detection, a chained variant causes 2^N traversals.
+    /// </summary>
+    internal static byte[] BuildDoublingDagCar( ) {
+        byte[] recBytes = BuildRecordBlock( new BridgeBeats.Contracts.Records.MediaLinkResultRecord(
+            results: [new BridgeBeats.Contracts.Records.ProviderResultRecord(
+                "spotify", "Artist", "Track",
+                "https://open.spotify.com/track/x", "US" )],
+            lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
+        ) );
+        byte[] recCid = ComputeCidBytes( recBytes );
+
+        // nodeA: standalone leaf — will be referenced twice by nodeB
+        byte[] nodeABytes = BuildMstNode( null,
+            [new MstEntry( 0, "link.bridgebeats.lookup/a", recCid )] );
+        byte[] nodeACid = ComputeCidBytes( nodeABytes );
+
+        // nodeB: l=nodeA, entry[0].t=nodeA  ← nodeA referenced TWICE
+        byte[] nodeBBytes = BuildMstNode( nodeACid,
+            [new MstEntry( 0, "link.bridgebeats.lookup/b", recCid, nodeACid )] );
+        byte[] nodeBCid = ComputeCidBytes( nodeBBytes );
+
+        byte[] commitBytes = BuildCommit( "did:plc:test", nodeBCid );
+        byte[] commitCid = ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [nodeBCid] = nodeBBytes,
+            [nodeACid] = nodeABytes,
+            [recCid] = recBytes,
+        };
+        return BuildCar( commitCid, blocks );
+    }
+
+    /// <summary>
+    /// Builds a raw DAG-CBOR byte sequence of <paramref name="nestingDepth"/> nested single-element
+    /// arrays, terminated by an empty array. Each level costs exactly 1 byte (0x81 = array of 1).
+    /// A depth of 33 exceeds the DagCborConverter.MaxDepth of 32, triggering CarParseException.
+    /// </summary>
+    internal static byte[] BuildDeeplyNestedCborBytes( int nestingDepth ) {
+        using MemoryStream ms = new( );
+        // Write nestingDepth levels of 0x81 (array of 1 item), then 0x80 (empty array)
+        for (int i = 0; i < nestingDepth; i++) {
+            ms.WriteByte( 0x81 ); // array(1)
+        }
+        ms.WriteByte( 0x80 ); // array(0) — innermost
+        return ms.ToArray( );
+    }
+
+    /// <summary>
+    /// Builds a CAR containing an MST entry whose <c>p</c> (prefix-len) field is set to
+    /// <paramref name="negativePrefixLen"/> (a negative integer). The second entry's negative
+    /// p value should be rejected by MstWalker as a CarParseException.
+    /// </summary>
+    internal static byte[] BuildCarWithNegativePrefixLen( int negativePrefixLen = -1 ) {
+        byte[] recBytes = BuildRecordBlock( new BridgeBeats.Contracts.Records.MediaLinkResultRecord(
+            results: [new BridgeBeats.Contracts.Records.ProviderResultRecord(
+                "spotify", "Artist", "Track",
+                "https://open.spotify.com/track/x", "US" )],
+            lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
+        ) );
+        byte[] recCid = ComputeCidBytes( recBytes );
+
+        // Build the node bytes manually so we can write a negative p value.
+        // First entry: p=0, k="link.bridgebeats.lookup/rkey1", valid
+        // Second entry: p=negativePrefixLen (e.g. -1) — structurally invalid
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        WriteCborTextString( writer, "e" );
+        writer.WriteStartArray( null );
+
+        // Entry 0: valid
+        writer.WriteStartMap( null );
+        WriteCborTextString( writer, "k" );
+        writer.WriteByteString( System.Text.Encoding.UTF8.GetBytes( "link.bridgebeats.lookup/rkey1" ) );
+        WriteCborTextString( writer, "p" );
+        writer.WriteInt32( 0 );
+        WriteCborTextString( writer, "t" );
+        writer.WriteNull( );
+        WriteCborTextString( writer, "v" );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( MakeLinkBytes( recCid ) );
+        writer.WriteEndMap( );
+
+        // Entry 1: negative p
+        writer.WriteStartMap( null );
+        WriteCborTextString( writer, "k" );
+        writer.WriteByteString( System.Text.Encoding.UTF8.GetBytes( "suffix" ) );
+        WriteCborTextString( writer, "p" );
+        writer.WriteInt32( negativePrefixLen );
+        WriteCborTextString( writer, "t" );
+        writer.WriteNull( );
+        WriteCborTextString( writer, "v" );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( MakeLinkBytes( recCid ) );
+        writer.WriteEndMap( );
+
+        writer.WriteEndArray( );
+
+        WriteCborTextString( writer, "l" );
+        writer.WriteNull( );
+
+        writer.WriteEndMap( );
+
+        byte[] mstNodeBytes = writer.Encode( );
+        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [recCid] = recBytes,
+        };
+        return BuildCar( commitCid, blocks );
+    }
+
+    /// <summary>
+    /// Builds a CAR with <paramref name="blockCount"/> tiny blocks (each containing 4 bytes of
+    /// unique content) plus a valid commit and MST root. Used to test the block-count cap.
+    /// </summary>
+    internal static byte[] BuildCarWithManyTinyBlocks( int blockCount ) {
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance );
+
+        for (int i = 0; i < blockCount; i++) {
+            byte[] blockBytes = [(byte)(i >> 24), (byte)(i >> 16), (byte)(i >> 8), (byte)i];
+            byte[] cid = ComputeCidBytes( blockBytes );
+            blocks[cid] = blockBytes;
+        }
+
+        byte[] mstNodeBytes = BuildMstNode( null, [] );
+        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
+        blocks[mstCid] = mstNodeBytes;
+
+        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = ComputeCidBytes( commitBytes );
+        blocks[commitCid] = commitBytes;
+
+        return BuildCar( commitCid, blocks );
+    }
+
+    /// <summary>
+    /// Builds a CAR whose first block section has a declared length larger than 2 MB,
+    /// which should be rejected by CarV1Reader before any block content is read.
+    /// </summary>
+    internal static byte[] BuildCarWithOversizedBlockSection( ) {
+        using MemoryStream ms = new( );
+
+        // Build a minimal valid header pointing to a fake commit CID
+        byte[] fakeCid = ComputeCidBytes( new byte[1] { 0xFF } );
+        byte[] header = BuildCarHeaderPublic( fakeCid );
+        WriteVarint( ms, (ulong)header.Length );
+        ms.Write( header );
+
+        // Write one section whose declared length is 3 MB (> MaxBlockSize 2 MB)
+        // section_len = CID_bytes(36) + block_bytes
+        ulong oversizedLen = (ulong)(36 + 3 * 1024 * 1024);
+        WriteVarint( ms, oversizedLen );
+        // Write the CID bytes (real CID for the over-limit block)
+        ms.Write( fakeCid );
+        // Don't write the block bytes — the parser should throw before reading them
+        // because blockLen > MaxBlockSize is checked before reading block content.
+
+        return ms.ToArray( );
+    }
+
+    /// <summary>
+    /// Builds a CAR with a duplicate CID section: the same block appears twice in the stream.
+    /// Per last-write-wins semantics, the dictionary should contain exactly one entry per CID.
+    /// </summary>
+    internal static byte[] BuildCarWithDuplicateCid( out string duplicatedCidHex ) {
+        byte[] blockBytes = System.Text.Encoding.UTF8.GetBytes( "duplicate-block-content" );
+        byte[] cid = ComputeCidBytes( blockBytes );
+        duplicatedCidHex = Convert.ToHexStringLower( cid.AsSpan( 4 ) ); // KeyHex uses digest bytes only
+
+        byte[] mstNodeBytes = BuildMstNode( null, [] );
+        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = ComputeCidBytes( commitBytes );
+
+        // We build the CAR manually to emit the duplicate-content block twice
+        using MemoryStream ms = new( );
+        byte[] header = BuildCarHeaderPublic( commitCid );
+        WriteVarint( ms, (ulong)header.Length );
+        ms.Write( header );
+
+        // Emit blockBytes block TWICE with the same CID
+        foreach (byte[] _ in new[] { blockBytes, blockBytes }) {
+            ulong sectionLen = (ulong)(cid.Length + blockBytes.Length);
+            WriteVarint( ms, sectionLen );
+            ms.Write( cid );
+            ms.Write( blockBytes );
+        }
+
+        // Emit commit and MST node normally
+        void WriteBlock( byte[] c, byte[] b ) {
+            ulong sl = (ulong)(c.Length + b.Length);
+            WriteVarint( ms, sl );
+            ms.Write( c );
+            ms.Write( b );
+        }
+
+        WriteBlock( mstCid, mstNodeBytes );
+        WriteBlock( commitCid, commitBytes );
+
+        return ms.ToArray( );
+    }
+
+    /// <summary>
+    /// Builds a CAR containing an MST entry with the given raw rkey string.
+    /// Used to exercise SEC-005 rkey validation in ATProtoStorageService.
+    /// </summary>
+    internal static byte[] BuildCarWithRawRkey( string collection, string rawRkey ) {
+        byte[] recBytes = BuildRecordBlock( new BridgeBeats.Contracts.Records.MediaLinkResultRecord(
+            results: [new BridgeBeats.Contracts.Records.ProviderResultRecord(
+                "spotify", "Artist", "Track",
+                "https://open.spotify.com/track/x", "US" )],
+            lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
+        ) );
+        byte[] recCid = ComputeCidBytes( recBytes );
+
+        string fullKey = $"{collection}/{rawRkey}";
+        byte[] mstNodeBytes = BuildMstNode( null,
+            [new MstEntry( 0, fullKey, recCid )] );
+        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [recCid] = recBytes,
+        };
+        return BuildCar( commitCid, blocks );
+    }
+
+    /// <summary>
+    /// Builds a CAR header byte array — public surface used by security test helpers.
+    /// </summary>
+    internal static byte[] BuildCarHeaderPublic( byte[] rootCidBytes ) =>
+        BuildCarHeader( rootCidBytes );
+
+    /// <summary>
+    /// Builds a complete CAR v1 file from a dictionary of blocks and a root CID.
+    /// </summary>
+    /// <param name="rootCidBytes">CID bytes for the root (commit) block.</param>
+    /// <param name="blocks">All blocks keyed by their CID bytes.</param>
+    internal static byte[] BuildCar( byte[] rootCidBytes, Dictionary<byte[], byte[]> blocks ) {
+        using MemoryStream stream = new( );
+
+        // Build DAG-CBOR header: {version: 1, roots: [rootCid]}
+        byte[] header = BuildCarHeader( rootCidBytes );
+
+        // Write varint(header_len) | header
+        WriteVarint( stream, (ulong)header.Length );
+        stream.Write( header );
+
+        // Write sections: varint(cid_len + block_len) | cid_bytes | block_bytes
+        foreach (KeyValuePair<byte[], byte[]> kvp in blocks) {
+            byte[] cidBytes = kvp.Key;
+            byte[] blockBytes = kvp.Value;
+            ulong sectionLen = (ulong)(cidBytes.Length + blockBytes.Length);
+            WriteVarint( stream, sectionLen );
+            stream.Write( cidBytes );
+            stream.Write( blockBytes );
+        }
+
+        return stream.ToArray( );
+    }
+
+    private static byte[] BuildCarHeader( byte[] rootCidBytes ) {
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        // roots (5) before version (7)
+        WriteCborTextString( writer, "roots" );
+        writer.WriteStartArray( null );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( MakeLinkBytes( rootCidBytes ) );
+        writer.WriteEndArray( );
+
+        WriteCborTextString( writer, "version" );
+        writer.WriteInt32( 1 );
+
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
+    private static void WriteCborTextString( CborWriter writer, string value ) {
+        writer.WriteTextString( value );
+    }
+
+    // ─── High-level factory: single-collection repo ───────────────────────────
+
+    /// <summary>
+    /// Builds a minimal CAR representing a repo with the given lookup records.
+    /// Each record gets a deterministic rkey based on its index.
+    /// </summary>
+    internal static byte[] BuildRepoCarWithRecords(
+        string did,
+        string collection,
+        IReadOnlyList<(string Rkey, MediaLinkResultRecord Record)> records
+    ) {
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance );
+
+        // Build a record block for each entry
+        List<(string Key, byte[] CidBytes)> mstEntries = [];
+        foreach ((string rkey, MediaLinkResultRecord record) in records) {
+            byte[] recordBytes = BuildRecordBlock( record );
+            byte[] cidBytes = ComputeCidBytes( recordBytes );
+            blocks[cidBytes] = recordBytes;
+            mstEntries.Add( ($"{collection}/{rkey}", cidBytes) );
+        }
+
+        // Sort entries by key (MST is lexicographically ordered)
+        mstEntries.Sort( static ( a, b ) => string.Compare( a.Key, b.Key, StringComparison.Ordinal ) );
+
+        // Build MST entries with prefix compression
+        List<MstEntry> entries = [];
+        string prevKey = "";
+        foreach ((string key, byte[] cidBytes) in mstEntries) {
+            int prefixLen = CommonPrefixLength( prevKey, key );
+            string suffix = key[prefixLen..];
+            entries.Add( new MstEntry( prefixLen, suffix, cidBytes ) );
+            prevKey = key;
+        }
+
+        // Build single MST node
+        byte[] mstNodeBytes = BuildMstNode( null, entries );
+        byte[] mstCidBytes = ComputeCidBytes( mstNodeBytes );
+        blocks[mstCidBytes] = mstNodeBytes;
+
+        // Build commit
+        byte[] commitBytes = BuildCommit( did, mstCidBytes );
+        byte[] commitCidBytes = ComputeCidBytes( commitBytes );
+        blocks[commitCidBytes] = commitBytes;
+
+        return BuildCar( commitCidBytes, blocks );
+    }
+
+    /// <summary>
+    /// Builds a minimal CAR representing a repo with the given lookup records and a specified commit version.
+    /// Useful for testing warn-and-proceed on non-3 commit versions.
+    /// </summary>
+    internal static byte[] BuildRepoCarWithRecordsAndVersion(
+        string did,
+        string collection,
+        IReadOnlyList<(string Rkey, MediaLinkResultRecord Record)> records,
+        int commitVersion
+    ) {
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance );
+
+        List<(string Key, byte[] CidBytes)> mstEntries = [];
+        foreach ((string rkey, MediaLinkResultRecord record) in records) {
+            byte[] recordBytes = BuildRecordBlock( record );
+            byte[] cidBytes = ComputeCidBytes( recordBytes );
+            blocks[cidBytes] = recordBytes;
+            mstEntries.Add( ($"{collection}/{rkey}", cidBytes) );
+        }
+
+        mstEntries.Sort( static ( a, b ) => string.Compare( a.Key, b.Key, StringComparison.Ordinal ) );
+
+        List<MstEntry> entries = [];
+        string prevKey = "";
+        foreach ((string key, byte[] cidBytes) in mstEntries) {
+            int prefixLen = CommonPrefixLength( prevKey, key );
+            string suffix = key[prefixLen..];
+            entries.Add( new MstEntry( prefixLen, suffix, cidBytes ) );
+            prevKey = key;
+        }
+
+        byte[] mstNodeBytes = BuildMstNode( null, entries );
+        byte[] mstCidBytes = ComputeCidBytes( mstNodeBytes );
+        blocks[mstCidBytes] = mstNodeBytes;
+
+        byte[] commitBytes = BuildCommit( did, mstCidBytes, commitVersion );
+        byte[] commitCidBytes = ComputeCidBytes( commitBytes );
+        blocks[commitCidBytes] = commitBytes;
+
+        return BuildCar( commitCidBytes, blocks );
+    }
+
+    private static int CommonPrefixLength( string a, string b ) {
+        int len = Math.Min( a.Length, b.Length );
+        int i = 0;
+        while (i < len && a[i] == b[i]) {
+            i++;
+        }
+        return i;
+    }
+
+    /// <summary>
+    /// Comparer for byte array dictionary keys.
+    /// </summary>
+    private sealed class ByteArrayComparer : IEqualityComparer<byte[]> {
+        internal static readonly ByteArrayComparer Instance = new( );
+        public bool Equals( byte[]? x, byte[]? y ) => x is not null && y is not null && x.AsSpan( ).SequenceEqual( y );
+        public int GetHashCode( byte[] obj ) {
+            HashCode hc = new( );
+            hc.AddBytes( obj );
+            return hc.ToHashCode( );
+        }
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/Helpers/TestCarBuilder.cs
+++ b/Tests/Unit/Helpers/TestCarBuilder.cs
@@ -612,6 +612,100 @@ internal static class TestCarBuilder {
         return i;
     }
 
+    // ─── Malformed-input helpers (hardening tests) ────────────────────────────
+
+    /// <summary>
+    /// Builds a CAR header whose "roots" array contains a CID byte string that is one byte longer
+    /// than the expected 36 bytes (37 bytes total). Used to verify that ParseFromBytes rejects
+    /// oversized CID byte sequences rather than silently truncating them.
+    /// </summary>
+    internal static byte[] BuildCarWithOversizedCidInHeader( ) {
+        byte[] normalCid = ComputeCidBytes( new byte[] { 0xAA } );
+        // Produce a 37-byte link: 0x00 multibase prefix + 36-byte CID + 1 extra trailing byte
+        byte[] oversizedLinkBytes = new byte[1 + normalCid.Length + 1];
+        oversizedLinkBytes[0] = 0x00; // multibase prefix
+        normalCid.CopyTo( oversizedLinkBytes, 1 );
+        oversizedLinkBytes[^1] = 0xFF; // extra trailing byte
+
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        WriteCborTextString( writer, "roots" );
+        writer.WriteStartArray( null );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( oversizedLinkBytes );
+        writer.WriteEndArray( );
+
+        WriteCborTextString( writer, "version" );
+        writer.WriteInt32( 1 );
+
+        writer.WriteEndMap( );
+        byte[] header = writer.Encode( );
+
+        using MemoryStream ms = new( );
+        WriteVarint( ms, (ulong)header.Length );
+        ms.Write( header );
+        return ms.ToArray( );
+    }
+
+    /// <summary>
+    /// Builds a CAR whose header DAG-CBOR map contains only "roots" — the "version" key is absent.
+    /// Used to verify that ParseRootCidFromRawHeader rejects headers missing the required version field.
+    /// </summary>
+    internal static byte[] BuildCarWithHeaderMissingVersion( ) {
+        byte[] fakeCid = ComputeCidBytes( new byte[] { 0xBB } );
+
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        WriteCborTextString( writer, "roots" );
+        writer.WriteStartArray( null );
+        writer.WriteTag( (CborTag)42 );
+        writer.WriteByteString( MakeLinkBytes( fakeCid ) );
+        writer.WriteEndArray( );
+
+        // "version" key intentionally omitted
+
+        writer.WriteEndMap( );
+        byte[] header = writer.Encode( );
+
+        using MemoryStream ms = new( );
+        WriteVarint( ms, (ulong)header.Length );
+        ms.Write( header );
+        return ms.ToArray( );
+    }
+
+    /// <summary>
+    /// Builds a commit block where the "data" field is explicitly set to CBOR null.
+    /// Used to verify that ReadCommitDataLinkAndVersion rejects null/absent data links.
+    /// </summary>
+    internal static byte[] BuildCommitWithNullData( string did, int version = 3 ) {
+        CborWriter writer = new( CborConformanceMode.Lax );
+        writer.WriteStartMap( null );
+
+        // Same key ordering as BuildCommit: did(3) < rev(3) < sig(3) < data(4) < prev(4) < version(7)
+        WriteCborTextString( writer, "did" );
+        WriteCborTextString( writer, did );
+
+        WriteCborTextString( writer, "rev" );
+        WriteCborTextString( writer, "3" );
+
+        WriteCborTextString( writer, "sig" );
+        writer.WriteByteString( new byte[64] );
+
+        WriteCborTextString( writer, "data" );
+        writer.WriteNull( ); // explicitly null — no data link
+
+        WriteCborTextString( writer, "prev" );
+        writer.WriteNull( );
+
+        WriteCborTextString( writer, "version" );
+        writer.WriteInt32( version );
+
+        writer.WriteEndMap( );
+        return writer.Encode( );
+    }
+
     /// <summary>
     /// Comparer for byte array dictionary keys.
     /// </summary>

--- a/Tests/Unit/Helpers/TestCarBuilder.cs
+++ b/Tests/Unit/Helpers/TestCarBuilder.cs
@@ -339,30 +339,6 @@ internal static class TestCarBuilder {
     }
 
     /// <summary>
-    /// Builds a CAR with <paramref name="blockCount"/> tiny blocks (each containing 4 bytes of
-    /// unique content) plus a valid commit and MST root. Used to test the block-count cap.
-    /// </summary>
-    internal static byte[] BuildCarWithManyTinyBlocks( int blockCount ) {
-        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance );
-
-        for (int i = 0; i < blockCount; i++) {
-            byte[] blockBytes = [(byte)(i >> 24), (byte)(i >> 16), (byte)(i >> 8), (byte)i];
-            byte[] cid = ComputeCidBytes( blockBytes );
-            blocks[cid] = blockBytes;
-        }
-
-        byte[] mstNodeBytes = BuildMstNode( null, [] );
-        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
-        blocks[mstCid] = mstNodeBytes;
-
-        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
-        byte[] commitCid = ComputeCidBytes( commitBytes );
-        blocks[commitCid] = commitBytes;
-
-        return BuildCar( commitCid, blocks );
-    }
-
-    /// <summary>
     /// Builds a CAR whose first block section has a declared length larger than 2 MB,
     /// which should be rejected by CarV1Reader before any block content is read.
     /// </summary>
@@ -427,34 +403,6 @@ internal static class TestCarBuilder {
         WriteBlock( commitCid, commitBytes );
 
         return ms.ToArray( );
-    }
-
-    /// <summary>
-    /// Builds a CAR containing an MST entry with the given raw rkey string.
-    /// Used to exercise SEC-005 rkey validation in ATProtoStorageService.
-    /// </summary>
-    internal static byte[] BuildCarWithRawRkey( string collection, string rawRkey ) {
-        byte[] recBytes = BuildRecordBlock( new BridgeBeats.Contracts.Records.MediaLinkResultRecord(
-            results: [new BridgeBeats.Contracts.Records.ProviderResultRecord(
-                "spotify", "Artist", "Track",
-                "https://open.spotify.com/track/x", "US" )],
-            lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
-        ) );
-        byte[] recCid = ComputeCidBytes( recBytes );
-
-        string fullKey = $"{collection}/{rawRkey}";
-        byte[] mstNodeBytes = BuildMstNode( null,
-            [new MstEntry( 0, fullKey, recCid )] );
-        byte[] mstCid = ComputeCidBytes( mstNodeBytes );
-        byte[] commitBytes = BuildCommit( "did:plc:test", mstCid );
-        byte[] commitCid = ComputeCidBytes( commitBytes );
-
-        Dictionary<byte[], byte[]> blocks = new( ByteArrayComparer.Instance ) {
-            [commitCid] = commitBytes,
-            [mstCid] = mstNodeBytes,
-            [recCid] = recBytes,
-        };
-        return BuildCar( commitCid, blocks );
     }
 
     /// <summary>

--- a/Tests/Unit/LogSanitizerExtensionsTests.cs
+++ b/Tests/Unit/LogSanitizerExtensionsTests.cs
@@ -1,0 +1,256 @@
+using BridgeBeats.Core.Infrastructure.Utilities;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="LogSanitizerExtensions"/>.
+/// </summary>
+[TestClass]
+public class LogSanitizerExtensionsTests {
+
+    #region Null and whitespace input tests
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging returns an empty string for null input.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_ReturnsEmpty_ForNullInput( ) {
+        // Arrange
+        string? input = null;
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( string.Empty, result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging returns an empty string for empty-string input.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_ReturnsEmpty_ForEmptyString( ) {
+        // Arrange
+        string input = string.Empty;
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( string.Empty, result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging returns an empty string for whitespace-only input.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_ReturnsEmpty_ForWhitespaceOnlyInput( ) {
+        // Arrange
+        string input = "   \t  ";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( string.Empty, result );
+    }
+
+    #endregion
+
+    #region C0 control character tests
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes C0 control characters (U+0000-U+001F).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesC0ControlCharacters( ) {
+        // Arrange - embed a null byte, carriage return, and line feed among normal text
+        string input = "before" + (char)0x00 + (char)0x0D + (char)0x0A + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes DEL (U+007F).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesDelCharacter( ) {
+        // Arrange
+        string input = "before" + (char)0x7F + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    #endregion
+
+    #region C1 control character tests
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes C1 control character CSI (U+009B).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesC1ControlCharacter_Csi( ) {
+        // Arrange - U+009B is CSI (Control Sequence Introducer), first byte of ANSI escape sequences
+        string input = "before" + (char)0x9B + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes NEL (U+0085, C1 Next Line).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesC1ControlCharacter_Nel( ) {
+        // Arrange - U+0085 is NEL (Next Line), a Unicode newline variant
+        string input = "before" + (char)0x85 + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes the full C1 range (U+0080-U+009F).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesEntireC1Range( ) {
+        // Arrange - build a string with every C1 character flanked by known-good chars
+        string c1Block = string.Concat( Enumerable.Range( 0x80, 0x20 ).Select( i => (char)i ) );
+        string input = "start" + c1Block + "end";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "startend", result );
+    }
+
+    #endregion
+
+    #region Unicode line/paragraph separator tests
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes U+2028 (LINE SEPARATOR).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesLineSeparator_U2028( ) {
+        // Arrange - U+2028 is the Unicode LINE SEPARATOR; used in log injection via multiline forging
+        string input = "before" + (char)0x2028 + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes U+2029 (PARAGRAPH SEPARATOR).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesParagraphSeparator_U2029( ) {
+        // Arrange - U+2029 is the Unicode PARAGRAPH SEPARATOR
+        string input = "before" + (char)0x2029 + "after";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "beforeafter", result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging removes both U+2028 and U+2029 when they appear together.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_RemovesBothUnicodeSeparators( ) {
+        // Arrange
+        string input = "a" + (char)0x2028 + "b" + (char)0x2029 + "c";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( "abc", result );
+    }
+
+    #endregion
+
+    #region Legitimate Unicode passthrough tests
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging preserves plain ASCII text without modification.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_PreservesPlainAsciiText( ) {
+        // Arrange
+        string input = "Hello, world! 123 #$%";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( input, result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging preserves non-ASCII letters (e.g., accented, CJK).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_PreservesNonAsciiLetters( ) {
+        // Arrange - accented characters (Latin Extended), CJK ideographs, Arabic
+        string input = "café 中文 مرحبا";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( input, result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging preserves emoji, which are well above the blocked ranges.
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_PreservesEmoji( ) {
+        // Arrange - emoji lie well outside the blocked control-character ranges
+        string input = "track " + char.ConvertFromUtf32( 0x1F3B5 ) + " found";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( input, result );
+    }
+
+    /// <summary>
+    /// Verifies that SanitizeForLogging preserves regular space (U+0020).
+    /// </summary>
+    [TestMethod]
+    public void SanitizeForLogging_PreservesRegularSpace( ) {
+        // Arrange - U+0020 (SPACE) is above the C0 range and must not be stripped
+        string input = "hello world";
+
+        // Act
+        string result = input.SanitizeForLogging( );
+
+        // Assert
+        Assert.AreEqual( input, result );
+    }
+
+    #endregion
+}

--- a/Tests/Unit/LookupStatisticsTests.cs
+++ b/Tests/Unit/LookupStatisticsTests.cs
@@ -72,6 +72,54 @@ public class LookupStatisticsTests {
 
     #endregion
 
+    /// <summary>
+    /// Reflection-based round-trip guard: every init-only property on <see cref="LookupStatistics"/>
+    /// is carried forward by <see cref="LookupStatistics.WithBootstrapStatus"/> unchanged
+    /// (except <see cref="LookupStatistics.CacheBootstrapStatus"/> which is replaced).
+    /// If a new property is added to <see cref="LookupStatistics"/> without updating
+    /// <see cref="LookupStatistics.WithBootstrapStatus"/>, this test fails.
+    /// </summary>
+    [TestMethod]
+    public void WithBootstrapStatus_CarriesForwardAllProperties_ReflectionRoundTrip( ) {
+        // Arrange: build a source with every property set to a non-default value
+        DateTimeOffset t = new( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero );
+        LookupStatistics source = new( ) {
+            TotalRecords = 42,
+            AlbumCount = 7,
+            TrackCount = 35,
+            ProviderCounts = new Dictionary<string, int> { ["Spotify"] = 10, ["AppleMusic"] = 5 },
+            RecentEntries = [new RecentLookupEntry { Title = "T" }],
+            EarliestLookup = t,
+            LatestLookup = t.AddDays( 1 ),
+            GeneratedAt = t.AddDays( 2 ),
+            CacheBootstrapStatus = new CacheBootstrapStatus { IsRunning = true, LastSuccessCount = 1 }
+        };
+
+        CacheBootstrapStatus? newStatus = new( ) { IsRunning = false, LastSuccessCount = 99 };
+
+        // Act
+        LookupStatistics result = source.WithBootstrapStatus( newStatus );
+
+        // Assert: every property except CacheBootstrapStatus matches the source
+        System.Reflection.PropertyInfo[] props = typeof( LookupStatistics ).GetProperties(
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance );
+
+        foreach (System.Reflection.PropertyInfo prop in props) {
+            object? sourceVal = prop.GetValue( source );
+            object? resultVal = prop.GetValue( result );
+
+            if (prop.Name == nameof( LookupStatistics.CacheBootstrapStatus )) {
+                // Must be replaced with newStatus
+                Assert.AreSame( newStatus, resultVal,
+                    $"Property {prop.Name} was expected to be the new status object." );
+            } else {
+                // Must be carried forward unchanged
+                Assert.AreEqual( sourceVal, resultVal,
+                    $"Property {prop.Name} was not carried forward by WithBootstrapStatus." );
+            }
+        }
+    }
+
     #region RecentLookupEntry Tests
 
     /// <summary>

--- a/Tests/Unit/MstWalkerTests.cs
+++ b/Tests/Unit/MstWalkerTests.cs
@@ -317,6 +317,109 @@ public class MstWalkerTests {
         } );
     }
 
+    // ─── Resource-exhaustion guards ──────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a left-child chain of 66 MST nodes throws CarParseException due to the
+    /// MaxWalkDepth guard at the start of WalkNode (depth &gt; MaxWalkDepth),
+    /// before the duplicate-Add cycle check or the block-not-found throw.
+    ///
+    /// Construction: nodes[0]..nodes[65] form a pure left-child chain (no entries).
+    /// nodes[65] is a leaf (l=null, e=[]). Commit → nodes[0].
+    /// Walk: nodes[0]@depth=0 → nodes[1]@depth=1 → ... → nodes[64]@depth=64 →
+    ///        nodes[65]@depth=65 → 65 &gt; 64 → CarParseException.
+    ///
+    /// Failure-first evidence: without the MaxWalkDepth guard, the walk enters
+    /// nodes[65] at depth=65 without throwing, parses it as a leaf (l=null, e=[]), yields nothing,
+    /// and unwinds back to nodes[0]. The enumeration returns an empty list — no exception is thrown —
+    /// so ThrowsExactly&lt;CarParseException&gt; fails, confirming the guard is load-bearing.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 5000 )]
+    public void EnumerateRecords_DepthExceeded_ThrowsCarParseException( ) {
+        // Build a chain of 66 nodes in reverse (leaf first, root last).
+        // nodes[0]..nodes[64] each have l=nodes[i+1]; nodes[65] is the leaf.
+        // Depth 65 (nodes[65]) is the first call that exceeds MaxWalkDepth (64).
+        const int ChainLength = 66;
+        byte[][] nodeCids = new byte[ChainLength][];
+        byte[][] nodeBlocks = new byte[ChainLength][];
+
+        nodeBlocks[ChainLength - 1] = TestCarBuilder.BuildMstNode( null, [] );
+        nodeCids[ChainLength - 1] = TestCarBuilder.ComputeCidBytes( nodeBlocks[ChainLength - 1] );
+
+        for (int i = ChainLength - 2; i >= 0; i--) {
+            nodeBlocks[i] = TestCarBuilder.BuildMstNode( nodeCids[i + 1], [] );
+            nodeCids[i] = TestCarBuilder.ComputeCidBytes( nodeBlocks[i] );
+        }
+
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:depth-test", nodeCids[0] );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance );
+        blocks[commitCid] = commitBytes;
+        for (int i = 0; i < ChainLength; i++) {
+            blocks[nodeCids[i]] = nodeBlocks[i];
+        }
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
+    /// <summary>
+    /// Verifies that a single MST node whose entry count exceeds car.Blocks.Count throws
+    /// CarParseException due to the recordCount cap in the entry loop
+    /// (recordCount[0] &gt; maxNodes).
+    ///
+    /// Construction: 1 commit block + 1 MST node = 2 blocks total; maxNodes = 2.
+    /// The MST node contains 3 entries (all with p=0, distinct keys, shared placeholder value CID).
+    /// Walk sequence: entry[0] → recordCount=1 ≤ 2, yield; entry[1] → recordCount=2 ≤ 2, yield;
+    ///                entry[2] → recordCount=3 &gt; 2 → CarParseException.
+    /// MstWalker does not resolve value-block CIDs during WalkNode (they are yielded as hex
+    /// strings), so the placeholder CID not being in car.Blocks is irrelevant.
+    ///
+    /// Guard ordering: the MaxWalkDepth guard and the duplicate-Add cycle check do not fire
+    /// first because there is only one root node at depth=0 visited exactly once.
+    ///
+    /// Failure-first evidence: without the recordCount cap in the entry loop, all 3
+    /// entries yield normally, the enumeration returns a 3-element list, and
+    /// ThrowsExactly&lt;CarParseException&gt; fails because no exception is thrown.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateRecords_RecordCountExceedsBlockCount_ThrowsCarParseException( ) {
+        // Placeholder value CID — not in blocks; WalkNode never resolves value-block CIDs.
+        byte[] placeholderValueCid = TestCarBuilder.ComputeCidBytes( [0xDE, 0xAD] );
+
+        // 3 entries in a single root node; 1 commit + 1 MST node = 2 blocks → maxNodes = 2.
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [
+                new TestCarBuilder.MstEntry( 0, "col/key1", placeholderValueCid ),
+                new TestCarBuilder.MstEntry( 0, "col/key2", placeholderValueCid ),
+                new TestCarBuilder.MstEntry( 0, "col/key3", placeholderValueCid ),
+            ] );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:amp-test", mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes
+            // placeholderValueCid block intentionally absent — value blocks are not resolved by WalkNode
+        };
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
     // ─── CancellationToken propagation ───────────────────────────────────────
 
     /// <summary>

--- a/Tests/Unit/MstWalkerTests.cs
+++ b/Tests/Unit/MstWalkerTests.cs
@@ -292,6 +292,31 @@ public class MstWalkerTests {
         } );
     }
 
+    // ─── Hardening: null/absent "data" link rejected ─────────────────────────
+
+    /// <summary>
+    /// Verifies that a commit block whose "data" field is explicitly CBOR null is rejected with
+    /// CarParseException, regardless of the commit version.
+    /// Failure-first evidence: before Fix 3, the condition was `mstRootHex is null &amp;&amp; commitVersion == 0`;
+    /// with a version=3 commit, a null data link was accepted and EnumerateRecords returned an empty
+    /// sequence instead of throwing — so this test would have failed on ThrowsExactly.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateRecords_CommitWithNullDataLink_ThrowsCarParseException( ) {
+        byte[] commitBytes = TestCarBuilder.BuildCommitWithNullData( "did:plc:test", version: 3 );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes
+        };
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
     // ─── CancellationToken propagation ───────────────────────────────────────
 
     /// <summary>

--- a/Tests/Unit/MstWalkerTests.cs
+++ b/Tests/Unit/MstWalkerTests.cs
@@ -1,0 +1,329 @@
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Tests.Unit.Helpers;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="MstWalker.EnumerateRecords"/>.
+/// </summary>
+[TestClass]
+public class MstWalkerTests {
+
+    /// <summary>Gets or sets the test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    private static MediaLinkResultRecord MakeRecord( string artist = "Test", string title = "Track" ) =>
+        new(
+            results: [
+                new ProviderResultRecord(
+                    provider: "spotify",
+                    artist: artist,
+                    title: title,
+                    url: "https://open.spotify.com/track/x",
+                    marketRegion: "US"
+                )
+            ],
+            lookedUpAt: new DateTimeOffset( 2024, 1, 1, 0, 0, 0, TimeSpan.Zero )
+        );
+
+    private List<(string Key, string ValueCidHex)> EnumerateAll( CarFile car ) =>
+        [.. MstWalker.EnumerateRecords( car, TestContext.CancellationToken ).Records];
+
+    [TestMethod]
+    public void EnumerateRecords_EmptyRepo_YieldsNothing( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            []
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        List<(string Key, string ValueCidHex)> records = EnumerateAll( car );
+
+        Assert.IsEmpty( records );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_SingleRecord_YieldsOneKey( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            [("rkey1", MakeRecord( ))]
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        List<(string Key, string ValueCidHex)> records = EnumerateAll( car );
+
+        Assert.HasCount( 1, records );
+        Assert.AreEqual( "link.bridgebeats.lookup/rkey1", records[0].Key );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_MultipleRecords_YieldsInKeyOrder( ) {
+        (string Rkey, MediaLinkResultRecord Record)[] entries = [
+            ("zzz", MakeRecord( title: "zzz" )),
+            ("aaa", MakeRecord( title: "aaa" )),
+            ("mmm", MakeRecord( title: "mmm" ))
+        ];
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            entries
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        List<(string Key, string ValueCidHex)> records = EnumerateAll( car );
+
+        Assert.HasCount( 3, records );
+        Assert.AreEqual( "link.bridgebeats.lookup/aaa", records[0].Key );
+        Assert.AreEqual( "link.bridgebeats.lookup/mmm", records[1].Key );
+        Assert.AreEqual( "link.bridgebeats.lookup/zzz", records[2].Key );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_PrefixCompression_CorrectlyReconstructs( ) {
+        (string Rkey, MediaLinkResultRecord Record)[] entries = [
+            ("spotify:track:abc123def456", MakeRecord( title: "Track 1" )),
+            ("spotify:track:abc123xyz789", MakeRecord( title: "Track 2" ))
+        ];
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            entries
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        List<(string Key, string ValueCidHex)> records = EnumerateAll( car );
+
+        Assert.HasCount( 2, records );
+        Assert.AreEqual( "link.bridgebeats.lookup/spotify:track:abc123def456", records[0].Key );
+        Assert.AreEqual( "link.bridgebeats.lookup/spotify:track:abc123xyz789", records[1].Key );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_MultiNodeTree_InOrderTraversal( ) {
+        // Build a three-node MST:
+        //   root: l=leftNode, entries=[{p=0, k="link.bridgebeats.lookup/mmm", v=rec2, t=rightNode}]
+        //   leftNode: l=null, entries=[{p=0, k="link.bridgebeats.lookup/aaa", v=rec1, t=null}]
+        //   rightNode: l=null, entries=[{p=0, k="link.bridgebeats.lookup/zzz", v=rec3, t=null}]
+        // In-order: leftNode(aaa) → root(mmm) → rightNode(zzz)
+        // Also validates prevKeyInNode propagation: root entry p=0 reconstructs "link.bridgebeats.lookup/mmm"
+        // from scratch (not relative to "aaa"), and rightNode entry p=0 reconstructs "link.bridgebeats.lookup/zzz".
+        byte[] rec1Bytes = TestCarBuilder.BuildRecordBlock( MakeRecord( title: "aaa" ) );
+        byte[] rec2Bytes = TestCarBuilder.BuildRecordBlock( MakeRecord( title: "mmm" ) );
+        byte[] rec3Bytes = TestCarBuilder.BuildRecordBlock( MakeRecord( title: "zzz" ) );
+
+        byte[] cid1 = TestCarBuilder.ComputeCidBytes( rec1Bytes );
+        byte[] cid2 = TestCarBuilder.ComputeCidBytes( rec2Bytes );
+        byte[] cid3 = TestCarBuilder.ComputeCidBytes( rec3Bytes );
+
+        byte[] leftNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/aaa", cid1 )]
+        );
+        byte[] leftCid = TestCarBuilder.ComputeCidBytes( leftNodeBytes );
+
+        byte[] rightNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/zzz", cid3 )]
+        );
+        byte[] rightCid = TestCarBuilder.ComputeCidBytes( rightNodeBytes );
+
+        byte[] rootNodeBytes = TestCarBuilder.BuildMstNode(
+            leftCid,
+            [new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/mmm", cid2, rightCid )]
+        );
+        byte[] rootCid = TestCarBuilder.ComputeCidBytes( rootNodeBytes );
+
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:test", rootCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [rootCid] = rootNodeBytes,
+            [leftCid] = leftNodeBytes,
+            [rightCid] = rightNodeBytes,
+            [cid1] = rec1Bytes,
+            [cid2] = rec2Bytes,
+            [cid3] = rec3Bytes
+        };
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        List<(string Key, string ValueCidHex)> records = EnumerateAll( car );
+
+        Assert.HasCount( 3, records );
+        Assert.AreEqual( "link.bridgebeats.lookup/aaa", records[0].Key );
+        Assert.AreEqual( "link.bridgebeats.lookup/mmm", records[1].Key );
+        Assert.AreEqual( "link.bridgebeats.lookup/zzz", records[2].Key );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_MissingValueBlock_ThrowsCarParseException( ) {
+        // Build a CAR where an MST entry's value CID is not included in the CAR blocks.
+        // The MST references a value block that was never added — this exercises
+        // CarRepoReader's throw at "Value block ... not found in CAR."
+        byte[] recordBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( ) );
+        byte[] validRecordCid = TestCarBuilder.ComputeCidBytes( recordBytes );
+
+        // Create a "dangling" CID that doesn't correspond to any block in the CAR
+        byte[] danglingCid = TestCarBuilder.ComputeCidBytes( new byte[] { 0xDE, 0xAD, 0xBE, 0xEF } );
+
+        // MST node references danglingCid as the value — no corresponding block present
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/rkey1", danglingCid )]
+        );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        // Deliberately omit the value block whose CID is danglingCid
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes
+            // danglingCid block intentionally absent
+        };
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = CarRepoReader.EnumerateCollection( carBytes, "link.bridgebeats.lookup", CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
+    [TestMethod]
+    public void EnumerateRecords_InvalidPrefixLen_ThrowsCarParseException( ) {
+        byte[] recordBytes = TestCarBuilder.BuildRecordBlock( MakeRecord( ) );
+        byte[] recordCid = TestCarBuilder.ComputeCidBytes( recordBytes );
+
+        // Second entry: p=100 (way bigger than the previous key length)
+        byte[] mstNodeBytes = TestCarBuilder.BuildMstNode(
+            null,
+            [
+                new TestCarBuilder.MstEntry( 0, "link.bridgebeats.lookup/rkey1", recordCid ),
+                new TestCarBuilder.MstEntry( 100, "overflow", recordCid )
+            ]
+        );
+        byte[] mstCid = TestCarBuilder.ComputeCidBytes( mstNodeBytes );
+        byte[] commitBytes = TestCarBuilder.BuildCommit( "did:plc:test", mstCid );
+        byte[] commitCid = TestCarBuilder.ComputeCidBytes( commitBytes );
+
+        Dictionary<byte[], byte[]> blocks = new( ByteArrayKeyComparer.Instance ) {
+            [commitCid] = commitBytes,
+            [mstCid] = mstNodeBytes,
+            [recordCid] = recordBytes
+        };
+
+        byte[] carBytes = TestCarBuilder.BuildCar( commitCid, blocks );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
+    // ─── QA Major: commit version != 3 warn-and-proceed contract ─────────────
+
+    /// <summary>
+    /// Verifies that a commit with version=4 still yields records (warn-and-proceed contract).
+    /// Failure-first evidence: before the version field was added to CarEnumerationResult and the
+    /// warn-and-proceed branch added to ATProtoStorageService, this test had no surface to assert.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateRecords_CommitVersion4_YieldsRecordsAndReportsVersion4( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecordsAndVersion(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            [("rkey1", MakeRecord( ))],
+            commitVersion: 4
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        (IEnumerable<(string Key, string ValueCidHex)> records, int commitVersion) =
+            MstWalker.EnumerateRecords( car, TestContext.CancellationToken );
+
+        List<(string Key, string ValueCidHex)> list = [.. records];
+        Assert.AreEqual( 4, commitVersion, "CommitVersion must surface the actual version from the commit block." );
+        Assert.HasCount( 1, list );
+        Assert.AreEqual( "link.bridgebeats.lookup/rkey1", list[0].Key );
+    }
+
+    // ─── SEC-001 regression: doubling DAG ────────────────────────────────────
+
+    /// <summary>
+    /// SEC-001 regression: a CAR where one MST node is referenced twice (once via 'l' and once via
+    /// an entry's 't') must throw CarParseException, not loop indefinitely or OOM.
+    /// The test uses [Timeout] to ensure termination within 5 seconds even if the guard fails.
+    /// Failure-first evidence: without the visited-set check in WalkNode, this test would loop until
+    /// the depth cap fires (depth 64) rather than immediately detecting the re-visit.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 5000 )]
+    public void EnumerateRecords_DoublingDagCar_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildDoublingDagCar( );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
+    // ─── SEC-003 regression: negative p ──────────────────────────────────────
+
+    /// <summary>
+    /// SEC-003 regression: a non-first MST entry with p=-1 must produce CarParseException,
+    /// NOT ArgumentOutOfRangeException (which would escape the CarParseException/OCE-only catch
+    /// in ATProtoStorageService and propagate as an unhandled exception).
+    /// Failure-first evidence: without the `prefixLen &lt; 0` guard in ReadEntries, this test fails
+    /// because ThrowsExactly&lt;CarParseException&gt; does not match ArgumentOutOfRangeException.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateRecords_NegativePrefixLen_ThrowsCarParseException( ) {
+        byte[] carBytes = TestCarBuilder.BuildCarWithNegativePrefixLen( -1 );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        _ = Assert.ThrowsExactly<CarParseException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, CancellationToken.None ).Records.ToList( );
+        } );
+    }
+
+    // ─── CancellationToken propagation ───────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that passing an already-cancelled token to EnumerateRecords propagates
+    /// OperationCanceledException, NOT CarParseException.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateRecords_CancelledToken_ThrowsOperationCanceledException( ) {
+        byte[] carBytes = TestCarBuilder.BuildRepoCarWithRecords(
+            "did:plc:test",
+            "link.bridgebeats.lookup",
+            [("rkey1", MakeRecord( )), ("rkey2", MakeRecord( ))]
+        );
+        CarFile car = CarV1Reader.Read( carBytes );
+
+        using CancellationTokenSource cts = new( );
+        cts.Cancel( );
+
+        _ = Assert.ThrowsExactly<OperationCanceledException>( ( ) => {
+            _ = MstWalker.EnumerateRecords( car, cts.Token ).Records.ToList( );
+        } );
+    }
+
+    private sealed class ByteArrayKeyComparer : System.Collections.Generic.IEqualityComparer<byte[]> {
+        internal static readonly ByteArrayKeyComparer Instance = new( );
+        public bool Equals( byte[]? x, byte[]? y ) => x is not null && y is not null && x.AsSpan( ).SequenceEqual( y );
+        public int GetHashCode( byte[] obj ) {
+            System.HashCode hc = new( );
+            hc.AddBytes( obj );
+            return hc.ToHashCode( );
+        }
+    }
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/StatisticsControllerTests.cs
+++ b/Tests/Unit/StatisticsControllerTests.cs
@@ -20,10 +20,15 @@ public class StatisticsControllerTests {
     public void Initialize( ) {
         _statisticsServiceMock = new Mock<IStatisticsService>( );
         _loggerMock = new Mock<ILogger<StatisticsController>>( );
+
+        // Default: live status returns null (no bootstrap has run yet)
+        _ = _statisticsServiceMock
+            .Setup( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( (CacheBootstrapStatus?)null );
     }
 
     [TestMethod]
-    public void Index_WithCachedStats_ReturnsViewWithStats( ) {
+    public async Task Index_WithCachedStats_ReturnsViewWithStats( ) {
         LookupStatistics expectedStats = CreateTestStatistics( );
         _ = _statisticsServiceMock
             .Setup( x => x.GetCachedStatistics( ) )
@@ -34,7 +39,7 @@ public class StatisticsControllerTests {
 
         StatisticsController controller = CreateController( );
 
-        IActionResult result = controller.Index();
+        IActionResult result = await controller.Index( );
 
         ViewResult viewResult = Assert.IsInstanceOfType<ViewResult>( result );
         LookupStatistics model = Assert.IsInstanceOfType<LookupStatistics>( viewResult.Model );
@@ -43,14 +48,14 @@ public class StatisticsControllerTests {
     }
 
     [TestMethod]
-    public void Index_WithNoCachedStats_ReturnsGeneratingView( ) {
+    public async Task Index_WithNoCachedStats_ReturnsGeneratingView( ) {
         _ = _statisticsServiceMock
             .Setup( x => x.GetCachedStatistics( ) )
             .Returns( (LookupStatistics?)null );
 
-        StatisticsController controller = CreateController();
+        StatisticsController controller = CreateController( );
 
-        IActionResult result = controller.Index();
+        IActionResult result = await controller.Index( );
 
         ViewResult viewResult = Assert.IsInstanceOfType<ViewResult>( result );
         Assert.AreEqual( "Generating", viewResult.ViewName );
@@ -58,19 +63,81 @@ public class StatisticsControllerTests {
     }
 
     [TestMethod]
-    public void Index_WithNullService_ReturnsErrorView( ) {
+    public async Task Index_WithNullService_ReturnsErrorView( ) {
         StatisticsController controller = new(
             null,
             _loggerMock.Object
         );
 
-        IActionResult result = controller.Index();
+        IActionResult result = await controller.Index( );
 
         ViewResult viewResult = Assert.IsInstanceOfType<ViewResult>( result );
         Assert.AreEqual( "Error", viewResult.ViewName );
         ErrorViewModel model = Assert.IsInstanceOfType<ErrorViewModel>( viewResult.Model );
         Assert.IsNotNull( model.Message );
         Assert.Contains( "not configured", model.Message );
+    }
+
+    [TestMethod]
+    public async Task Index_WithLiveBootstrapStatus_OverlaysStatusOntoCachedStats( ) {
+        // Arrange: cached stats have no bootstrap status; live status has a running flag
+        LookupStatistics cachedStats = CreateTestStatistics( );
+        CacheBootstrapStatus liveStatus = new( ) {
+            IsRunning = true,
+            LastRunTime = DateTimeOffset.UtcNow.AddHours( -1 ),
+            LastSuccessCount = 247404
+        };
+
+        _ = _statisticsServiceMock
+            .Setup( x => x.GetCachedStatistics( ) )
+            .Returns( cachedStats );
+        _ = _statisticsServiceMock
+            .Setup( x => x.IsRefreshing )
+            .Returns( false );
+        _ = _statisticsServiceMock
+            .Setup( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( liveStatus );
+
+        StatisticsController controller = CreateController( );
+
+        // Act
+        IActionResult result = await controller.Index( );
+
+        // Assert: model reflects live status, not cached status
+        ViewResult viewResult = Assert.IsInstanceOfType<ViewResult>( result );
+        LookupStatistics model = Assert.IsInstanceOfType<LookupStatistics>( viewResult.Model );
+        Assert.IsNotNull( model.CacheBootstrapStatus );
+        Assert.IsTrue( model.CacheBootstrapStatus.IsRunning );
+        Assert.AreEqual( 247404, model.CacheBootstrapStatus.LastSuccessCount );
+        // Other cached stats fields are preserved
+        Assert.AreEqual( 100, model.TotalRecords );
+    }
+
+    [TestMethod]
+    public async Task Index_WhenLiveStatusReturnsNull_ModelHasNullBootstrapStatus( ) {
+        // Arrange: live status unavailable (Redis failure or no prior run)
+        LookupStatistics cachedStats = CreateTestStatistics( );
+
+        _ = _statisticsServiceMock
+            .Setup( x => x.GetCachedStatistics( ) )
+            .Returns( cachedStats );
+        _ = _statisticsServiceMock
+            .Setup( x => x.IsRefreshing )
+            .Returns( false );
+        _ = _statisticsServiceMock
+            .Setup( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( (CacheBootstrapStatus?)null );
+
+        StatisticsController controller = CreateController( );
+
+        // Act: should not throw even when live status is null
+        IActionResult result = await controller.Index( );
+
+        // Assert: page renders successfully with null bootstrap status
+        ViewResult viewResult = Assert.IsInstanceOfType<ViewResult>( result );
+        LookupStatistics model = Assert.IsInstanceOfType<LookupStatistics>( viewResult.Model );
+        Assert.IsNull( model.CacheBootstrapStatus );
+        Assert.AreEqual( 100, model.TotalRecords );
     }
 
     [TestMethod]
@@ -81,7 +148,7 @@ public class StatisticsControllerTests {
 
         StatisticsController controller = CreateController( );
 
-        IActionResult result = controller.Refresh();
+        IActionResult result = controller.Refresh( );
 
         RedirectToActionResult redirectResult = Assert.IsInstanceOfType<RedirectToActionResult>( result );
         Assert.AreEqual( "Index", redirectResult.ActionName );
@@ -96,7 +163,7 @@ public class StatisticsControllerTests {
 
         StatisticsController controller = CreateController( );
 
-        IActionResult result = controller.Refresh();
+        IActionResult result = controller.Refresh( );
 
         RedirectToActionResult redirectResult = Assert.IsInstanceOfType<RedirectToActionResult>( result );
         Assert.AreEqual( "Index", redirectResult.ActionName );

--- a/Tests/Unit/StatisticsServiceTests.cs
+++ b/Tests/Unit/StatisticsServiceTests.cs
@@ -250,6 +250,64 @@ public class StatisticsServiceTests {
         } );
         return (atUri, result);
     }
+
+    [TestMethod]
+    public async Task GetLiveBootstrapStatusAsync_WhenRedisHasStatus_ReturnsDeserializedStatus( ) {
+        // Arrange: pre-load a completed status into the Redis mock
+        CacheBootstrapStatus expected = new( ) {
+            IsRunning = false,
+            LastRunTime = DateTimeOffset.UtcNow.AddHours( -2 ),
+            LastSuccessCount = 247404,
+            LastErrorCount = 0,
+            LastDurationSeconds = 4565.9,
+            RedisKeyCount = 2882803
+        };
+        string json = System.Text.Json.JsonSerializer.Serialize( expected );
+        _ = _redisDatabaseMock
+            .Setup( x => x.StringGetAsync( CacheBootstrapStatus.RedisKey, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisValue)json );
+
+        StatisticsService service = CreateService( );
+
+        // Act
+        CacheBootstrapStatus? result = await service.GetLiveBootstrapStatusAsync( CancellationToken.None );
+
+        // Assert: returns the deserialized status directly from Redis (not cached stats)
+        Assert.IsNotNull( result );
+        Assert.IsFalse( result.IsRunning );
+        Assert.AreEqual( 247404, result.LastSuccessCount );
+        Assert.AreEqual( 4565.9, result.LastDurationSeconds );
+
+        // Verify that ATProto storage was NOT called (live status does not trigger a refresh)
+        _atProtoStorageMock.Verify(
+            x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never( )
+        );
+    }
+
+    [TestMethod]
+    public async Task GetLiveBootstrapStatusAsync_WhenRedisReturnsNull_ReturnsNull( ) {
+        // Default mock already returns RedisValue.Null
+        StatisticsService service = CreateService( );
+
+        CacheBootstrapStatus? result = await service.GetLiveBootstrapStatusAsync( CancellationToken.None );
+
+        Assert.IsNull( result );
+    }
+
+    [TestMethod]
+    public async Task GetLiveBootstrapStatusAsync_WhenRedisThrows_ReturnsNullWithoutThrowing( ) {
+        _ = _redisDatabaseMock
+            .Setup( x => x.StringGetAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new StackExchange.Redis.RedisException( "Connection refused" ) );
+
+        StatisticsService service = CreateService( );
+
+        // Act: should not throw; returns null gracefully
+        CacheBootstrapStatus? result = await service.GetLiveBootstrapStatusAsync( CancellationToken.None );
+
+        Assert.IsNull( result );
+    }
 }
 
 #pragma warning restore CS1591

--- a/Tests/Unit/VarintTests.cs
+++ b/Tests/Unit/VarintTests.cs
@@ -1,0 +1,104 @@
+using BridgeBeats.Core.Infrastructure.Storage.Car;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="Varint.TryRead"/>.
+/// </summary>
+[TestClass]
+public class VarintTests {
+
+    [TestMethod]
+    public void TryRead_SingleByte_Zero_Succeeds( ) {
+        bool ok = Varint.TryRead( [0x00], out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 0UL, value );
+        Assert.AreEqual( 1, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_SingleByte_Max_Succeeds( ) {
+        // 0x7F = 127 (max single-byte varint)
+        bool ok = Varint.TryRead( [0x7F], out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 127UL, value );
+        Assert.AreEqual( 1, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_MultiByteValue_300_Succeeds( ) {
+        // 300 = 0xAC 0x02 in LEB128
+        bool ok = Varint.TryRead( [0xAC, 0x02], out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 300UL, value );
+        Assert.AreEqual( 2, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_MultiByteValue_128_Succeeds( ) {
+        // 128 = 0x80 0x01 in LEB128
+        bool ok = Varint.TryRead( [0x80, 0x01], out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 128UL, value );
+        Assert.AreEqual( 2, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_EmptySpan_ReturnsFalse( ) {
+        bool ok = Varint.TryRead( ReadOnlySpan<byte>.Empty, out ulong value, out int bytesRead );
+
+        Assert.IsFalse( ok );
+        Assert.AreEqual( 0UL, value );
+        Assert.AreEqual( 0, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_TruncatedMultiByte_ReturnsFalse( ) {
+        // Continuation bit set but no next byte
+        bool ok = Varint.TryRead( [0x80], out ulong value, out int bytesRead );
+
+        Assert.IsFalse( ok );
+        Assert.AreEqual( 0UL, value );
+        Assert.AreEqual( 0, bytesRead );
+    }
+
+    [TestMethod]
+    public void TryRead_NineByteMaxValue_Succeeds( ) {
+        // 9 bytes of max LEB128 (encodes 0x7FFFFFFFFFFFFFFF at 9 bytes)
+        // Build a valid 9-byte varint
+        byte[] nineBytes = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F];
+        bool ok = Varint.TryRead( nineBytes, out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 9, bytesRead );
+        Assert.IsGreaterThan( 0UL, value );
+    }
+
+    [TestMethod]
+    public void TryRead_TenByteInput_ReturnsFalseForOversized( ) {
+        // 10 bytes with continuation bits set — exceeds 9-byte cap
+        byte[] tenBytes = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
+        bool ok = Varint.TryRead( tenBytes, out ulong value, out int bytesRead );
+
+        // 9th byte (0xFF) has continuation bit set; cap exceeded → returns false
+        Assert.IsFalse( ok );
+    }
+
+    [TestMethod]
+    public void TryRead_ReadsOnlyNeededBytes( ) {
+        // Varint followed by extra data — only the varint bytes should be consumed
+        bool ok = Varint.TryRead( [0x05, 0xFF, 0xFF], out ulong value, out int bytesRead );
+
+        Assert.IsTrue( ok );
+        Assert.AreEqual( 5UL, value );
+        Assert.AreEqual( 1, bytesRead );
+    }
+}
+
+#pragma warning restore CS1591

--- a/src/BridgeBeats.Contracts/DTOs/LookupStatistics.cs
+++ b/src/BridgeBeats.Contracts/DTOs/LookupStatistics.cs
@@ -49,4 +49,23 @@ public sealed class LookupStatistics {
     /// Status of the cache bootstrap background service.
     /// </summary>
     public CacheBootstrapStatus? CacheBootstrapStatus { get; init; }
+
+    /// <summary>
+    /// Returns a copy of this instance with <see cref="CacheBootstrapStatus"/> replaced by
+    /// <paramref name="status"/>. All other properties are carried forward unchanged.
+    /// </summary>
+    /// <param name="status">The bootstrap status to overlay. May be null.</param>
+    /// <returns>A new <see cref="LookupStatistics"/> with the updated status.</returns>
+    public LookupStatistics WithBootstrapStatus( CacheBootstrapStatus? status ) =>
+        new( ) {
+            TotalRecords = TotalRecords,
+            AlbumCount = AlbumCount,
+            TrackCount = TrackCount,
+            ProviderCounts = ProviderCounts,
+            RecentEntries = RecentEntries,
+            EarliestLookup = EarliestLookup,
+            LatestLookup = LatestLookup,
+            GeneratedAt = GeneratedAt,
+            CacheBootstrapStatus = status
+        };
 }

--- a/src/BridgeBeats.Contracts/Interfaces/IATProtoStorageService.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IATProtoStorageService.cs
@@ -27,12 +27,19 @@ public interface IATProtoStorageService {
 
     /// <summary>
     /// Lists all MediaLinkResult records from the ATProto PDS collection.
-    /// Uses unauthenticated access for public records with cursor-based pagination.
+    /// Issues a single HTTP GET to <c>com.atproto.sync.getRepo</c> and parses the resulting
+    /// CAR v1 file locally — one request per call instead of ⌈N/100⌉ paginated listRecords calls.
     /// </summary>
     /// <param name="pdsUri">The PDS URI to query (e.g., "https://pds.bridgebeats.link").</param>
     /// <param name="userDid">The DID of the account whose collection to query.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>An async enumerable of tuples containing the AT-URI and MediaLinkResult for each record.</returns>
+    /// <remarks>
+    /// Throws on download failure (<see cref="System.Net.Http.HttpRequestException"/>) or CAR/MST
+    /// structural errors. Callers outside Core can only catch broadly because the internal
+    /// <c>CarParseException</c> type is not visible across the assembly boundary.
+    /// Per-record deserialization failures are skipped with a warning log rather than aborting the batch.
+    /// </remarks>
     IAsyncEnumerable<(string AtUri, MediaLinkResult Result)> ListAllRecordsAsync(
         Uri pdsUri,
         string userDid,

--- a/src/BridgeBeats.Contracts/Interfaces/IStatisticsService.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IStatisticsService.cs
@@ -42,4 +42,12 @@ public interface IStatisticsService {
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>The refreshed lookup statistics.</returns>
     Task<LookupStatistics> RefreshStatisticsAsync( CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Reads the current cache bootstrap status directly from Redis, bypassing the
+    /// statistics cache. Returns null if the status is absent or cannot be read.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>The live bootstrap status, or null if unavailable.</returns>
+    Task<CacheBootstrapStatus?> GetLiveBootstrapStatusAsync( CancellationToken cancellationToken = default );
 }

--- a/src/BridgeBeats.Core/Domain/Services/Statistics/StatisticsService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Statistics/StatisticsService.cs
@@ -68,6 +68,10 @@ public sealed partial class StatisticsService(
         return await RefreshStatisticsAsync( false, cancellationToken );
     }
 
+    /// <inheritdoc/>
+    public async Task<CacheBootstrapStatus?> GetLiveBootstrapStatusAsync( CancellationToken cancellationToken = default ) =>
+        await GetCacheBootstrapStatusAsync( ).WaitAsync( cancellationToken );
+
     /// <summary>
     /// Refreshes cached statistics, optionally forcing recomputation even when cache is fresh.
     /// </summary>

--- a/src/BridgeBeats.Core/Infrastructure/Extensions/LogSanitizerExtensions.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Extensions/LogSanitizerExtensions.cs
@@ -8,16 +8,17 @@ namespace BridgeBeats.Core.Infrastructure.Utilities;
 public static partial class LogSanitizerExtensions {
 
     /// <summary>
-    /// Sanitizes user input for safe logging by removing or replacing characters that could be used for log injection attacks.
+    /// Sanitizes user input for safe logging by removing characters that could be used for log injection attacks.
     /// </summary>
     /// <param name="input">The user-provided string to sanitize</param>
-    /// <returns>A sanitized string safe for logging</returns>
+    /// <returns>A sanitized string safe for logging, or <see cref="string.Empty"/> if the input is null or whitespace</returns>
     public static string SanitizeForLogging( this string? input ) {
         if (string.IsNullOrWhiteSpace( input )) { return string.Empty; }
-        // Remove all ASCII control characters (0x00-0x1F, 0x7F) to prevent log injection and forging
+        // Remove C0 controls (U+0000-U+001F), DEL (U+007F), C1 controls (U+0080-U+009F),
+        // and Unicode line/paragraph separators (U+2028, U+2029) to prevent log injection and forging
         return LogSanitizerRegex( ).Replace( input, string.Empty );
     }
 
-    [GeneratedRegex( @"[\x00-\x1F\x7F]" )]
+    [GeneratedRegex( @"[\p{Cc}\p{Zl}\p{Zp}]" )]
     private static partial Regex LogSanitizerRegex( );
 }

--- a/src/BridgeBeats.Core/Infrastructure/Extensions/StorageServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Extensions/StorageServiceExtensions.cs
@@ -42,14 +42,23 @@ namespace BridgeBeats.Core.Infrastructure.Extensions {
         /// <summary>
         /// Adds ATProto storage services if credentials are provided.
         /// Requires <see cref="IATProtoSessionManager"/> to be registered first via <see cref="AddATProtoSessionManager"/>.
+        /// Registers a named HTTP client for the sync (getRepo) endpoint with a 10-minute timeout.
         /// </summary>
         /// <param name="services">The service collection to configure.</param>
         /// <returns>The configured service collection.</returns>
         public static IServiceCollection AddATProtoStorage( this IServiceCollection services ) {
+            // Register named client for com.atproto.sync.getRepo (large CAR downloads).
+            // Do NOT add AddStandardResilienceHandler here — AspireServiceExtensions attaches
+            // one globally via ConfigureHttpClientDefaults, which would stack two retry pipelines.
+            _ = services
+                .AddHttpClient( ATProtoStorageService.ATProtoSyncHttpClientName )
+                .ConfigureHttpClient( c => c.Timeout = TimeSpan.FromMinutes( 10 ) );
+
             _ = services.AddSingleton<IATProtoStorageService>( sp =>
                 new ATProtoStorageService(
                     sp.GetRequiredService<IATProtoSessionManager>( ),
-                    sp.GetRequiredService<ILogger<ATProtoStorageService>>( )
+                    sp.GetRequiredService<ILogger<ATProtoStorageService>>( ),
+                    sp.GetRequiredService<IHttpClientFactory>( )
                 )
             );
 

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -88,9 +88,36 @@ public static class LogEventIds {
             public const int ATProtoStorageServiceRetrieveError = 1079;
 
             /// <summary>
-            /// EventId for <see cref="ATProtoStorageService.LogListRecordsError"/>.
+            /// EventId for ATProtoStorageService list-records error (retired; superseded by CAR-based logging).
             /// </summary>
             public const int ATProtoStorageServiceListRecordsError = 1080;
+
+            // ATProtoStorageService CAR download log events (1081-1099)
+
+            /// <summary>
+            /// EventId for ATProtoStorageService CAR file downloaded successfully (bytes, blocks, elapsed).
+            /// </summary>
+            public const int ATProtoStorageServiceCarDownloaded = 1081;
+
+            /// <summary>
+            /// EventId for ATProtoStorageService CAR enumeration complete (record count).
+            /// </summary>
+            public const int ATProtoStorageServiceCarEnumerated = 1082;
+
+            /// <summary>
+            /// EventId for ATProtoStorageService CAR download or parse failure.
+            /// </summary>
+            public const int ATProtoStorageServiceCarDownloadFailed = 1083;
+
+            /// <summary>
+            /// EventId for ATProtoStorageService per-record skip due to parse or convert failure.
+            /// </summary>
+            public const int ATProtoStorageServiceCarRecordSkipped = 1084;
+
+            /// <summary>
+            /// EventId for ATProtoStorageService CAR commit version not equal to 3 (warn and proceed).
+            /// </summary>
+            public const int ATProtoStorageServiceCarCommitVersionUnexpected = 1085;
 
             // RedisATProtoSessionManager (1100-1149)
 

--- a/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -10,6 +9,7 @@ using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Infrastructure.Logging;
 using BridgeBeats.Core.Infrastructure.Storage.Car;
+using BridgeBeats.Core.Infrastructure.Utilities;
 using idunno.AtProto;
 using idunno.AtProto.Repo;
 using idunno.Bluesky;
@@ -126,7 +126,7 @@ public partial class ATProtoStorageService(
                 // Convert the custom record back to MediaLinkResult DTO
                 return ConvertFromRecord( getRecordResult.Result.Value );
             } else if (!getRecordResult.Succeeded) {
-                string errorMsg = getRecordResult.AtErrorDetail?.Message ?? $"HTTP {getRecordResult.StatusCode}";
+                string errorMsg = (getRecordResult.AtErrorDetail?.Message ?? $"HTTP {getRecordResult.StatusCode}").SanitizeForLogging( );
                 LogGetRecordFailed( logger, errorMsg );
             }
 
@@ -369,7 +369,7 @@ public partial class ATProtoStorageService(
                 // MST keys come from an operator-controlled PDS; an attacker could inject
                 // control characters or path separators. Skip invalid rkeys with a warning.
                 if (!IsValidRkey( rkey )) {
-                    LogCarRecordSkipped( logger, TruncateForLog( rkey, 64 ), "invalid rkey" );
+                    LogCarRecordSkipped( logger, rkey.SanitizeForLogging( ), "invalid rkey" );
                     skippedCount++;
                     continue;
                 }
@@ -400,7 +400,7 @@ public partial class ATProtoStorageService(
                     results.Add( (atUri, converted) );
                     recordCount++;
                 } catch (Exception ex) when (ex is not OperationCanceledException) {
-                    LogCarRecordSkipped( logger, rkey, ex.Message );
+                    LogCarRecordSkipped( logger, rkey, ex.Message.SanitizeForLogging( ) );
                     skippedCount++;
                 }
             }
@@ -442,32 +442,6 @@ public partial class ATProtoStorageService(
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Returns the first <paramref name="maxLen"/> characters of <paramref name="value"/>,
-    /// appending "…" if truncated, and replaces ASCII control characters (\r, \n, \t and
-    /// other C0 codes) with spaces to prevent CWE-117 log-forging on plain-text sinks.
-    /// </summary>
-    private static string TruncateForLog( string value, int maxLen ) {
-        ReadOnlySpan<char> source = value.Length <= maxLen
-            ? value.AsSpan( )
-            : value.AsSpan( 0, maxLen );
-        bool hasControl = false;
-        foreach (char c in source) {
-            if (c < ' ' || c == 127) { hasControl = true; break; }
-        }
-        if (!hasControl) {
-            return value.Length <= maxLen ? value : string.Concat( source, "..." );
-        }
-        System.Text.StringBuilder sb = new( source.Length + 3 );
-        foreach (char c in source) {
-            _ = sb.Append( c < ' ' || c == 127 ? ' ' : c );
-        }
-        if (value.Length > maxLen) {
-            _ = sb.Append( "..." );
-        }
-        return sb.ToString( );
     }
 
     #endregion

--- a/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
@@ -1,11 +1,15 @@
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Infrastructure.Logging;
+using BridgeBeats.Core.Infrastructure.Storage.Car;
 using idunno.AtProto;
 using idunno.AtProto.Repo;
 using idunno.Bluesky;
@@ -20,13 +24,22 @@ namespace BridgeBeats.Core.Infrastructure.Storage;
 /// This service uses the idunno.Bluesky library to interact with ATProto-compatible PDS instances.
 /// MediaLinkResults are stored as custom link.bridgebeats.lookup lexicon records.
 /// Authentication is managed centrally by <see cref="IATProtoSessionManager"/> to reduce PDS API calls.
+/// Record enumeration uses a single CAR v1 download (com.atproto.sync.getRepo) instead of
+/// paginated listRecords calls, reducing N/100 round-trips to a single HTTP request.
 /// </remarks>
 /// <param name="sessionManager">The centralized session manager for authentication.</param>
 /// <param name="logger">Logger for diagnostic information.</param>
+/// <param name="httpClientFactory">Factory for creating named HTTP clients.</param>
 public partial class ATProtoStorageService(
     IATProtoSessionManager sessionManager,
-    ILogger<ATProtoStorageService> logger
+    ILogger<ATProtoStorageService> logger,
+    IHttpClientFactory httpClientFactory
 ) : IATProtoStorageService {
+
+    /// <summary>
+    /// Named HTTP client used for com.atproto.sync.getRepo (large CAR file downloads).
+    /// </summary>
+    internal const string ATProtoSyncHttpClientName = "atproto-sync";
 
     /// <summary>
     /// The NSID (Namespaced Identifier) for the BridgeBeats MediaLinkResult lexicon.
@@ -263,42 +276,201 @@ public partial class ATProtoStorageService(
         // Validate DID format before using it
         ATProtoUriHelper.ValidateDid( userDid, nameof( userDid ) );
 
-        // Use unauthenticated agent for public record access
-        BlueskyAgent unauthenticatedAgent = new( );
-        Did repo = new( userDid );
-        string? cursor = null;
+        // Fetch all records via a single CAR download. Failures propagate so callers
+        // can preserve the last known good cache rather than caching a zero-record result.
+        List<(string AtUri, MediaLinkResult Result)> records =
+            await FetchAllViaCarAsync( pdsUri, userDid, cancellationToken );
 
-        do {
+        foreach ((string atUri, MediaLinkResult result) in records) {
             cancellationToken.ThrowIfCancellationRequested( );
+            yield return (atUri, result);
+        }
+    }
 
-            AtProtoHttpResult<PagedReadOnlyCollection<AtProtoRepositoryRecord<MediaLinkResultRecord>>> listResult =
-                await unauthenticatedAgent.ListRecords<MediaLinkResultRecord>(
-                    repo: repo,
-                    collection: s_mediaLinkResultCollection,
-                    limit: 100,
-                    cursor: cursor,
-                    service: pdsUri,
-                    cancellationToken: cancellationToken
-                );
+    private const long MaxCarBytes = 512L * 1024 * 1024;
+    private const int ChunkSize = 81920; // 80 KB read buffer
 
-            if (!listResult.Succeeded || listResult.Result is null) {
-                string errorMsg = listResult.AtErrorDetail?.Message ?? $"HTTP {listResult.StatusCode}";
-                LogListRecordsError( logger, errorMsg );
-                yield break;
+    /// <summary>
+    /// Downloads the repo as a CAR v1 file and enumerates all link.bridgebeats.lookup records.
+    /// Per-record parse failures are skipped with a warning.
+    /// Download or structural parse failures throw (HTTP or CarParseException).
+    /// </summary>
+    private async Task<List<(string AtUri, MediaLinkResult Result)>> FetchAllViaCarAsync(
+        Uri pdsUri,
+        string userDid,
+        CancellationToken cancellationToken
+    ) {
+        cancellationToken.ThrowIfCancellationRequested( );
+
+        Stopwatch stopwatch = Stopwatch.StartNew( );
+        string getRepoUrl = $"{pdsUri.ToString( ).TrimEnd( '/' )}/xrpc/com.atproto.sync.getRepo?did={Uri.EscapeDataString( userDid )}";
+
+        HttpClient httpClient = httpClientFactory.CreateClient( ATProtoSyncHttpClientName );
+
+        ReadOnlyMemory<byte> carMemory;
+        try {
+            using HttpResponseMessage response = await httpClient.GetAsync(
+                getRepoUrl,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken );
+
+            _ = response.EnsureSuccessStatusCode( );
+
+            // Reject early if Content-Length header is present and already exceeds cap
+            long? contentLength = response.Content.Headers.ContentLength;
+            if (contentLength.HasValue && contentLength.Value > MaxCarBytes) {
+                throw new CarParseException(
+                    $"CAR Content-Length {contentLength.Value} exceeds 512 MB cap." );
             }
 
-            foreach (AtProtoRepositoryRecord<MediaLinkResultRecord> record in listResult.Result) {
-                if (record.Value is not null) {
-                    MediaLinkResult? converted = ConvertFromRecord( record.Value );
-                    if (converted is not null) {
-                        yield return (record.Uri.ToString( ), converted);
+            // Buffer the full CAR into memory — MST walk requires random access to blocks.
+            // Copy in chunks enforcing the running total against the cap.
+            using MemoryStream ms = new( );
+            byte[] buffer = new byte[ChunkSize];
+            Stream contentStream = await response.Content.ReadAsStreamAsync( cancellationToken );
+            int read;
+            while ((read = await contentStream.ReadAsync( buffer, cancellationToken )) > 0) {
+                if (ms.Length + read > MaxCarBytes) {
+                    throw new CarParseException(
+                        $"CAR response exceeds 512 MB cap during download (already read {ms.Length + read} bytes)." );
+                }
+                ms.Write( buffer, 0, read );
+            }
+
+            carMemory = ms.GetBuffer( ).AsMemory( 0, (int)ms.Length );
+        } catch (CarParseException ex) {
+            LogCarDownloadFailed( logger, ex );
+            throw;
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            LogCarDownloadFailed( logger, ex );
+            throw;
+        }
+
+        stopwatch.Stop( );
+        long elapsedMs = stopwatch.ElapsedMilliseconds;
+
+        List<(string AtUri, MediaLinkResult Result)> results = [];
+
+        try {
+            CarEnumerationResult enumResult =
+                CarRepoReader.EnumerateCollection( carMemory, s_mediaLinkResultCollection.ToString( ), cancellationToken );
+
+            if (enumResult.CommitVersion != 3) {
+                LogCarCommitVersionUnexpected( logger, enumResult.CommitVersion );
+            }
+
+            int recordCount = 0;
+            int skippedCount = 0;
+
+            foreach ((string rkey, System.Text.Json.Nodes.JsonNode recordNode) in enumResult.Records) {
+                cancellationToken.ThrowIfCancellationRequested( );
+
+                // SEC-005: validate rkey before building AT-URI or logging it verbatim.
+                // MST keys come from an operator-controlled PDS; an attacker could inject
+                // control characters or path separators. Skip invalid rkeys with a warning.
+                if (!IsValidRkey( rkey )) {
+                    LogCarRecordSkipped( logger, TruncateForLog( rkey, 64 ), "invalid rkey" );
+                    skippedCount++;
+                    continue;
+                }
+
+                // Strip $type if present to avoid friction with JsonSerializer
+                if (recordNode is System.Text.Json.Nodes.JsonObject obj && obj.ContainsKey( "$type" )) {
+                    _ = obj.Remove( "$type" );
+                }
+
+                try {
+                    string json = recordNode.ToJsonString( );
+                    MediaLinkResultRecord? record = JsonSerializer.Deserialize<MediaLinkResultRecord>( json );
+
+                    if (record is null) {
+                        LogCarRecordSkipped( logger, rkey, "deserialized to null" );
+                        skippedCount++;
+                        continue;
                     }
+
+                    MediaLinkResult? converted = ConvertFromRecord( record );
+                    if (converted is null) {
+                        LogCarRecordSkipped( logger, rkey, "no valid providers" );
+                        skippedCount++;
+                        continue;
+                    }
+
+                    string atUri = ATProtoUriHelper.BuildLookupRecordUri( userDid, rkey );
+                    results.Add( (atUri, converted) );
+                    recordCount++;
+                } catch (Exception ex) when (ex is not OperationCanceledException) {
+                    LogCarRecordSkipped( logger, rkey, ex.Message );
+                    skippedCount++;
                 }
             }
 
-            cursor = listResult.Result.Cursor;
-        } while (!string.IsNullOrEmpty( cursor ));
+            LogCarDownloaded( logger, carMemory.Length, enumResult.BlockCount, elapsedMs );
+            LogCarEnumerated( logger, recordCount, skippedCount );
+        } catch (CarParseException ex) {
+            LogCarDownloadFailed( logger, ex );
+            throw;
+        } catch (OperationCanceledException) {
+            throw;
+        }
+
+        return results;
     }
+
+    #region Rkey validation
+
+    /// <summary>
+    /// Maximum record-key length per the atproto record-key specification.
+    /// </summary>
+    private const int MaxRkeyLength = 512;
+
+    /// <summary>
+    /// Validates an atproto record key against the allowed grammar.
+    /// Valid characters: A-Za-z0-9 . _ ~ : -
+    /// Length must be between 1 and 512 characters.
+    /// </summary>
+    private static bool IsValidRkey( string rkey ) {
+        if (rkey.Length == 0 || rkey.Length > MaxRkeyLength) {
+            return false;
+        }
+
+        foreach (char c in rkey) {
+            if (!char.IsAsciiLetterOrDigit( c )
+                && c != '.' && c != '_' && c != '~' && c != ':' && c != '-') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the first <paramref name="maxLen"/> characters of <paramref name="value"/>,
+    /// appending "…" if truncated, and replaces ASCII control characters (\r, \n, \t and
+    /// other C0 codes) with spaces to prevent CWE-117 log-forging on plain-text sinks.
+    /// </summary>
+    private static string TruncateForLog( string value, int maxLen ) {
+        ReadOnlySpan<char> source = value.Length <= maxLen
+            ? value.AsSpan( )
+            : value.AsSpan( 0, maxLen );
+        bool hasControl = false;
+        foreach (char c in source) {
+            if (c < ' ' || c == 127) { hasControl = true; break; }
+        }
+        if (!hasControl) {
+            return value.Length <= maxLen ? value : string.Concat( source, "..." );
+        }
+        System.Text.StringBuilder sb = new( source.Length + 3 );
+        foreach (char c in source) {
+            _ = sb.Append( c < ' ' || c == 127 ? ' ' : c );
+        }
+        if (value.Length > maxLen) {
+            _ = sb.Append( "..." );
+        }
+        return sb.ToString( );
+    }
+
+    #endregion
 
     #region LoggerMessage Methods
 
@@ -333,10 +505,34 @@ public partial class ATProtoStorageService(
     internal static partial void LogRetrieveError( ILogger logger, Exception ex, string uri );
 
     [LoggerMessage(
-        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceListRecordsError,
+        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceCarDownloaded,
+        Level = LogLevel.Information,
+        Message = "CAR download complete: {Bytes} bytes, {Blocks} blocks, {ElapsedMs} ms" )]
+    internal static partial void LogCarDownloaded( ILogger logger, long bytes, int blocks, long elapsedMs );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceCarEnumerated,
+        Level = LogLevel.Information,
+        Message = "CAR enumeration complete: {RecordCount} records returned, {SkippedCount} skipped" )]
+    internal static partial void LogCarEnumerated( ILogger logger, int recordCount, int skippedCount );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceCarCommitVersionUnexpected,
+        Level = LogLevel.Warning,
+        Message = "CAR commit version {CommitVersion} is not 3; proceeding anyway" )]
+    internal static partial void LogCarCommitVersionUnexpected( ILogger logger, int commitVersion );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceCarDownloadFailed,
         Level = LogLevel.Error,
-        Message = "Failed to list records from ATProto PDS: {error}" )]
-    internal static partial void LogListRecordsError( ILogger logger, string error );
+        Message = "CAR download or parse failed" )]
+    internal static partial void LogCarDownloadFailed( ILogger logger, Exception? ex );
+
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Storage.ATProtoStorageServiceCarRecordSkipped,
+        Level = LogLevel.Warning,
+        Message = "Skipping record {Rkey}: {Reason}" )]
+    internal static partial void LogCarRecordSkipped( ILogger logger, string rkey, string reason );
 
     #endregion
 }

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarParseException.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarParseException.cs
@@ -1,0 +1,8 @@
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+internal sealed class CarParseException : Exception {
+
+    internal CarParseException( string message ) : base( message ) { }
+
+    internal CarParseException( string message, Exception innerException ) : base( message, innerException ) { }
+}

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarRepoReader.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarRepoReader.cs
@@ -1,0 +1,73 @@
+using System.Text.Json.Nodes;
+
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+/// <summary>
+/// Facade for reading atproto repo CAR files.
+/// The only type <see cref="ATProtoStorageService"/> touches directly.
+/// </summary>
+internal static class CarRepoReader {
+
+    /// <summary>
+    /// Enumerates all records in the given collection from a CAR v1 repo download.
+    /// </summary>
+    /// <param name="car">Raw CAR v1 bytes from com.atproto.sync.getRepo.</param>
+    /// <param name="collectionNsid">The NSID to filter by (e.g. "link.bridgebeats.lookup").</param>
+    /// <param name="cancellationToken">Token to cancel a long-running MST walk.</param>
+    /// <returns>
+    /// A <see cref="CarEnumerationResult"/> containing the record sequence, block count, and commit
+    /// version. The caller is responsible for acting on a non-3 commit version.
+    /// Enumeration throws <see cref="CarParseException"/> for CAR/MST structural errors; callers
+    /// outside Core can only catch broadly since <see cref="CarParseException"/> is internal.
+    /// </returns>
+    internal static CarEnumerationResult EnumerateCollection(
+        ReadOnlyMemory<byte> car,
+        string collectionNsid,
+        CancellationToken cancellationToken = default
+    ) {
+        string prefix = collectionNsid + "/";
+        CarFile carFile = CarV1Reader.Read( car );
+        int blockCount = carFile.Blocks.Count;
+
+        (IEnumerable<(string Key, string ValueCidHex)> records, int commitVersion) =
+            MstWalker.EnumerateRecords( carFile, cancellationToken );
+
+        return new CarEnumerationResult(
+            Records: ProjectRecords( records, carFile, prefix ),
+            BlockCount: blockCount,
+            CommitVersion: commitVersion
+        );
+    }
+
+    private static IEnumerable<(string Rkey, JsonNode Record)> ProjectRecords(
+        IEnumerable<(string Key, string ValueCidHex)> records,
+        CarFile carFile,
+        string prefix
+    ) {
+        foreach ((string key, string valueCidHex) in records) {
+            if (!key.StartsWith( prefix, StringComparison.Ordinal )) {
+                continue;
+            }
+
+            string rkey = key[prefix.Length..];
+
+            if (!carFile.Blocks.TryGetValue( valueCidHex, out ReadOnlyMemory<byte> blockBytes )) {
+                throw new CarParseException( $"Value block {valueCidHex} for key '{key}' not found in CAR." );
+            }
+
+            JsonNode recordNode = DagCborConverter.ToJsonNode( blockBytes )
+                ?? throw new CarParseException( $"Record block for key '{key}' deserialized to null." );
+
+            yield return (rkey, recordNode);
+        }
+    }
+}
+
+/// <summary>
+/// Result of <see cref="CarRepoReader.EnumerateCollection"/>.
+/// </summary>
+internal sealed record CarEnumerationResult(
+    IEnumerable<(string Rkey, System.Text.Json.Nodes.JsonNode Record)> Records,
+    int BlockCount,
+    int CommitVersion
+);

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarV1Reader.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarV1Reader.cs
@@ -138,6 +138,10 @@ internal static class CarV1Reader {
 
             reader.ReadEndMap( );
 
+            if (version is null) {
+                throw new CarParseException( "CAR header missing required 'version' field." );
+            }
+
             if (rootCid is null) {
                 throw new CarParseException( "CAR header missing roots." );
             }

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarV1Reader.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/CarV1Reader.cs
@@ -1,0 +1,170 @@
+using System.Formats.Cbor;
+
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+/// <summary>
+/// Parses a CAR v1 file into a <see cref="CarFile"/> containing the root CID and all blocks.
+/// </summary>
+/// <remarks>
+/// CAR v1 format: varint(header_len) | header DAG-CBOR {version:1, roots:[CID]} | sections*
+/// Each section: varint(len) | CID bytes | block bytes (len covers both)
+/// All block buffers are slices over the single download buffer — no per-block copies.
+/// Per-block sha256 digest is verified against the CID.
+/// </remarks>
+internal static class CarV1Reader {
+
+    private const int MaxBlockSize = 2 * 1024 * 1024; // 2 MB per block
+    private const int ExpectedCidBytes = 4 + 32;       // CIDv1 dag-cbor sha2-256
+    private const int CarV2Magic = 2;                  // CAR version 2 — rejected
+
+    /// <summary>
+    /// Parses a CAR v1 byte buffer and returns the root CID and block dictionary.
+    /// Throws <see cref="CarParseException"/> on malformed or unsupported input.
+    /// </summary>
+    /// <param name="buffer">The raw CAR v1 bytes.</param>
+    /// <remarks>
+    /// Memory is bounded by the 512 MB download-buffer cap enforced upstream in
+    /// ATProtoStorageService.MaxCarBytes — not by a block count. A per-block cap would
+    /// false-positive against legitimate repo growth (the production repo grows ~1,810 records
+    /// per 6-hour cycle; every record is its own IPLD block). The per-block 2 MB size cap and
+    /// per-block sha256 digest verification remain active.
+    /// </remarks>
+    internal static CarFile Read( ReadOnlyMemory<byte> buffer ) {
+        int offset = 0;
+        ReadOnlySpan<byte> span = buffer.Span;
+
+        // ── Parse header length varint ──────────────────────────────────────
+        if (!Varint.TryRead( span.Slice( offset ), out ulong headerLen, out int headerLenBytes )) {
+            throw new CarParseException( "Failed to read CAR header length varint." );
+        }
+        offset += headerLenBytes;
+
+        if (headerLen == 0 || (ulong)span.Length < (ulong)offset + headerLen) {
+            throw new CarParseException( $"CAR header length {headerLen} exceeds buffer." );
+        }
+
+        // ── Parse header DAG-CBOR ───────────────────────────────────────────
+        ReadOnlyMemory<byte> headerBytes = buffer.Slice( offset, (int)headerLen );
+        Cid rootCid = ParseCarHeader( headerBytes );
+        offset += (int)headerLen;
+
+        // ── Parse block sections ────────────────────────────────────────────
+        Dictionary<string, ReadOnlyMemory<byte>> blocks = [];
+
+        while (offset < span.Length) {
+            // Section length varint
+            if (!Varint.TryRead( span.Slice( offset ), out ulong sectionLen, out int sectionLenBytes )) {
+                throw new CarParseException( $"Failed to read section length varint at offset {offset}." );
+            }
+            offset += sectionLenBytes;
+
+            if (sectionLen == 0) {
+                // Zero-length section = stream terminator (valid in some CAR dialects)
+                break;
+            }
+
+            if ((ulong)(span.Length - offset) < sectionLen) {
+                throw new CarParseException( $"Section length {sectionLen} at offset {offset} exceeds remaining buffer." );
+            }
+
+            int sectionStart = offset;
+
+            // CID bytes (fixed 36 bytes for CIDv1 dag-cbor sha256)
+            if (span.Length - offset < ExpectedCidBytes) {
+                throw new CarParseException( $"Section at offset {offset} too short for CID." );
+            }
+            Cid blockCid = Cid.ParseFromBytes( span.Slice( offset, ExpectedCidBytes ) );
+            offset += ExpectedCidBytes;
+
+            // Block bytes
+            int blockLen = (int)sectionLen - ExpectedCidBytes;
+            if (blockLen < 0) {
+                throw new CarParseException( $"Section length {sectionLen} smaller than CID size at offset {sectionStart}." );
+            }
+            if (blockLen > MaxBlockSize) {
+                throw new CarParseException( $"Block at offset {offset} exceeds 2 MB cap ({blockLen} bytes)." );
+            }
+
+            // Verify sha256 digest
+            ReadOnlySpan<byte> blockSpan = span.Slice( offset, blockLen );
+            if (!blockCid.VerifyBlock( blockSpan )) {
+                throw new CarParseException( $"Block digest mismatch at offset {offset} (CID: {blockCid})." );
+            }
+
+            // Store as a slice over the original buffer (no copy)
+            blocks[blockCid.KeyHex] = buffer.Slice( offset, blockLen );
+            offset += blockLen;
+        }
+
+        return new CarFile( rootCid, blocks );
+    }
+
+    private static Cid ParseCarHeader( ReadOnlyMemory<byte> headerBytes ) =>
+        ParseRootCidFromRawHeader( headerBytes );
+
+    private static Cid ParseRootCidFromRawHeader( ReadOnlyMemory<byte> headerBytes ) {
+        try {
+            CborReader reader = new( headerBytes, CborConformanceMode.Lax );
+            _ = reader.ReadStartMap( );
+
+            Cid? rootCid = null;
+            int? version = null;
+
+            while (reader.PeekState( ) != CborReaderState.EndMap) {
+                string key = reader.ReadTextString( );
+                if (key == "roots") {
+                    _ = reader.ReadStartArray( );
+                    while (reader.PeekState( ) != CborReaderState.EndArray) {
+                        CborTag tag = reader.ReadTag( );
+                        if (tag != (CborTag)42) {
+                            throw new CarParseException( $"CAR header root CID has unexpected tag {(ulong)tag}." );
+                        }
+                        byte[] linkBytes = reader.ReadByteString( );
+                        rootCid = Cid.FromDagCborLinkBytes( linkBytes );
+                    }
+                    reader.ReadEndArray( );
+                } else if (key == "version") {
+                    version = reader.ReadInt32( );
+                    if (version == CarV2Magic) {
+                        throw new CarParseException( "CAR v2 is not supported; only v1 is accepted." );
+                    }
+                    if (version != 1) {
+                        throw new CarParseException( $"Unsupported CAR version {version}; expected 1." );
+                    }
+                } else {
+                    reader.SkipValue( );
+                }
+            }
+
+            reader.ReadEndMap( );
+
+            if (rootCid is null) {
+                throw new CarParseException( "CAR header missing roots." );
+            }
+
+            return rootCid.Value;
+        } catch (CarParseException) {
+            throw;
+        } catch (Exception ex) when (ex is CborContentException or OverflowException or InvalidOperationException) {
+            throw new CarParseException( "Failed to parse CAR header CBOR.", ex );
+        }
+    }
+}
+
+/// <summary>
+/// The result of parsing a CAR v1 file: a root CID and a dictionary of blocks
+/// keyed by their CID hex string.
+/// </summary>
+internal sealed class CarFile {
+
+    internal CarFile( Cid root, Dictionary<string, ReadOnlyMemory<byte>> blocks ) {
+        Root = root;
+        Blocks = blocks;
+    }
+
+    /// <summary>The root (commit) CID.</summary>
+    internal Cid Root { get; }
+
+    /// <summary>All blocks, keyed by their CID hex string.</summary>
+    internal Dictionary<string, ReadOnlyMemory<byte>> Blocks { get; }
+}

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/Cid.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/Cid.cs
@@ -37,8 +37,11 @@ internal readonly struct Cid {
             throw new CarParseException( "CIDv0 is not supported; atproto repos use CIDv1 only." );
         }
 
-        if (bytes.Length < ExpectedCidBytes) {
-            throw new CarParseException( $"CID bytes too short: expected {ExpectedCidBytes}, got {bytes.Length}." );
+        if (bytes.Length != ExpectedCidBytes) {
+            throw new CarParseException(
+                bytes.Length < ExpectedCidBytes
+                    ? $"CID bytes too short: expected exactly {ExpectedCidBytes}, got {bytes.Length}."
+                    : $"CID bytes too long: expected exactly {ExpectedCidBytes}, got {bytes.Length}." );
         }
 
         if (bytes[0] != CidV1Version || bytes[1] != DagCborCodec ||

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/Cid.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/Cid.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+/// <summary>
+/// Represents a CIDv1 in the atproto format: 0x01 0x71 0x12 0x20 + 32-byte sha256 digest.
+/// CIDv0 (starts with 0x12) is rejected per spec.
+/// </summary>
+internal readonly struct Cid {
+
+    // CIDv1 codec prefix: version=0x01, codec=dag-cbor=0x71, hash-fn=sha2-256=0x12, hash-len=0x20
+    private const byte CidV1Version = 0x01;
+    private const byte DagCborCodec = 0x71;
+    private const byte Sha256HashFn = 0x12;
+    private const byte Sha256HashLen = 0x20;
+    private const int ExpectedCidBytes = 4 + 32; // 4-byte prefix + 32-byte digest
+
+    private const byte CidV0FirstByte = 0x12;
+
+    private readonly byte[] _digest; // 32-byte sha256 digest
+
+    private Cid( byte[] digest ) {
+        _digest = digest;
+    }
+
+    /// <summary>
+    /// Hex string used as dictionary key.
+    /// </summary>
+    internal string KeyHex => Convert.ToHexStringLower( _digest );
+
+    /// <summary>
+    /// Parses a CIDv1 from raw bytes (4-byte prefix + 32-byte digest).
+    /// Throws CarParseException for CIDv0 or malformed CIDs.
+    /// </summary>
+    internal static Cid ParseFromBytes( ReadOnlySpan<byte> bytes ) {
+        if (bytes.Length > 0 && bytes[0] == CidV0FirstByte) {
+            throw new CarParseException( "CIDv0 is not supported; atproto repos use CIDv1 only." );
+        }
+
+        if (bytes.Length < ExpectedCidBytes) {
+            throw new CarParseException( $"CID bytes too short: expected {ExpectedCidBytes}, got {bytes.Length}." );
+        }
+
+        if (bytes[0] != CidV1Version || bytes[1] != DagCborCodec ||
+            bytes[2] != Sha256HashFn || bytes[3] != Sha256HashLen) {
+            throw new CarParseException(
+                $"Unexpected CID prefix 0x{bytes[0]:x2} 0x{bytes[1]:x2} 0x{bytes[2]:x2} 0x{bytes[3]:x2}; " +
+                "expected CIDv1 dag-cbor sha2-256 (0x01 0x71 0x12 0x20)." );
+        }
+
+        byte[] digest = bytes.Slice( 4, 32 ).ToArray( );
+        return new Cid( digest );
+    }
+
+    /// <summary>
+    /// Parses a CID from a DAG-CBOR tag-42 link value.
+    /// Tag-42 link bytes have a 0x00 multibase prefix that must be stripped before the CID bytes.
+    /// </summary>
+    internal static Cid FromDagCborLinkBytes( ReadOnlySpan<byte> bytes ) {
+        if (bytes.Length < 1 || bytes[0] != 0x00) {
+            throw new CarParseException(
+                $"DAG-CBOR tag-42 link missing 0x00 multibase prefix (first byte: 0x{(bytes.Length > 0 ? bytes[0] : 0xFF):x2})." );
+        }
+
+        return ParseFromBytes( bytes.Slice( 1 ) );
+    }
+
+    /// <summary>
+    /// Verifies that the given block bytes hash to this CID's digest.
+    /// </summary>
+    internal bool VerifyBlock( ReadOnlySpan<byte> blockBytes ) {
+        Span<byte> hash = stackalloc byte[32];
+        int written = SHA256.HashData( blockBytes, hash );
+        return written == 32 && hash.SequenceEqual( _digest );
+    }
+
+    /// <summary>
+    /// Returns a base32 multibase representation for diagnostics.
+    /// </summary>
+    public override string ToString( ) {
+        // Build: 0x01 0x71 0x12 0x20 + digest, then base32lower with 'b' prefix
+        byte[] cidBytes = new byte[ExpectedCidBytes];
+        cidBytes[0] = CidV1Version;
+        cidBytes[1] = DagCborCodec;
+        cidBytes[2] = Sha256HashFn;
+        cidBytes[3] = Sha256HashLen;
+        _digest.CopyTo( cidBytes, 4 );
+        return "b" + Base32Encode( cidBytes );
+    }
+
+    private static string Base32Encode( byte[] data ) {
+        const string Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+        System.Text.StringBuilder sb = new( );
+        int bits = 0;
+        int accumulator = 0;
+
+        foreach (byte b in data) {
+            accumulator = (accumulator << 8) | b;
+            bits += 8;
+            while (bits >= 5) {
+                bits -= 5;
+                _ = sb.Append( Alphabet[(accumulator >> bits) & 0x1F] );
+            }
+        }
+
+        if (bits > 0) {
+            _ = sb.Append( Alphabet[(accumulator << (5 - bits)) & 0x1F] );
+        }
+
+        return sb.ToString( );
+    }
+}

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/DagCborConverter.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/DagCborConverter.cs
@@ -1,0 +1,127 @@
+using System.Formats.Cbor;
+using System.Text.Json.Nodes;
+
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+/// <summary>
+/// Converts DAG-CBOR encoded bytes into a <see cref="JsonNode"/> tree.
+/// </summary>
+/// <remarks>
+/// DAG-CBOR is a deterministic subset of CBOR (RFC 7049) used by atproto.
+/// Tag 42 encodes CID links; bare byte strings encode binary data.
+/// Key ordering in maps is length-first, then lexicographic (deterministic CBOR).
+/// </remarks>
+internal static class DagCborConverter {
+
+    /// <summary>
+    /// Maximum nesting depth for CBOR maps and arrays.
+    /// atproto records are shallow; 32 levels is generous and prevents
+    /// unbounded recursion that would cause an uncatchable StackOverflow.
+    /// </summary>
+    private const int MaxDepth = 32;
+
+    /// <summary>
+    /// Converts DAG-CBOR bytes to a <see cref="JsonNode"/> representation.
+    /// Returns null for a CBOR null value.
+    /// Throws <see cref="CarParseException"/> for malformed or unsupported CBOR.
+    /// </summary>
+    internal static JsonNode? ToJsonNode( ReadOnlyMemory<byte> bytes ) {
+        try {
+            CborReader reader = new( bytes, CborConformanceMode.Lax );
+            return ReadValue( reader, 0 );
+        } catch (CarParseException) {
+            throw;
+        } catch (Exception ex) when (ex is CborContentException or OverflowException or InvalidOperationException) {
+            throw new CarParseException( "Failed to decode DAG-CBOR bytes.", ex );
+        }
+    }
+
+    private static JsonNode? ReadValue( CborReader reader, int depth ) {
+        if (depth > MaxDepth) {
+            throw new CarParseException(
+                $"DAG-CBOR nesting depth exceeded maximum of {MaxDepth}; possible malicious or malformed input." );
+        }
+
+        CborReaderState state = reader.PeekState( );
+
+        return state switch {
+            CborReaderState.UnsignedInteger => JsonValue.Create( reader.ReadUInt64( ) ),
+            CborReaderState.NegativeInteger => JsonValue.Create( reader.ReadInt64( ) ),
+            CborReaderState.Boolean => JsonValue.Create( reader.ReadBoolean( ) ),
+            CborReaderState.Null => ReadNull( reader ),
+            CborReaderState.SinglePrecisionFloat => JsonValue.Create( (double)reader.ReadSingle( ) ),
+            CborReaderState.DoublePrecisionFloat => JsonValue.Create( reader.ReadDouble( ) ),
+            CborReaderState.HalfPrecisionFloat => JsonValue.Create( (double)reader.ReadHalf( ) ),
+            CborReaderState.TextString => JsonValue.Create( reader.ReadTextString( ) ),
+            CborReaderState.ByteString => ReadByteString( reader ),
+            CborReaderState.StartMap => ReadMap( reader, depth ),
+            CborReaderState.StartArray => ReadArray( reader, depth ),
+            CborReaderState.Tag => ReadTag( reader ),
+            _ => throw new CarParseException( $"Unsupported CBOR state: {state}." )
+        };
+    }
+
+    private static JsonNode? ReadNull( CborReader reader ) {
+        reader.ReadNull( );
+        return null;
+    }
+
+    private static JsonNode ReadByteString( CborReader reader ) {
+        byte[] bytes = reader.ReadByteString( );
+        return JsonValue.Create( Convert.ToBase64String( bytes ) ) is JsonNode node
+            ? new JsonObject { ["$bytes"] = node }
+            : new JsonObject { ["$bytes"] = JsonValue.Create( "" ) };
+    }
+
+    private static JsonNode ReadMap( CborReader reader, int depth ) {
+        _ = reader.ReadStartMap( );
+        JsonObject obj = [];
+
+        while (reader.PeekState( ) != CborReaderState.EndMap) {
+            string key = reader.ReadTextString( );
+            JsonNode? value = ReadValue( reader, depth + 1 );
+            obj[key] = value;
+        }
+
+        reader.ReadEndMap( );
+        return obj;
+    }
+
+    private static JsonNode ReadArray( CborReader reader, int depth ) {
+        _ = reader.ReadStartArray( );
+        JsonArray arr = [];
+
+        while (reader.PeekState( ) != CborReaderState.EndArray) {
+            arr.Add( ReadValue( reader, depth + 1 ) );
+        }
+
+        reader.ReadEndArray( );
+        return arr;
+    }
+
+    private static JsonNode ReadTag( CborReader reader ) {
+        CborTag tag = reader.ReadTag( );
+
+        if (tag == (CborTag)42) {
+            // Tag-42: IPLD CID link — value is a byte string with 0x00 multibase prefix + CID bytes
+            if (reader.PeekState( ) != CborReaderState.ByteString) {
+                throw new CarParseException( "Tag-42 CID link must be followed by a byte string." );
+            }
+
+            byte[] cidBytes = reader.ReadByteString( );
+            // Strip 0x00 multibase prefix; return as {"$link": "base32multibase"}
+            if (cidBytes.Length < 1 || cidBytes[0] != 0x00) {
+                throw new CarParseException(
+                    $"Tag-42 link byte string missing 0x00 multibase prefix (first byte: 0x{(cidBytes.Length > 0 ? cidBytes[0] : 0xFF):x2})." );
+            }
+
+            Cid cid = Cid.ParseFromBytes( cidBytes.AsSpan( 1 ) );
+            return new JsonObject { ["$link"] = JsonValue.Create( cid.ToString( ) ) };
+        }
+
+        // Other tags: reject.
+        // Tag-42 reads a byte string directly (no recursive ReadValue), so depth is not applicable.
+        // Any other unsupported tag causes an immediate rejection.
+        throw new CarParseException( $"Unsupported CBOR tag: {(ulong)tag}." );
+    }
+}

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
@@ -152,7 +152,6 @@ internal static class MstWalker {
 
             if (entry.RightChildHex is not null) {
                 foreach ((string childKey, string childValueCidHex) in WalkNode( car, entry.RightChildHex, key, depth + 1, visited, maxNodes, recordCount, cancellationToken )) {
-                    currentPrefix = childKey;
                     yield return (childKey, childValueCidHex);
                 }
             }

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
@@ -33,8 +33,7 @@ internal static class MstWalker {
         (string mstRootHex, int commitVersion) = ReadCommitDataLinkAndVersion( commitBytes );
 
         // Visited-node set: a valid MST is a tree — no node may appear twice.
-        // Caps are derived from block count: a valid walk cannot visit more nodes
-        // than there are blocks in the file, and cannot yield more records than blocks.
+        // Cap derived from block count: a valid walk cannot yield more records than there are blocks in the file.
         HashSet<string> visited = new( car.Blocks.Count );
         int maxNodes = car.Blocks.Count;
         int[] recordCount = [0];
@@ -102,12 +101,6 @@ internal static class MstWalker {
         if (!visited.Add( nodeHex )) {
             throw new CarParseException(
                 $"MST node {nodeHex} encountered more than once; CAR contains a cycle or doubling DAG." );
-        }
-
-        // Hard cap: cannot visit more nodes than there are blocks in the file.
-        if (visited.Count > maxNodes) {
-            throw new CarParseException(
-                $"MST walk visited {visited.Count} nodes, exceeding the block-count cap of {maxNodes}." );
         }
 
         if (!car.Blocks.TryGetValue( nodeHex, out ReadOnlyMemory<byte> nodeBytes )) {

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
@@ -1,0 +1,279 @@
+using System.Formats.Cbor;
+using System.Text;
+
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+/// <summary>
+/// Walks an atproto Merkle Search Tree (MST) and enumerates all records in key order.
+/// </summary>
+/// <remarks>
+/// MST node structure: {l: CID|null, e: [{p:int, k:bytes, v:CID, t:CID|null}]}
+/// In-order walk: recurse l → per entry: reconstruct key, yield (key, v), recurse t.
+/// Keys are "{collection}/{rkey}"; prefix compression via the p (prefix-len) field.
+/// </remarks>
+internal static class MstWalker {
+
+    private const int MaxWalkDepth = 64;
+
+    /// <summary>
+    /// Enumerates all (key, valueCidHex) pairs in the MST rooted at the commit in <paramref name="car"/>.
+    /// Returns an empty sequence for an empty repo.
+    /// Throws <see cref="CarParseException"/> for structural violations.
+    /// </summary>
+    /// <returns>Sequence of (key, valueCidHex) plus the commit version (or 0 if absent).</returns>
+    internal static (IEnumerable<(string Key, string ValueCidHex)> Records, int CommitVersion) EnumerateRecords(
+        CarFile car,
+        CancellationToken cancellationToken = default
+    ) {
+        string commitHex = car.Root.KeyHex;
+        if (!car.Blocks.TryGetValue( commitHex, out ReadOnlyMemory<byte> commitBytes )) {
+            throw new CarParseException( $"Commit block {commitHex} not found in CAR." );
+        }
+
+        (string? mstRootHex, int commitVersion) = ReadCommitDataLinkAndVersion( commitBytes );
+        if (mstRootHex is null) {
+            return ([], commitVersion);
+        }
+
+        // Visited-node set: a valid MST is a tree — no node may appear twice.
+        // Caps are derived from block count: a valid walk cannot visit more nodes
+        // than there are blocks in the file, and cannot yield more records than blocks.
+        HashSet<string> visited = new( car.Blocks.Count );
+        int maxNodes = car.Blocks.Count;
+        int[] recordCount = [0];
+
+        return (WalkNode( car, mstRootHex, "", 0, visited, maxNodes, recordCount, cancellationToken ), commitVersion);
+    }
+
+    private static (string? mstRootHex, int commitVersion) ReadCommitDataLinkAndVersion( ReadOnlyMemory<byte> commitBytes ) {
+        try {
+            CborReader reader = new( commitBytes, CborConformanceMode.Lax );
+            _ = reader.ReadStartMap( );
+
+            string? mstRootHex = null;
+            int commitVersion = 0;
+
+            while (reader.PeekState( ) != CborReaderState.EndMap) {
+                string key = reader.ReadTextString( );
+                if (key == "data") {
+                    if (reader.PeekState( ) == CborReaderState.Null) {
+                        reader.ReadNull( );
+                    } else {
+                        CborTag tag = reader.ReadTag( );
+                        if (tag != (CborTag)42) {
+                            throw new CarParseException( $"Commit 'data' field has unexpected tag {(ulong)tag}." );
+                        }
+                        byte[] linkBytes = reader.ReadByteString( );
+                        mstRootHex = Cid.FromDagCborLinkBytes( linkBytes ).KeyHex;
+                    }
+                } else if (key == "version") {
+                    commitVersion = reader.ReadInt32( );
+                } else {
+                    reader.SkipValue( );
+                }
+            }
+
+            if (mstRootHex is null && commitVersion == 0) {
+                throw new CarParseException( "Commit block missing 'data' field." );
+            }
+
+            return (mstRootHex, commitVersion);
+        } catch (CarParseException) {
+            throw;
+        } catch (Exception ex) when (ex is CborContentException or OverflowException or InvalidOperationException) {
+            throw new CarParseException( "Failed to parse commit block CBOR.", ex );
+        }
+    }
+
+    private static IEnumerable<(string Key, string ValueCidHex)> WalkNode(
+        CarFile car,
+        string nodeHex,
+        string prevKeyInNode,
+        int depth,
+        HashSet<string> visited,
+        int maxNodes,
+        int[] recordCount,
+        CancellationToken cancellationToken
+    ) {
+        cancellationToken.ThrowIfCancellationRequested( );
+
+        if (depth > MaxWalkDepth) {
+            throw new CarParseException( $"MST walk exceeded maximum depth {MaxWalkDepth}; possible cycle or malformed tree." );
+        }
+
+        // Cycle/DAG detection: a valid MST is a tree — each node may be visited at most once.
+        if (!visited.Add( nodeHex )) {
+            throw new CarParseException(
+                $"MST node {nodeHex} encountered more than once; CAR contains a cycle or doubling DAG." );
+        }
+
+        // Hard cap: cannot visit more nodes than there are blocks in the file.
+        if (visited.Count > maxNodes) {
+            throw new CarParseException(
+                $"MST walk visited {visited.Count} nodes, exceeding the block-count cap of {maxNodes}." );
+        }
+
+        if (!car.Blocks.TryGetValue( nodeHex, out ReadOnlyMemory<byte> nodeBytes )) {
+            throw new CarParseException( $"MST node block {nodeHex} not found in CAR." );
+        }
+
+        (string? leftHex, List<MstNodeEntry> entries) = ParseMstNode( nodeBytes );
+
+        // Validate first entry in node has p==0 (keys in a node are absolute at entry[0])
+        if (entries.Count > 0 && entries[0].PrefixLen != 0) {
+            throw new CarParseException(
+                $"MST node first entry has p={entries[0].PrefixLen}; must be 0." );
+        }
+
+        // Recurse into left subtree first (in-order)
+        if (leftHex is not null) {
+            foreach ((string key, string valueCidHex) in WalkNode( car, leftHex, prevKeyInNode, depth + 1, visited, maxNodes, recordCount, cancellationToken )) {
+                prevKeyInNode = key;
+                yield return (key, valueCidHex);
+            }
+        }
+
+        // Process entries; after left subtree, the current prefix is the last key yielded from left
+        string currentPrefix = prevKeyInNode;
+
+        foreach (MstNodeEntry entry in entries) {
+            if (entry.PrefixLen > currentPrefix.Length) {
+                throw new CarParseException(
+                    $"MST entry p={entry.PrefixLen} exceeds current key length {currentPrefix.Length}." );
+            }
+
+            string key;
+            try {
+                key = currentPrefix[..entry.PrefixLen] + entry.KeySuffix;
+            } catch (ArgumentOutOfRangeException ex) {
+                throw new CarParseException(
+                    $"MST entry p={entry.PrefixLen} caused invalid slice on key of length {currentPrefix.Length}.", ex );
+            }
+            currentPrefix = key;
+
+            // Cap on total records yielded: cannot exceed block count.
+            recordCount[0]++;
+            if (recordCount[0] > maxNodes) {
+                throw new CarParseException(
+                    $"MST walk yielded {recordCount[0]} records, exceeding the block-count cap of {maxNodes}." );
+            }
+
+            yield return (key, entry.ValueCidHex);
+
+            if (entry.RightChildHex is not null) {
+                foreach ((string childKey, string childValueCidHex) in WalkNode( car, entry.RightChildHex, key, depth + 1, visited, maxNodes, recordCount, cancellationToken )) {
+                    currentPrefix = childKey;
+                    yield return (childKey, childValueCidHex);
+                }
+            }
+        }
+    }
+
+    private static (string? leftHex, List<MstNodeEntry> entries) ParseMstNode( ReadOnlyMemory<byte> nodeBytes ) {
+        try {
+            CborReader reader = new( nodeBytes, CborConformanceMode.Lax );
+            _ = reader.ReadStartMap( );
+
+            string? leftHex = null;
+            List<MstNodeEntry>? entries = null;
+
+            while (reader.PeekState( ) != CborReaderState.EndMap) {
+                string key = reader.ReadTextString( );
+
+                if (key == "l") {
+                    leftHex = ReadOptionalCidLink( reader );
+                } else if (key == "e") {
+                    entries = ReadEntries( reader );
+                } else {
+                    reader.SkipValue( );
+                }
+            }
+
+            reader.ReadEndMap( );
+            return (leftHex, entries ?? []);
+        } catch (CarParseException) {
+            throw;
+        } catch (Exception ex) when (ex is CborContentException or OverflowException or InvalidOperationException) {
+            throw new CarParseException( "Failed to parse MST node CBOR.", ex );
+        }
+    }
+
+    private static string? ReadOptionalCidLink( CborReader reader ) {
+        if (reader.PeekState( ) == CborReaderState.Null) {
+            reader.ReadNull( );
+            return null;
+        }
+
+        CborTag tag = reader.ReadTag( );
+        if (tag != (CborTag)42) {
+            throw new CarParseException( $"MST link has unexpected tag {(ulong)tag}." );
+        }
+
+        byte[] linkBytes = reader.ReadByteString( );
+        return Cid.FromDagCborLinkBytes( linkBytes ).KeyHex;
+    }
+
+    private static List<MstNodeEntry> ReadEntries( CborReader reader ) {
+        _ = reader.ReadStartArray( );
+        List<MstNodeEntry> entries = [];
+
+        while (reader.PeekState( ) != CborReaderState.EndArray) {
+            _ = reader.ReadStartMap( );
+
+            int prefixLen = 0;
+            string? keySuffix = null;
+            string? valueHex = null;
+            string? rightChildHex = null;
+
+            while (reader.PeekState( ) != CborReaderState.EndMap) {
+                string fieldKey = reader.ReadTextString( );
+
+                if (fieldKey == "p") {
+                    prefixLen = reader.ReadInt32( );
+                    // SEC-003: a negative prefix length is structurally invalid and would
+                    // cause an ArgumentOutOfRangeException in the slice below if unchecked.
+                    if (prefixLen < 0) {
+                        throw new CarParseException(
+                            $"MST entry has negative prefix length p={prefixLen}; must be >= 0." );
+                    }
+                } else if (fieldKey == "k") {
+                    byte[] keyBytes = reader.ReadByteString( );
+                    keySuffix = Encoding.UTF8.GetString( keyBytes );
+                } else if (fieldKey == "v") {
+                    CborTag tag = reader.ReadTag( );
+                    if (tag != (CborTag)42) {
+                        throw new CarParseException( $"MST entry 'v' has unexpected tag {(ulong)tag}." );
+                    }
+                    byte[] linkBytes = reader.ReadByteString( );
+                    valueHex = Cid.FromDagCborLinkBytes( linkBytes ).KeyHex;
+                } else if (fieldKey == "t") {
+                    rightChildHex = ReadOptionalCidLink( reader );
+                } else {
+                    reader.SkipValue( );
+                }
+            }
+
+            reader.ReadEndMap( );
+
+            if (keySuffix is null) {
+                throw new CarParseException( "MST entry missing 'k' (key suffix) field." );
+            }
+
+            if (valueHex is null) {
+                throw new CarParseException( "MST entry missing 'v' (value CID) field." );
+            }
+
+            entries.Add( new MstNodeEntry( prefixLen, keySuffix, valueHex, rightChildHex ) );
+        }
+
+        reader.ReadEndArray( );
+        return entries;
+    }
+
+    private sealed record MstNodeEntry(
+        int PrefixLen,
+        string KeySuffix,
+        string ValueCidHex,
+        string? RightChildHex
+    );
+}

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/MstWalker.cs
@@ -30,10 +30,7 @@ internal static class MstWalker {
             throw new CarParseException( $"Commit block {commitHex} not found in CAR." );
         }
 
-        (string? mstRootHex, int commitVersion) = ReadCommitDataLinkAndVersion( commitBytes );
-        if (mstRootHex is null) {
-            return ([], commitVersion);
-        }
+        (string mstRootHex, int commitVersion) = ReadCommitDataLinkAndVersion( commitBytes );
 
         // Visited-node set: a valid MST is a tree — no node may appear twice.
         // Caps are derived from block count: a valid walk cannot visit more nodes
@@ -45,12 +42,12 @@ internal static class MstWalker {
         return (WalkNode( car, mstRootHex, "", 0, visited, maxNodes, recordCount, cancellationToken ), commitVersion);
     }
 
-    private static (string? mstRootHex, int commitVersion) ReadCommitDataLinkAndVersion( ReadOnlyMemory<byte> commitBytes ) {
+    private static (string mstRootHex, int commitVersion) ReadCommitDataLinkAndVersion( ReadOnlyMemory<byte> commitBytes ) {
         try {
             CborReader reader = new( commitBytes, CborConformanceMode.Lax );
             _ = reader.ReadStartMap( );
 
-            string? mstRootHex = null;
+            string? mstRootHexParsed = null;
             int commitVersion = 0;
 
             while (reader.PeekState( ) != CborReaderState.EndMap) {
@@ -64,7 +61,7 @@ internal static class MstWalker {
                             throw new CarParseException( $"Commit 'data' field has unexpected tag {(ulong)tag}." );
                         }
                         byte[] linkBytes = reader.ReadByteString( );
-                        mstRootHex = Cid.FromDagCborLinkBytes( linkBytes ).KeyHex;
+                        mstRootHexParsed = Cid.FromDagCborLinkBytes( linkBytes ).KeyHex;
                     }
                 } else if (key == "version") {
                     commitVersion = reader.ReadInt32( );
@@ -73,11 +70,11 @@ internal static class MstWalker {
                 }
             }
 
-            if (mstRootHex is null && commitVersion == 0) {
-                throw new CarParseException( "Commit block missing 'data' field." );
+            if (mstRootHexParsed is null) {
+                throw new CarParseException( "Commit block missing required 'data' link." );
             }
 
-            return (mstRootHex, commitVersion);
+            return (mstRootHexParsed, commitVersion);
         } catch (CarParseException) {
             throw;
         } catch (Exception ex) when (ex is CborContentException or OverflowException or InvalidOperationException) {

--- a/src/BridgeBeats.Core/Infrastructure/Storage/Car/Varint.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/Car/Varint.cs
@@ -1,0 +1,30 @@
+namespace BridgeBeats.Core.Infrastructure.Storage.Car;
+
+internal static class Varint {
+
+    private const int MaxVarintBytes = 9;
+
+    /// <summary>
+    /// Attempts to read an unsigned LEB-128 varint from a span.
+    /// Caps at 9 bytes per the CAR v1 spec.
+    /// </summary>
+    internal static bool TryRead( ReadOnlySpan<byte> source, out ulong value, out int bytesRead ) {
+        value = 0;
+        bytesRead = 0;
+
+        for (int i = 0; i < MaxVarintBytes && i < source.Length; i++) {
+            byte b = source[i];
+            value |= (ulong)(b & 0x7F) << (7 * i);
+            bytesRead++;
+
+            if ((b & 0x80) == 0) {
+                return true;
+            }
+        }
+
+        // Either source was too short or exceeded 9-byte cap
+        value = 0;
+        bytesRead = 0;
+        return false;
+    }
+}

--- a/src/BridgeBeats.Web/Controllers/StatisticsController.cs
+++ b/src/BridgeBeats.Web/Controllers/StatisticsController.cs
@@ -25,22 +25,28 @@ public partial class StatisticsController(
     /// Displays the statistics page with lookup collection metrics.
     /// </summary>
     /// <returns>The statistics view.</returns>
-    public IActionResult Index( ) {
+    public async Task<IActionResult> Index( ) {
         if (statisticsService is null) {
             LogNotAvailable( );
             return View( "Error", new ErrorViewModel { Message = "Statistics service is not configured." } );
         }
 
         try {
-            LookupStatistics? stats = statisticsService.GetCachedStatistics();
+            LookupStatistics? stats = statisticsService.GetCachedStatistics( );
 
             if (stats is null) {
                 ViewBag.IsRefreshing = true;
                 return View( "Generating" );
             }
 
+            // Overlay live bootstrap status so the page reflects the current run state
+            // without waiting for the full statistics cache to expire.
+            CacheBootstrapStatus? liveStatus =
+                await statisticsService.GetLiveBootstrapStatusAsync( HttpContext?.RequestAborted ?? CancellationToken.None );
+            LookupStatistics displayStats = stats.WithBootstrapStatus( liveStatus );
+
             ViewBag.IsRefreshing = statisticsService.IsRefreshing;
-            return View( stats );
+            return View( displayStats );
         } catch (Exception ex) {
             LogRetrieveError( ex );
             return View( "Error", new ErrorViewModel { Message = "Unable to retrieve statistics. Please try again later." } );

--- a/src/BridgeBeats.Worker.CacheBootstrap/CacheBootstrapBackgroundService.cs
+++ b/src/BridgeBeats.Worker.CacheBootstrap/CacheBootstrapBackgroundService.cs
@@ -77,7 +77,7 @@ public sealed partial class CacheBootstrapBackgroundService(
                 ? null
                 : JsonSerializer.Deserialize<CacheBootstrapStatus>( value.ToString( ), s_jsonReadOptions );
         } catch (Exception ex) {
-            LogStatusUpdateError( logger, ex );
+            LogStatusReadError( logger, ex );
             return null;
         }
     }
@@ -300,6 +300,13 @@ public sealed partial class CacheBootstrapBackgroundService(
         Level = LogLevel.Warning,
         Message = "Failed to update cache bootstrap status in Redis" )]
     private static partial void LogStatusUpdateError( ILogger logger, Exception ex );
+
+    /// <summary>Logs failure to read status from Redis.</summary>
+    [LoggerMessage(
+        EventId = LogEventIds.StatusReadError,
+        Level = LogLevel.Warning,
+        Message = "Failed to read cache bootstrap status from Redis" )]
+    private static partial void LogStatusReadError( ILogger logger, Exception ex );
 
     #endregion
 }

--- a/src/BridgeBeats.Worker.CacheBootstrap/CacheBootstrapBackgroundService.cs
+++ b/src/BridgeBeats.Worker.CacheBootstrap/CacheBootstrapBackgroundService.cs
@@ -28,6 +28,7 @@ public sealed partial class CacheBootstrapBackgroundService(
 ) : BackgroundService {
 
     private static readonly JsonSerializerOptions s_jsonOptions = new( ) { WriteIndented = false };
+    private static readonly JsonSerializerOptions s_jsonReadOptions = new( ) { PropertyNameCaseInsensitive = true };
 
     /// <inheritdoc/>
     protected override async Task ExecuteAsync( CancellationToken stoppingToken ) {
@@ -39,12 +40,6 @@ public sealed partial class CacheBootstrapBackgroundService(
 
         while (!stoppingToken.IsCancellationRequested) {
             try {
-                // Update status with next scheduled run time
-                await UpdateStatusAsync( new CacheBootstrapStatus {
-                    IsRunning = false,
-                    NextScheduledRun = DateTimeOffset.UtcNow.Add( settings.BootstrapInterval )
-                } );
-
                 _ = await timer.WaitForNextTickAsync( stoppingToken );
                 await RunBootstrapAsync( stoppingToken );
             } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
@@ -72,13 +67,35 @@ public sealed partial class CacheBootstrapBackgroundService(
     }
 
     /// <summary>
+    /// Reads the current cache bootstrap status from Redis, or returns null if absent or unreadable.
+    /// </summary>
+    private async Task<CacheBootstrapStatus?> GetCacheBootstrapStatusAsync( ) {
+        try {
+            IDatabase db = redis.GetDatabase( );
+            RedisValue value = await db.StringGetAsync( CacheBootstrapStatus.RedisKey );
+            return value.IsNullOrEmpty
+                ? null
+                : JsonSerializer.Deserialize<CacheBootstrapStatus>( value.ToString( ), s_jsonReadOptions );
+        } catch (Exception ex) {
+            LogStatusUpdateError( logger, ex );
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Performs a full cache bootstrap by fetching all records from ATProto and populating Redis.
     /// </summary>
     private async Task RunBootstrapAsync( CancellationToken cancellationToken ) {
-        // Update status to show bootstrap is running
+        // Preserve previously completed-run fields when signalling that a run has started.
+        CacheBootstrapStatus? previous = await GetCacheBootstrapStatusAsync( );
         await UpdateStatusAsync( new CacheBootstrapStatus {
             IsRunning = true,
-            NextScheduledRun = null
+            NextScheduledRun = null,
+            LastRunTime = previous?.LastRunTime,
+            LastSuccessCount = previous?.LastSuccessCount,
+            LastErrorCount = previous?.LastErrorCount,
+            LastDurationSeconds = previous?.LastDurationSeconds,
+            RedisKeyCount = previous?.RedisKeyCount
         } );
 
         // Get Redis key count before bootstrap for comparison
@@ -127,6 +144,22 @@ public sealed partial class CacheBootstrapBackgroundService(
             throw;
         } catch (Exception ex) {
             LogBootstrapFatalError( logger, ex );
+            stopwatch.Stop( );
+
+            // Preserve the last successful run's fields; only update lifecycle fields.
+            // Do NOT fall through to the normal completion write — that would record a zero-count
+            // run as a completed run and clobber the previous successful run's stats.
+            CacheBootstrapStatus? prior = await GetCacheBootstrapStatusAsync( );
+            await UpdateStatusAsync( new CacheBootstrapStatus {
+                IsRunning = false,
+                NextScheduledRun = DateTimeOffset.UtcNow.Add( settings.BootstrapInterval ),
+                LastRunTime = prior?.LastRunTime,
+                LastSuccessCount = prior?.LastSuccessCount,
+                LastErrorCount = prior?.LastErrorCount,
+                LastDurationSeconds = prior?.LastDurationSeconds,
+                RedisKeyCount = prior?.RedisKeyCount
+            } );
+            return;
         }
 
         stopwatch.Stop( );

--- a/src/BridgeBeats.Worker.CacheBootstrap/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.CacheBootstrap/Logging/LogEventIds.cs
@@ -46,6 +46,9 @@ public static class LogEventIds {
     /// <summary>Failed to update status in Redis.</summary>
     public const int StatusUpdateError = 5512;
 
+    /// <summary>Failed to read status from Redis.</summary>
+    public const int StatusReadError = 5513;
+
     #endregion
 
     #region Program Startup (5550-5574)


### PR DESCRIPTION
This pull request refactors the statistics calculation process to use the direct car download instead of using the pagination process via list records. Also improves the reliability and correctness of integration and unit tests for the cache bootstrap and account registration logic. The changes focus on making tests more robust against timing issues, ensuring accurate simulation of database exceptions, and verifying the specificity of error handling logic.

**Test reliability and timing improvements:**

- Replaced `Task.Delay` with `TaskCompletionSource` signaling in `CacheBootstrapBackgroundServiceTests` to make tests deterministic and eliminate flakiness, especially in CI environments. This ensures tests wait precisely for the completion of key actions (such as all records being processed or a method being called) rather than relying on arbitrary delays. [[1]](diffhunk://#diff-776fbbb9da3a8991e7f6bdb180bf82bae4bd4c4436a23e276887124aacb01cb5R86) [[2]](diffhunk://#diff-776fbbb9da3a8991e7f6bdb180bf82bae4bd4c4436a23e276887124aacb01cb5R97-R117) [[3]](diffhunk://#diff-776fbbb9da3a8991e7f6bdb180bf82bae4bd4c4436a23e276887124aacb01cb5R131-R149)

- Enhanced Redis mocking in `CacheBootstrapBackgroundServiceTests` by explicitly mocking the `IDatabase` interface and wiring up expected behaviors for `StringGetAsync` and `StringSetAsync`, ensuring more accurate simulation of Redis interactions during tests. [[1]](diffhunk://#diff-776fbbb9da3a8991e7f6bdb180bf82bae4bd4c4436a23e276887124aacb01cb5R21) [[2]](diffhunk://#diff-776fbbb9da3a8991e7f6bdb180bf82bae4bd4c4436a23e276887124aacb01cb5R41-R57)

**Account registration exception handling tests:**

- Updated and expanded tests for the account registration controller to precisely simulate and verify handling of unique email constraint violations:
    - Tests now use a `DbUpdateException` with an inner `SqliteException` (error code 19, message containing `AspNetUsers.NormalizedEmail`) to match the controller's catch filter and verify that a 400 Bad Request is returned for duplicate emails. [[1]](diffhunk://#diff-ed79dae5e55f542697d785faa53f7a683f152da1b42ada632297dc8a758441a9L24-R50) [[2]](diffhunk://#diff-ed79dae5e55f542697d785faa53f7a683f152da1b42ada632297dc8a758441a9L68-R104)
    - Added tests to ensure the catch filter does not swallow unrelated exceptions:
        - If the `SqliteException` refers to a different column, or if the inner exception is not a `SqliteException`, the exception is not caught and propagates as expected. [[1]](diffhunk://#diff-ed79dae5e55f542697d785faa53f7a683f152da1b42ada632297dc8a758441a9L68-R104) [[2]](diffhunk://#diff-ed79dae5e55f542697d785faa53f7a683f152da1b42ada632297dc8a758441a9L113-R177)

- Refactored the `FakeUserManager` helper to use C# primary constructor syntax for improved clarity and conciseness.

**Integration test addition:**

- Added a new integration test (`CarVsListRecordsParityTests`) that verifies the parity between CAR-based record enumeration and paginated `listRecords` API calls against a live PDS. This test ensures both methods yield the same set of AT-URIs and matching `LookedUpAt` values, but is excluded from automated runs and intended for manual execution.