### PR TITLE
Fix/duplicate saga writes

### DIFF
--- a/Tests/Integration/QueueMetricsIntegrationTests.cs
+++ b/Tests/Integration/QueueMetricsIntegrationTests.cs
@@ -1,5 +1,9 @@
 using System.Diagnostics.Metrics;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Extensions;
 using BridgeBeats.Core.Infrastructure.Queue;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
 
 namespace BridgeBeats.Tests.Integration;
@@ -21,13 +25,21 @@ public class QueueMetricsIntegrationTests {
     private static IConnectionMultiplexer? s_redis;
 
     /// <summary>
-    /// Requires the shared Redis container and opens a connection to it for the test class.
+    /// Per-run token used to namespace all <c>queue:*</c> keys this class touches, so parallel
+    /// class runs cannot delete each other's in-flight stream data.
+    /// </summary>
+    private static string s_runToken = string.Empty;
+
+    /// <summary>
+    /// Requires the shared Redis container, opens a connection, and generates a stable per-run key
+    /// prefix token so every key created by this class is isolated from other concurrent classes.
     /// </summary>
     /// <param name="_">The MSTest class context (unused).</param>
     [ClassInitialize]
     public static async Task ClassInitialize( TestContext _ ) {
         SharedTestInfrastructure.RequireRedis( );
         s_redis = await ConnectionMultiplexer.ConnectAsync( SharedTestInfrastructure.RedisConnectionString );
+        s_runToken = Guid.NewGuid( ).ToString( "N" )[..8];
     }
 
     /// <summary>
@@ -42,17 +54,53 @@ public class QueueMetricsIntegrationTests {
     }
 
     /// <summary>
-    /// Clears any leftover <c>queue:*</c> keys from Redis before each test for isolation.
+    /// Clears this run's prefixed <c>queue:{runToken}:*</c> keys and the specific production-format
+    /// queue keys written by the gauge-depth tests within this class before each test, so tests do
+    /// not accumulate stream entries from prior runs within the session. The cleanup uses explicit
+    /// known-key deletion for the production-format keys — not a bare <c>queue:*</c> wipe — so keys
+    /// owned by concurrently executing test classes are never touched.
     /// </summary>
     [TestInitialize]
     public async Task TestInitialize( ) {
-        // Clear queue-related keys before each test
+        await CleanupOwnKeysAsync( );
+    }
+
+    /// <summary>
+    /// Deletes this run's own prefixed <c>queue:{runToken}:*</c> keys and the explicit set of
+    /// production-format keys written by the gauge-depth tests. Uses known-key deletion only —
+    /// no bare wildcard wipe — so foreign-class keys are never touched.
+    /// </summary>
+    private async Task CleanupOwnKeysAsync( ) {
         IDatabase db = s_redis!.GetDatabase( );
         IServer server = s_redis.GetServer( s_redis.GetEndPoints( )[0] );
-        await foreach (RedisKey key in server.KeysAsync( pattern: "queue:*" )) {
+
+        // Clean this run's own namespaced keys
+        string ownPattern = $"queue:{s_runToken}:*";
+        await foreach (RedisKey key in server.KeysAsync( pattern: ownPattern )) {
+            _ = await db.KeyDeleteAsync( key );
+        }
+
+        // Clean the specific production-format keys written by gauge-depth tests in this class.
+        // Using explicit key names, not a wildcard wipe, so no foreign keys are touched.
+        string[] productionKeys = [
+            "queue:spotify:interactive",
+            "queue:spotify:background",
+            "queue:spotify:bulk",
+            "queue:applemusic:interactive",
+            "queue:applemusic:background",
+            "queue:applemusic:bulk",
+            "queue:tidal:interactive",
+            "queue:tidal:background",
+            "queue:tidal:bulk",
+        ];
+        foreach (string key in productionKeys) {
             _ = await db.KeyDeleteAsync( key );
         }
     }
+
+    /// <summary>Returns a stream key namespaced under this class's per-run token.</summary>
+    private static string QueueKey( string provider, string priority ) =>
+        $"queue:{s_runToken}:{provider}:{priority}";
 
     #region Observable Gauge Tests
 
@@ -291,6 +339,116 @@ public class QueueMetricsIntegrationTests {
         }
 
         Assert.HasCount( 9, recordedCombinations, "Should have exactly 9 provider/priority combinations" );
+    }
+
+    #endregion
+
+    #region Alarm Observability Tests
+
+    /// <summary>
+    /// Verifies that <see cref="QueueServiceExtensions.AddQueueInfrastructure"/> with
+    /// <c>registerMetrics: true</c> (the default) registers a <see cref="QueueMetricsRegistration"/>
+    /// hosted service. Starting that service invokes <see cref="QueueMetrics.RegisterQueueDepthGauges"/>
+    /// and the queue-depth instrument is visible to a <see cref="MeterListener"/> without any direct
+    /// call to <see cref="QueueMetrics.RegisterQueueDepthGauges"/> in this test.
+    /// </summary>
+    [TestMethod]
+    public async Task HostBuild_WithMetricsEnabled_RegistersHostedServiceThatEmitsGauge( ) {
+        // Arrange - build a minimal service collection the same way the hosts do
+        ServiceCollection services = new( );
+        _ = services.AddSingleton( s_redis! );
+        _ = services.AddLogging( );
+        _ = services.Configure<QueueSettings>( _ => { } );
+        _ = services.AddQueueInfrastructure( registerMetrics: true );
+
+        await using ServiceProvider provider = services.BuildServiceProvider( );
+
+        // Verify a QueueMetricsRegistration hosted service was registered
+        IEnumerable<IHostedService> hostedServices = provider.GetServices<IHostedService>( );
+        bool hasMetricsService = hostedServices.Any( svc => svc is QueueMetricsRegistration );
+        Assert.IsTrue( hasMetricsService,
+            "AddQueueInfrastructure(registerMetrics: true) must register a QueueMetricsRegistration IHostedService" );
+
+        // Start the hosted service so the gauges are registered (idempotent — latch already set
+        // by earlier tests in this class, but StartAsync must not throw)
+        QueueMetricsRegistration metricsService = (QueueMetricsRegistration)hostedServices.First( svc => svc is QueueMetricsRegistration );
+        await metricsService.StartAsync( CancellationToken.None );
+
+        // Verify the queue-depth gauge is present on the meter
+        bool gaugeFound = false;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, _ ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName && instrument.Name == "bridgebeats.queue.depth") {
+                gaugeFound = true;
+            }
+        };
+        listener.Start( );
+
+        Assert.IsTrue( gaugeFound,
+            "The queue-depth gauge must be visible on the BridgeBeats.Queue meter after the hosted service starts" );
+    }
+
+    /// <summary>
+    /// Negative control: verifies that <see cref="QueueServiceExtensions.AddQueueInfrastructure"/>
+    /// with <c>registerMetrics: false</c> does NOT register a <see cref="QueueMetricsRegistration"/>
+    /// hosted service. Prevents the gauge from being registered in hosts that opt out of metrics.
+    /// </summary>
+    [TestMethod]
+    public void HostBuild_WithMetricsDisabled_DoesNotRegisterMetricsHostedService( ) {
+        // Arrange
+        ServiceCollection services = new( );
+        _ = services.AddSingleton( s_redis! );
+        _ = services.AddLogging( );
+        _ = services.Configure<QueueSettings>( _ => { } );
+        _ = services.AddQueueInfrastructure( registerMetrics: false );
+
+        using ServiceProvider provider = services.BuildServiceProvider( );
+
+        // Assert - no QueueMetricsRegistration in the service collection
+        IEnumerable<IHostedService> hostedServices = provider.GetServices<IHostedService>( );
+        bool hasMetricsService = hostedServices.Any( svc => svc is QueueMetricsRegistration );
+        Assert.IsFalse( hasMetricsService,
+            "AddQueueInfrastructure(registerMetrics: false) must NOT register a QueueMetricsRegistration IHostedService" );
+    }
+
+    #endregion
+
+    #region Test-Isolation Guard
+
+    /// <summary>
+    /// Regression guard: verifies that <see cref="CleanupOwnKeysAsync"/> never touches keys outside
+    /// this run's own prefix. Two sentinels are seeded to cover distinct bypass vectors: a bare
+    /// <c>queue:*</c> wipe catches a revert to an unnamespaced pattern, and a foreign run-token-shaped
+    /// key catches a namespaced-but-foreign-class wipe. Both must survive the cleanup call.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task TestIsolation_ForeignPrefixKeys_AreNeverTouched( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+
+        // Sentinel 1: bare queue: prefix — catches a revert to an unnamespaced queue:* wipe
+        string bareKey = "queue:__sentinel__:metrics-guard";
+        _ = await db.StringSetAsync( bareKey, "exists", TimeSpan.FromMinutes( 5 ) );
+
+        // Sentinel 2: foreign run-token-shaped key — catches a namespaced-foreign-class wipe
+        string foreignRunKey = "queue:ffffffff:spotify:interactive";
+        _ = await db.StringSetAsync( foreignRunKey, "exists", TimeSpan.FromMinutes( 5 ) );
+
+        // Exercise the real cleanup method (same code path as TestInitialize)
+        await CleanupOwnKeysAsync( );
+
+        // Both sentinels must survive: the cleanup must be scoped to this run's own prefix only
+        bool bareKeyStillExists = await db.KeyExistsAsync( bareKey );
+        Assert.IsTrue( bareKeyStillExists,
+            "CleanupOwnKeysAsync touched a key outside this class's prefix (bare queue: sentinel gone); isolation is broken." );
+
+        bool foreignRunKeyStillExists = await db.KeyExistsAsync( foreignRunKey );
+        Assert.IsTrue( foreignRunKeyStillExists,
+            "CleanupOwnKeysAsync touched a foreign run-token-shaped key; isolation is broken." );
+
+        // Cleanup: remove both sentinels
+        _ = await db.KeyDeleteAsync( bareKey );
+        _ = await db.KeyDeleteAsync( foreignRunKey );
     }
 
     #endregion

--- a/Tests/Integration/RedisRequestQueueTests.cs
+++ b/Tests/Integration/RedisRequestQueueTests.cs
@@ -26,6 +26,13 @@ public partial class RedisRequestQueueTests {
     /// <summary>The shared Redis connection used by the queue under test.</summary>
     private static IConnectionMultiplexer? s_redis;
 
+    /// <summary>
+    /// Per-run token used to namespace all stream keys so concurrent test classes cannot delete
+    /// each other's in-flight data. Generated once in <see cref="ClassInitialize"/> and stable
+    /// for the entire class run.
+    /// </summary>
+    private static string s_runToken = string.Empty;
+
     /// <summary>Mock logger captured for the queue under test.</summary>
     private Mock<ILogger<RedisRequestQueue<QueuedLookupRequest>>> _mockLogger = null!;
     /// <summary>Queue settings supplied to the queue under test.</summary>
@@ -37,13 +44,15 @@ public partial class RedisRequestQueueTests {
     public TestContext TestContext { get; set; } = null!;
 
     /// <summary>
-    /// Requires the shared Redis container and opens a connection to it for the test class.
+    /// Requires the shared Redis container, opens a connection, and generates a stable per-run key
+    /// prefix token so every stream key created by this class is isolated from other concurrent classes.
     /// </summary>
     /// <param name="_">The MSTest class context (unused).</param>
     [ClassInitialize]
     public static async Task ClassInitialize( TestContext _ ) {
         SharedTestInfrastructure.RequireRedis( );
         s_redis = await ConnectionMultiplexer.ConnectAsync( SharedTestInfrastructure.RedisConnectionString );
+        s_runToken = Guid.NewGuid( ).ToString( "N" )[..8];
     }
 
     /// <summary>
@@ -58,30 +67,40 @@ public partial class RedisRequestQueueTests {
     }
 
     /// <summary>
-    /// Clears leftover <c>queue:*</c> keys, constructs a fresh Spotify queue, and ensures its consumer
-    /// groups exist before each test.
+    /// Clears only this run's prefixed <c>queue:{runToken}:*</c> keys, constructs a fresh Spotify
+    /// queue using the same prefix, and ensures its consumer groups exist before each test.
     /// </summary>
     [TestInitialize]
     public async Task TestInitialize( ) {
-        // Clear only queue-related keys before each test
-        IDatabase db = s_redis!.GetDatabase( );
-        IServer server = s_redis.GetServer( s_redis.GetEndPoints( )[0] );
-        await foreach (RedisKey key in server.KeysAsync( pattern: "queue:*" )) {
-            _ = await db.KeyDeleteAsync( key );
-        }
+        await CleanupOwnKeysAsync( );
 
         _mockLogger = new Mock<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( );
         _settings = Options.Create( new QueueSettings( ) );
 
         _queue = new RedisRequestQueue<QueuedLookupRequest>(
-            s_redis,
+            s_redis!,
             _mockLogger.Object,
             _settings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
 
         // Ensure consumer groups exist
         await _queue.EnsureConsumerGroupsAsync( CancellationToken.None );
+    }
+
+    /// <summary>
+    /// Deletes this run's own prefixed <c>queue:{runToken}:*</c> keys. Uses the run-token-namespaced
+    /// pattern only — no bare wildcard — so keys owned by other concurrently executing test classes
+    /// are never touched.
+    /// </summary>
+    private async Task CleanupOwnKeysAsync( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        IServer server = s_redis.GetServer( s_redis.GetEndPoints( )[0] );
+        string ownPattern = $"queue:{s_runToken}:*";
+        await foreach (RedisKey key in server.KeysAsync( pattern: ownPattern )) {
+            _ = await db.KeyDeleteAsync( key );
+        }
     }
 
     /// <summary>
@@ -295,7 +314,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             appleLogger.Object,
             _settings,
-            SupportedProviders.AppleMusic
+            SupportedProviders.AppleMusic,
+            keyPrefix: s_runToken
         );
         await appleQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -334,7 +354,8 @@ public partial class RedisRequestQueueTests {
         // Arrange - add multiple messages to each priority
         const int MessagesPerPriority = 10;
 
-        // Create a queue with bulk gating disabled for this test
+        // Create a queue with bulk gating disabled for this test; use the run-token prefix so
+        // this instance shares the namespaced stream with _queue and TestInitialize cleanup.
         IOptions<QueueSettings> testSettings = Options.Create( new QueueSettings {
             DefaultMinBulkQueueThreshold = 0 // Disable bulk gating
         } );
@@ -343,7 +364,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -377,13 +399,15 @@ public partial class RedisRequestQueueTests {
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task ConsumerGroups_AllowMultipleWorkerInstances( ) {
-        // Arrange - create two queue instances (simulating two workers)
+        // Arrange - create two queue instances (simulating two workers); both must share
+        // the same run-token prefix so they operate on the same namespaced stream.
         Mock<ILogger<RedisRequestQueue<QueuedLookupRequest>>> logger2 = new( );
         RedisRequestQueue<QueuedLookupRequest> worker2Queue = new(
             s_redis!,
             logger2.Object,
             _settings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await worker2Queue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -561,7 +585,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -605,7 +630,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -668,7 +694,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -732,7 +759,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -780,7 +808,8 @@ public partial class RedisRequestQueueTests {
             s_redis!,
             testLogger.Object,
             testSettings,
-            SupportedProviders.Spotify
+            SupportedProviders.Spotify,
+            keyPrefix: s_runToken
         );
         await testQueue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
 
@@ -824,6 +853,32 @@ public partial class RedisRequestQueueTests {
             SagaId = $"saga-{id}",
             CreatedAt = DateTimeOffset.UtcNow
         };
+    }
+
+    /// <summary>
+    /// Regression guard: verifies that <see cref="CleanupOwnKeysAsync"/> never touches keys outside
+    /// this run's own prefix. A bare <c>queue:*</c> wipe would delete the sentinel and fail this
+    /// test, proving the cleanup is scoped to this class's namespaced keyspace.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task TestIsolation_ForeignPrefixKeys_AreNeverTouched( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+
+        // Seed a sentinel under a foreign prefix before the cleanup runs
+        string foreignKey = "queue:__sentinel__:guard";
+        _ = await db.StringSetAsync( foreignKey, "exists", TimeSpan.FromMinutes( 5 ) );
+
+        // Exercise the real cleanup method (same code path as TestInitialize)
+        await CleanupOwnKeysAsync( );
+
+        // The sentinel must survive: cleanup must be scoped to this run's prefix only
+        bool sentinelStillExists = await db.KeyExistsAsync( foreignKey );
+        Assert.IsTrue( sentinelStillExists,
+            "CleanupOwnKeysAsync touched a key outside this class's prefix; isolation is broken." );
+
+        // Cleanup: remove the sentinel we placed
+        _ = await db.KeyDeleteAsync( foreignKey );
     }
 
     [GeneratedRegex( "^[0-9a-f]{32}$" )]

--- a/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
+++ b/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
@@ -1,0 +1,348 @@
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Domain.Services.Queue;
+using BridgeBeats.Core.Infrastructure.Queue;
+using BridgeBeats.Worker.SagaCoordinator;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the saga finalize single-winner claim against a real Redis instance.
+/// Verifies that exactly one concurrent finalize trigger performs the PDS write, that a failed
+/// PDS write releases the claim so a retry can re-finalize, and that re-delivery of an already-
+/// finalized saga is a no-op. The shared Redis Testcontainer is required; tests are tagged
+/// Integration and Docker so the CI filter handles them consistently.
+/// </summary>
+[TestClass]
+[TestCategory( "Integration" )]
+[TestCategory( "Docker" )]
+[DoNotParallelize]
+public class SagaFinalizeClaimIntegrationTests {
+
+    /// <summary>The shared Redis connection used by the claim under test.</summary>
+    private static IConnectionMultiplexer? s_redis;
+
+    /// <summary>Queue settings supplied to the saga manager.</summary>
+    private IOptions<QueueSettings> _settings = null!;
+
+    /// <summary>The saga state manager backed by real Redis.</summary>
+    private RedisSagaStateManager _sagaManager = null!;
+
+    /// <summary>MSTest-injected context; its cancellation token bounds in-test delays.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Fixed saga id used across tests in this class.</summary>
+    private const string TestSagaId = "saga-claim-integ-0001";
+
+    /// <summary>Fixed lookup key used in the saga fixture.</summary>
+    private const string TestLookupKey = "isrc:USRC99999001";
+
+    /// <summary>
+    /// Requires the shared Redis container and opens a connection used by all tests in this class.
+    /// </summary>
+    /// <param name="_">The MSTest class context (unused).</param>
+    [ClassInitialize]
+    public static async Task ClassInitialize( TestContext _ ) {
+        SharedTestInfrastructure.RequireRedis( );
+        s_redis = await ConnectionMultiplexer.ConnectAsync( SharedTestInfrastructure.RedisConnectionString );
+    }
+
+    /// <summary>Closes and disposes the Redis connection after all tests in this class complete.</summary>
+    [ClassCleanup]
+    public static async Task ClassCleanup( ) {
+        if (s_redis is not null) {
+            await s_redis.CloseAsync( );
+            s_redis.Dispose( );
+        }
+    }
+
+    /// <summary>Clears saga keys and creates a fresh saga manager before each test.</summary>
+    [TestInitialize]
+    public async Task TestInitialize( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        IServer server = s_redis.GetServer( s_redis.GetEndPoints( )[0] );
+        await foreach (RedisKey key in server.KeysAsync( pattern: "saga:*" )) {
+            _ = await db.KeyDeleteAsync( key );
+        }
+
+        _settings = Options.Create( new QueueSettings { JobExpirationMinutes = 60 } );
+        _sagaManager = new RedisSagaStateManager(
+            s_redis,
+            new Mock<ILogger<RedisSagaStateManager>>( ).Object,
+            _settings
+        );
+    }
+
+    /// <summary>
+    /// The load-bearing single-winner race test. Drives genuinely concurrent acquirers
+    /// through a barrier into the shared finalize path — the convergence point of all
+    /// three real triggers (saga:completed, complete:{key}, the 30-second poll) — and
+    /// asserts exactly one PDS write via an Interlocked counter on a shared storage double.
+    /// A sequential test passes against the broken read-check; only true concurrency (all
+    /// acquirers reading FinalResultUri==null simultaneously before any writes) exercises
+    /// the race.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_UnderConcurrentTriggers_WritesExactlyOnce( ) {
+        // Arrange - seed one complete, finalizable saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+        await _sagaManager.AddToPendingIndexAsync( TestSagaId, TestContext.CancellationToken );
+
+        // Shared storage double with an Interlocked counter — the discriminator
+        int pdsWriteCount = 0;
+        Mock<IATProtoStorageService> storageDouble = new( );
+        _ = storageDouble
+            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref pdsWriteCount );
+                string rkey = Guid.NewGuid( ).ToString( "N" );
+                return $"at://did:plc:test/com.bridgebeats.medialink/{rkey}";
+            } );
+
+        // Build a complete saga fixture with one successful provider
+        string resultJson = """{"isrc":"USRC99999001","trackName":"Race Test","artistName":"Test","url":"https://spotify.com/t/1"}""";
+        LookupSagaState completeSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC99999001",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -5 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = false
+        };
+
+        // Build all mocks needed by SagaCoordinatorBackgroundService
+        Mock<IConnectionMultiplexer> redisMock = new( );
+        Mock<ISubscriber> subscriberMock = new( );
+        _ = redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( subscriberMock.Object );
+
+        Mock<IMediaLinkCacheRepository> cacheMock = new( );
+        _ = cacheMock
+            .Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( "at://cached" );
+
+        Mock<IRequestDeduplicator> deduplicatorMock = new( );
+        Mock<IProviderQueueResolver<QueuedLookupRequest>> queueResolverMock = new( );
+        Mock<ILogger<SagaResultCombiner>> combinerLoggerMock = new( );
+        SagaResultCombiner resultCombiner = new( combinerLoggerMock.Object );
+        Mock<ILogger<SagaCoordinatorBackgroundService>> loggerMock = new( );
+        HashSet<SupportedProviders> enabledProviders = [SupportedProviders.Spotify];
+
+        // Wire GetAsync to always return the same unfinalised saga
+        Mock<ISagaStateManager> sagaMgrWrapper = new( );
+        _ = sagaMgrWrapper
+            .Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( completeSaga );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, ct ) );
+        _ = sagaMgrWrapper
+            .Setup( s => s.ReleaseFinalizeClaimAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, CancellationToken ct ) => _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, ct ) );
+        _ = sagaMgrWrapper
+            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+        _ = sagaMgrWrapper
+            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+        _ = sagaMgrWrapper
+            .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false ); // ISRC saga: secondaries guard returns false (no fan-out)
+
+        // N = 8 concurrent acquirers through a release gate
+        const int Concurrency = 8;
+        TaskCompletionSource gate = new( TaskCreationOptions.RunContinuationsAsynchronously );
+
+        // Build a service per acquirer (each drives one of the three trigger paths)
+        async Task RunAcquirer( int index ) {
+            await gate.Task; // wait for simultaneous release
+
+            SagaCoordinatorBackgroundService svc = new(
+                redisMock.Object,
+                sagaMgrWrapper.Object,
+                storageDouble.Object,
+                cacheMock.Object,
+                deduplicatorMock.Object,
+                resultCombiner,
+                queueResolverMock.Object,
+                enabledProviders,
+                loggerMock.Object
+            );
+
+            // All paths converge on WriteFinalResultAsync internally; invoke via polling path
+            // (simplest to call without a full subscription setup per acquirer)
+            using CancellationTokenSource cts = new( TimeSpan.FromSeconds( 10 ) );
+            await svc.InvokeFinalizeForTestAsync( completeSaga, cts.Token );
+        }
+
+        // Release all acquirers simultaneously
+        Task<Task>[] racers = [.. Enumerable.Range( 0, Concurrency )
+            .Select( i => Task.Factory.StartNew(
+                ( ) => RunAcquirer( i ),
+                TestContext.CancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default
+            ) )];
+
+        // Small delay to let all tasks reach the gate before releasing
+        await Task.Delay( 50, TestContext.CancellationToken );
+        gate.SetResult( );
+
+        // Wait for all to complete
+        await Task.WhenAll( racers.Select( t => t.Unwrap( ) ) );
+
+        // Assert - exactly one PDS write
+        Assert.AreEqual( 1, pdsWriteCount,
+            $"Expected exactly 1 PDS write under {Concurrency} concurrent finalizers, got {pdsWriteCount}" );
+
+        // Assert - dedup lock released with a non-null URI exactly once
+        deduplicatorMock.Verify(
+            d => d.ReleaseAsync( TestLookupKey, It.Is<string?>( u => u != null ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies the Redis claim release/re-claim (HSETNX/HDEL) primitive: a claim that is released
+    /// can be re-acquired by a subsequent caller, but a held claim cannot be acquired a second time
+    /// without an intervening release.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ClaimPrimitive_AfterRelease_CanBeReacquired( ) {
+        // Arrange
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // First acquisition must succeed
+        bool firstClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsTrue( firstClaimed, "First acquisition must succeed" );
+
+        // Release the claim
+        await _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, TestContext.CancellationToken );
+
+        // Re-acquisition after release must succeed
+        bool reacquired = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsTrue( reacquired, "Re-acquisition after release must succeed" );
+
+        // A further acquisition WITHOUT an intervening release must fail
+        bool duplicateClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsFalse( duplicateClaimed, "A second acquisition without a release must fail" );
+    }
+
+    /// <summary>
+    /// Negative control for the failure-retry test: a finalize that succeeds does NOT leave the
+    /// claim releasable for a second winner. After success the claim remains held, so a subsequent
+    /// TryClaimFinalizeAsync returns false.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenPdsWriteSucceeds_ClaimStaysHeld( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
+            null, TestContext.CancellationToken
+        );
+
+        // Act - first caller wins the claim and does NOT release it on success
+        bool firstClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsTrue( firstClaimed, "First caller must win the claim" );
+
+        // No ReleaseFinalizeClaimAsync call (simulating the success path)
+
+        // Assert - a second caller cannot acquire the claim
+        bool secondClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsFalse( secondClaimed,
+            "Second caller must NOT acquire the claim after a successful finalization (claim is retained on success)" );
+    }
+
+    /// <summary>
+    /// Verifies that re-delivery of an already-finalized saga produces zero additional PDS writes.
+    /// The integration test drives the full claim path with real Redis to confirm the claim field
+    /// blocks re-finalization even after the dedup lock expires.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Redelivery_OfCompletedSaga_DoesNotProduceSecondRecord( ) {
+        // Arrange - seed the saga and claim it (simulating a successful finalization)
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
+            null, TestContext.CancellationToken
+        );
+
+        bool firstClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+        Assert.IsTrue( firstClaimed );
+
+        // Simulate: the first delivery wrote the final URI
+        await _sagaManager.SetFinalResultUriAsync(
+            TestSagaId, "at://did:plc:test/result/original", TestContext.CancellationToken
+        );
+
+        int pdsWriteCount = 0;
+        Mock<IATProtoStorageService> storageDouble = new( );
+        _ = storageDouble
+            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref pdsWriteCount );
+                return "at://did:plc:test/result/redelivery";
+            } );
+
+        // Act - simulate re-delivery: claim attempt must fail (claim still held from first delivery)
+        bool redeliveryClaimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+
+        // Assert - re-delivery cannot acquire the claim
+        Assert.IsFalse( redeliveryClaimed,
+            "Re-delivery must not acquire the finalize claim after a successful first delivery" );
+
+        // Assert - zero storage calls from the re-delivery path
+        Assert.AreEqual( 0, pdsWriteCount );
+    }
+
+    /// <summary>
+    /// Positive control for <see cref="Redelivery_OfCompletedSaga_DoesNotProduceSecondRecord"/>:
+    /// the first delivery DOES finalize. Without this, a handler that no-ops every call would
+    /// vacuously pass the redelivery assertion.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task FirstDelivery_ClaimsAndFinalizes( ) {
+        // Arrange
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
+            null, TestContext.CancellationToken
+        );
+
+        // Act
+        bool claimed = await _sagaManager.TryClaimFinalizeAsync( TestSagaId, TestContext.CancellationToken );
+
+        // Assert
+        Assert.IsTrue( claimed, "First delivery must successfully acquire the finalize claim" );
+    }
+
+
+}

--- a/Tests/Unit/LookupOrchestratorTests.cs
+++ b/Tests/Unit/LookupOrchestratorTests.cs
@@ -993,21 +993,21 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         // First read: saga is partial with a pending provider; second read: saga finalized
         LookupSagaState partialSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
         LookupSagaState finalSaga = CreateSagaState(
             isPartial: false,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             finalResultUri: TestRecordUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
         );
@@ -1050,15 +1050,15 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         LookupSagaState partialSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
 
@@ -1097,11 +1097,11 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         List<ProviderRateLimitInfo> rateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
@@ -1111,7 +1111,7 @@ public class LookupOrchestratorTests {
         // second read (after sentinel): rate limit info recorded
         LookupSagaState pendingSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false), (SupportedProviders.Tidal, false)]
         );
         LookupSagaState rateLimitedSaga = pendingSaga with { RateLimitInfo = rateLimitInfo };
@@ -1152,11 +1152,11 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         List<ProviderRateLimitInfo> rateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
@@ -1164,7 +1164,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState rateLimitedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: rateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
@@ -1202,20 +1202,20 @@ public class LookupOrchestratorTests {
         SetupCacheMiss( );
         SetupDeduplicationInFlight( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         LookupSagaState partialSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
         LookupSagaState finalSaga = CreateSagaState(
             isPartial: false,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             finalResultUri: TestRecordUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
         );
@@ -1257,11 +1257,11 @@ public class LookupOrchestratorTests {
         SetupCacheMiss( );
         SetupDeduplicationAcquired( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         LookupSagaState resumedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
 
@@ -1309,11 +1309,11 @@ public class LookupOrchestratorTests {
         SetupCacheMiss( );
         SetupDeduplicationAcquired( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         LookupSagaState resumedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
 
@@ -1338,7 +1338,7 @@ public class LookupOrchestratorTests {
         _ = await _orchestrator.LookupByIsrcAsync( TestIsrc );
 
         // Assert - released with the known URI (not null: an empty publish would leave waiters stuck)
-        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), partialUri ), Times.Once );
+        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), PartialUri ), Times.Once );
         _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), null ), Times.Never );
     }
 
@@ -1353,7 +1353,7 @@ public class LookupOrchestratorTests {
         SetupCacheMiss( );
         SetupDeduplicationInFlight( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         List<ProviderRateLimitInfo> rateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
@@ -1361,7 +1361,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState rateLimitedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: rateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
@@ -1399,7 +1399,7 @@ public class LookupOrchestratorTests {
         SetupCacheMiss( );
         SetupDeduplicationInFlight( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         List<ProviderRateLimitInfo> rateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
@@ -1407,7 +1407,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState rateLimitedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: rateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
@@ -1424,7 +1424,7 @@ public class LookupOrchestratorTests {
 
         MediaLinkResult partialResult = CreateMediaLinkResult( );
         _ = _atProtoStorageMock
-            .Setup( a => a.GetMediaLinkResultAsync( partialUri ) )
+            .Setup( a => a.GetMediaLinkResultAsync( PartialUri ) )
             .ReturnsAsync( partialResult );
 
         // Act
@@ -1449,11 +1449,11 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         // Rate limit lapsed five minutes ago - waiting CAN help, escape hatch must not fire
         List<ProviderRateLimitInfo> expiredRateLimitInfo = [
@@ -1462,13 +1462,13 @@ public class LookupOrchestratorTests {
 
         LookupSagaState partialSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: expiredRateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
         LookupSagaState finalSaga = CreateSagaState(
             isPartial: false,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             finalResultUri: TestRecordUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, true)]
         );
@@ -1511,11 +1511,11 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         List<ProviderRateLimitInfo> expiredRateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( -5 ), "/v1/catalog" )
@@ -1523,7 +1523,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState partialSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: expiredRateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
@@ -1604,7 +1604,7 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
@@ -1616,7 +1616,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState rateLimitedSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             rateLimitInfo: rateLimitInfo,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
@@ -1627,7 +1627,7 @@ public class LookupOrchestratorTests {
 
         MediaLinkResult partialResult = CreateMediaLinkResult( );
         _ = _atProtoStorageMock
-            .Setup( a => a.GetMediaLinkResultAsync( partialUri ) )
+            .Setup( a => a.GetMediaLinkResultAsync( PartialUri ) )
             .ReturnsAsync( partialResult );
 
         // Act
@@ -1652,11 +1652,11 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
         SetupSagaCreation( );
 
-        const string partialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
+        const string PartialUri = "at://did:plc:test/com.bridgebeats.media.link/partial";
 
         _ = _deduplicatorMock
             .Setup( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ) )
-            .ReturnsAsync( partialUri );
+            .ReturnsAsync( PartialUri );
 
         List<ProviderRateLimitInfo> rateLimitInfo = [
             new ProviderRateLimitInfo( SupportedProviders.AppleMusic, DateTimeOffset.UtcNow.AddMinutes( 5 ), "/v1/catalog" )
@@ -1664,7 +1664,7 @@ public class LookupOrchestratorTests {
 
         LookupSagaState pendingSaga = CreateSagaState(
             isPartial: true,
-            partialResultUri: partialUri,
+            partialResultUri: PartialUri,
             providers: [(SupportedProviders.Spotify, true), (SupportedProviders.AppleMusic, false)]
         );
         LookupSagaState rateLimitedSaga = pendingSaga with { RateLimitInfo = rateLimitInfo };

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -80,6 +80,11 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock
             .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
+
+        // By default the coordinator wins the finalize claim (no concurrent handler)
+        _ = _sagaManagerMock
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
     }
 
     #region Constructor Tests
@@ -1154,13 +1159,14 @@ public class SagaCoordinatorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// Verifies resilience when every secondary enqueue throws: both enqueues are attempted, the
-    /// saga is still marked partial and a partial result is written, and finalization is deferred —
-    /// a queue outage must not finalize a saga whose secondaries never ran.
+    /// Verifies the terminal-state contract when every secondary enqueue throws: both enqueues are
+    /// attempted, the saga is not finalized (the one-provider result is not promoted to final), the
+    /// partial result is written for waiting callers, and the saga is immediately removed from the
+    /// reconciliation pending index so it does not strand to TTL expiry.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task SagaCompletion_WhenEveryEnqueueFails_ShouldStillDeferFinalizationAndWritePartial( ) {
+    public async Task SagaCompletion_WhenEveryEnqueueFails_ReachesTerminalStateAndWritesPartial( ) {
         // Arrange
         Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
         _ = _subscriberMock
@@ -1223,8 +1229,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Exactly( 2 )
         );
 
-        // Assert - The saga is NOT finalized: the one-provider result must not be published
-        // as complete while providers are still missing
+        // Assert - The saga is NOT finalized: the one-provider result must not be promoted to
+        // final while secondary providers are still unresolved
         _sagaManagerMock.Verify(
             s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
@@ -1238,6 +1244,105 @@ public class SagaCoordinatorBackgroundServiceTests {
         _sagaManagerMock.Verify(
             s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
             Times.Once
+        );
+
+        // Assert - The saga is removed from the pending index so it does not strand to TTL expiry
+        _sagaManagerMock.Verify(
+            s => s.RemoveFromPendingIndexAsync( TestSagaId, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Negative control: a saga with at least one successful secondary enqueue stays partial and in
+    /// the pending index, awaiting its secondary providers. It must NOT reach the terminal state
+    /// reserved for the all-enqueues-failed path.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenSomeEnqueueSucceeds_StaysPartialAwaitingSecondaries( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState uriSaga = CreateUriLookupSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( uriSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ((MediaLinkResult result, string recordUri, bool isStale)?)null );
+
+        // One provider enqueues successfully; the other fails
+        Mock<IRequestQueue<QueuedLookupRequest>> successQueueMock = new( );
+        _ = successQueueMock
+            .Setup( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> failQueueMock = new( );
+        _ = failQueueMock
+            .Setup( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "queue unavailable" ) );
+
+        // AppleMusic succeeds, Tidal fails
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( SupportedProviders.AppleMusic ) )
+            .Returns( successQueueMock.Object );
+        _ = _queueResolverMock
+            .Setup( r => r.GetQueue( SupportedProviders.Tidal ) )
+            .Returns( failQueueMock.Object );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Not finalized: secondaries are still pending
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - The partial result is written so waiting callers receive a response
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - The pending index is NOT cleared: at least one provider is in flight
+        _sagaManagerMock.Verify(
+            s => s.RemoveFromPendingIndexAsync( TestSagaId, It.IsAny<CancellationToken>( ) ),
+            Times.Never
         );
     }
 
@@ -1302,6 +1407,523 @@ public class SagaCoordinatorBackgroundServiceTests {
         _sagaManagerMock.Verify(
             s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
+        );
+    }
+
+    #endregion
+
+    #region Finalize Claim Tests
+
+    /// <summary>
+    /// Verifies that a handler that loses the finalize claim performs no PDS write and does not
+    /// call SetFinalResultUriAsync. The loser must be completely silent.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenClaimLost_DoesNotWrite( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        // The claim is already held by another handler
+        _ = _sagaManagerMock
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - No PDS write (the loser must be completely silent)
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - No final URI recorded
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - No dedup release (the loser must not publish on complete:{key})
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a handler that wins the finalize claim writes to the PDS exactly once and
+    /// records the final URI. This is the companion positive control for the loser test above.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenClaimWon_WritesOnce( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Exactly one PDS write
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Final URI recorded
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( completeSaga.SagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - The claim is NOT released on the success path
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a failed PDS write releases the finalize claim so the next poll cycle can
+    /// retry. The dedup lock is released with null to unblock waiters.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenPdsWriteFails_ReleasesClaimAndDedup( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        // PDS write fails
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "PDS unavailable" ) );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Claim released so the next poll can retry
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( completeSaga.SagaId, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Dedup lock released with null to unblock waiters
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( completeSaga.LookupKey, null, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a re-delivery of a saga whose finalization already succeeded is a no-op:
+    /// the existing final result URI short-circuits before the claim is even attempted.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Completion_WhenSagaAlreadyFinalized_IsNoOp( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        // Saga already has a final result URI (already finalized)
+        LookupSagaState alreadyFinalizedSaga = CreateCompleteSaga( ) with {
+            FinalResultUri = TestRecordUri
+        };
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( alreadyFinalizedSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        // Simulate re-delivery of the saga:completed event
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - No second PDS write
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - No second final URI write
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - No second dedup release
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Negative control for <see cref="Completion_WhenSagaAlreadyFinalized_IsNoOp"/>: verifies
+    /// that the first delivery DOES finalize once, proving the no-op path is not over-suppressing.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task FirstDelivery_OfCompletedSaga_FinalizesOnce( ) {
+        // Arrange
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( completeSaga );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [] );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ), "Service should have subscribed to saga:completed" );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Exactly one PDS write on first delivery
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a failure occurring after the final result URI has been durably recorded does
+    /// NOT release the finalize claim. Retaining the claim prevents a re-entrant PDS write against
+    /// a URI that was already written. Pairs with
+    /// <see cref="Finalize_WhenPdsWriteFails_ReleasesClaimAndDedup"/> (pre-URI failure) as a
+    /// discriminator: together they prove the release is conditioned on the durability line, not
+    /// unconditional.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenFailureAfterUriRecorded_DoesNotReleaseClaim( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        // PDS write succeeds and returns a URI
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // SetFinalResultUriAsync succeeds (URI is now durably recorded)
+        _ = _sagaManagerMock
+            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        // The first post-URI step throws — simulates a failure after the durability line
+        _ = _sagaManagerMock
+            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "post-URI step failed" ) );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - A failure after the URI is recorded must retain the claim (no release)
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a cancellation mid-finalize (before the PDS write returns) releases the
+    /// finalize claim so the next host restart can re-finalize, but does NOT release the dedup lock
+    /// with a null URI (which would hand waiters a stale empty completion for a healthy saga) and
+    /// does NOT delete the saga.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenCancelledMidFinalize_ReleasesClaimButNotDedup( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        // Cancellation fires before the PDS write completes (before the durability line)
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new OperationCanceledException( ) );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Claim must be released so the next host can re-finalize
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - Dedup lock must NOT be released with null (no premature empty completion)
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), null, It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - Saga must not be deleted
+        _sagaManagerMock.Verify(
+            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a cancellation arriving after the final result URI is durably recorded does NOT
+    /// release the finalize claim. Retaining the claim prevents a re-entrant PDS write against an
+    /// already-recorded URI. The dedup lock is also never released here. Pairs with
+    /// <see cref="Finalize_WhenCancelledMidFinalize_ReleasesClaimButNotDedup"/> (pre-URI cancellation
+    /// → claim released) to prove the cancellation catch is conditioned on the durability line.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenCancelledAfterUriRecorded_DoesNotReleaseClaim( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [completeSaga] );
+
+        // PDS write succeeds — URI returned and durably recorded
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // SetFinalResultUriAsync completes — durability line crossed
+        _ = _sagaManagerMock
+            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        // The first post-URI step throws OperationCanceledException — cancellation after the durability line
+        _ = _sagaManagerMock
+            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new OperationCanceledException( ) );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Claim must NOT be released; releasing would allow a re-entrant PDS write against
+        // a URI that is already recorded
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - Dedup lock must NOT be released with null (saga succeeded; no premature empty completion)
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), null, It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - Saga must not be deleted
+        _sagaManagerMock.Verify(
+            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies two distinct sagas each finalize exactly once. This proves the single-winner
+    /// guard keys on saga identity and does not suppress legitimate distinct finalizations.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_TwoDistinctSagas_EachWriteOnce( ) {
+        // Arrange
+        const string SagaId2 = "test-saga-id-87654321";
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        LookupSagaState saga1 = CreateCompleteSaga( );
+        LookupSagaState saga2 = CreateCompleteSaga( ) with { SagaId = SagaId2 };
+
+        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+                It.IsAny<TimeSpan>( ),
+                It.IsAny<int>( ),
+                It.IsAny<CancellationToken>( )
+            ) )
+            .ReturnsAsync( [saga1, saga2] );
+
+        _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // Act - polling processes both sagas
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+
+        try {
+            await service.StopAsync( CancellationToken.None );
+        } catch (OperationCanceledException) {
+            // Expected
+        }
+
+        // Assert - Each saga produces exactly one PDS write (two total)
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 )
         );
     }
 

--- a/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
@@ -189,6 +189,29 @@ public interface ISagaStateManager {
     Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Atomically claims the exclusive right to finalize a saga, succeeding only once
+    /// (set-if-not-exists) so exactly one of the overlapping finalization triggers
+    /// (<c>saga:completed</c>, <c>complete:{key}</c>, the polling sweep) performs the PDS write.
+    /// </summary>
+    /// <param name="sagaId">The saga id to claim finalization for.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>
+    /// A task whose result is <see langword="true"/> when this caller acquired the claim (and must
+    /// finalize), or <see langword="false"/> when another caller already holds it.
+    /// </returns>
+    Task<bool> TryClaimFinalizeAsync( string sagaId, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Releases a finalize claim previously acquired via <see cref="TryClaimFinalizeAsync"/>,
+    /// so a legitimate retry can re-finalize after a failed PDS write. Must be called only on
+    /// the failure path; a saga that finalized successfully keeps its claim until TTL expiry.
+    /// </summary>
+    /// <param name="sagaId">The saga id whose finalize claim should be released.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A task that completes when the claim has been released.</returns>
+    Task ReleaseFinalizeClaimAsync( string sagaId, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Seeds the saga with an initial, not-yet-complete provider state for each of the given
     /// providers at the start of a saga, so the set of providers that must complete is known.
     /// </summary>

--- a/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
@@ -208,16 +208,23 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
                 ct
             );
 
+            // Acknowledge the message before publishing completion events so that a crash
+            // between the two does not leave the message in the PEL and re-publish both
+            // completion channels on redelivery. If the publish calls are lost, the 30-second
+            // polling sweep re-finalizes within one cycle.
+            await _queue.AcknowledgeAsync( message.MessageId, ct );
+
             // Check if saga is complete and publish saga completion event for coordinator
             await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
 
             // Publish lookup completion so the SagaCoordinator can process via pattern subscription
             await PublishLookupCompletionAsync( request.SagaId, ct );
 
-            // Acknowledge the message - processing complete
-            await _queue.AcknowledgeAsync( message.MessageId, ct );
-
             LogMessageProcessed( _logger, message.MessageId, request.SagaId );
+        } catch (OperationCanceledException) {
+            // Host is shutting down; do not publish completion events.
+            // The message will be redelivered after restart, or the polling sweep will finalize.
+            throw;
         } catch (RetryAfterExceededException ex) {
             status = "rate_limited";
             await HandleRateLimitExceptionAsync( message, request, ex, ct );
@@ -397,11 +404,12 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
                 ct
             );
 
+            // Acknowledge before publishing so a crash between the two does not re-publish
+            // the completion event on redelivery.
+            await _queue.AcknowledgeAsync( message.MessageId, ct );
+
             // Check if saga is complete and publish completion event
             await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
-
-            // Acknowledge the message (don't retry indefinitely for non-rate-limit errors)
-            await _queue.AcknowledgeAsync( message.MessageId, ct );
         }
     }
 

--- a/src/BridgeBeats.Core/Infrastructure/Extensions/QueueServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Extensions/QueueServiceExtensions.cs
@@ -2,6 +2,7 @@ using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Infrastructure.Queue;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
@@ -50,13 +51,11 @@ public static class QueueServiceExtensions {
             sp.GetRequiredService<IOptions<QueueSettings>>( )
         ) );
 
-        // Register queue depth metrics if requested
+        // Register queue depth metrics if requested. A hosted service is used so the gauges
+        // are registered eagerly at host start after the DI container is built and Redis is
+        // connected, rather than lazily on first resolution (which never happens for a marker).
         if (registerMetrics) {
-            _ = services.AddSingleton( sp => {
-                IConnectionMultiplexer redis = sp.GetRequiredService<IConnectionMultiplexer>( );
-                QueueMetrics.RegisterQueueDepthGauges( redis );
-                return new QueueMetricsRegistration( );
-            } );
+            _ = services.AddHostedService<QueueMetricsRegistration>( );
         }
 
         return services;
@@ -276,7 +275,18 @@ internal sealed class ProviderQueueResolver<T>(
 }
 
 /// <summary>
-/// Marker class to indicate queue metrics have been registered. Used as a singleton dependency to
-/// ensure metrics are registered exactly once during container build.
+/// Hosted service that eagerly registers the queue-depth observable gauges at host start, after
+/// the DI container is built and the Redis connection is available. Runs once per host startup;
+/// the underlying registration is idempotent so multiple hosts each registering is safe.
 /// </summary>
-internal sealed class QueueMetricsRegistration;
+internal sealed class QueueMetricsRegistration( IConnectionMultiplexer redis ) : IHostedService {
+
+    /// <inheritdoc/>
+    public Task StartAsync( CancellationToken cancellationToken ) {
+        QueueMetrics.RegisterQueueDepthGauges( redis );
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync( CancellationToken cancellationToken ) => Task.CompletedTask;
+}

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -454,6 +454,16 @@ public static class LogEventIds {
             /// </summary>
             public const int RedisSagaStateManagerSecondariesQueuedMarker = 1316;
 
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogFinalizeClaimMarker"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerFinalizeClaimMarker = 1317;
+
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogFinalizeClaimReleased"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerFinalizeClaimReleased = 1318;
+
             // RedisRequestDeduplicator (1350-1374)
 
             /// <summary>

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestQueue.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestQueue.cs
@@ -112,6 +112,14 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// <param name="logger">Logger for diagnostic information.</param>
     /// <param name="settings">Queue configuration settings.</param>
     /// <param name="provider">The provider this queue serves.</param>
+    /// <param name="keyPrefix">
+    /// Optional segment inserted between <c>"queue:"</c> and the provider in every stream
+    /// key. The value carries no separators — they are added internally — so
+    /// <c>"runtoken"</c> yields <c>"queue:runtoken:{provider}:interactive"</c>. When
+    /// <see langword="null"/> or empty the default <c>"queue:{provider}:…"</c> layout is
+    /// used. This parameter exists for test isolation only; do not supply it from
+    /// production callers.
+    /// </param>
     /// <remarks>
     /// A configured aging interval of 1 or less is treated as a misconfiguration and replaced with
     /// a default of 8 (logged), keeping the starvation-prevention logic well-defined.
@@ -121,7 +129,8 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         IConnectionMultiplexer redis,
         ILogger<RedisRequestQueue<T>> logger,
         IOptions<QueueSettings> settings,
-        SupportedProviders provider
+        SupportedProviders provider,
+        string? keyPrefix = null
     ) {
         _redis = redis ?? throw new ArgumentNullException( nameof( redis ) );
         _logger = logger ?? throw new ArgumentNullException( nameof( logger ) );
@@ -142,10 +151,13 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         }
 
         string providerName = provider.ToString( ).ToLowerInvariant( );
-        _interactiveStream = $"queue:{providerName}:interactive";
-        _backgroundStream = $"queue:{providerName}:background";
-        _bulkStream = $"queue:{providerName}:bulk";
-        _dlqStream = $"queue:{providerName}:dlq";
+        string queuePrefix = string.IsNullOrEmpty( keyPrefix )
+            ? $"queue:{providerName}"
+            : $"queue:{keyPrefix}:{providerName}";
+        _interactiveStream = $"{queuePrefix}:interactive";
+        _backgroundStream = $"{queuePrefix}:background";
+        _bulkStream = $"{queuePrefix}:bulk";
+        _dlqStream = $"{queuePrefix}:dlq";
 
         _consumerGroup = $"{providerName}-workers";
         _consumerId = $"{providerName}-worker-{Guid.NewGuid( ):N}";

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -83,6 +83,9 @@ public sealed partial class RedisSagaStateManager(
     /// <summary>Core hash field: single-winner marker that secondary lookups were queued. Literal: <c>"secondariesQueued"</c>.</summary>
     private const string FieldSecondariesQueued = "secondariesQueued";
 
+    /// <summary>Core hash field: single-winner marker that finalization has been claimed. Literal: <c>"finalizeClaimed"</c>.</summary>
+    private const string FieldFinalizeClaimed = "finalizeClaimed";
+
     // Hash field names for provider state
 
     /// <summary>Provider hash field: whether the provider has finished. Literal: <c>"isComplete"</c>.</summary>
@@ -154,14 +157,14 @@ public sealed partial class RedisSagaStateManager(
             }
         }
 
-        // Create new saga
+        // Create new saga. finalResultUri is intentionally not pre-populated so the
+        // When.NotExists guard in SetFinalResultUriAsync can enforce first-writer-wins.
         List<HashEntry> sagaHashEntries = [
             new HashEntry( FieldLookupKey, lookupKey ),
             new HashEntry( FieldLookupType, lookupType.ToString() ),
             new HashEntry( FieldLookupValue, lookupValue ),
             new HashEntry( FieldCreatedAt, DateTimeOffset.UtcNow.ToString( "O" ) ),
             new HashEntry( FieldPartialResultUri, RedisValue.EmptyString ),
-            new HashEntry( FieldFinalResultUri, RedisValue.EmptyString )
         ];
 
         if (originPriority.HasValue) {
@@ -368,7 +371,7 @@ public sealed partial class RedisSagaStateManager(
         IDatabase db = _redis.GetDatabase( );
         TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
 
-        _ = await db.HashSetAsync( key, FieldFinalResultUri, uri );
+        _ = await db.HashSetAsync( key, FieldFinalResultUri, uri, When.NotExists );
         _ = await db.KeyExpireAsync( key, ttl );
 
         // Remove from pending index since saga is now finalized
@@ -500,6 +503,51 @@ public sealed partial class RedisSagaStateManager(
         LogSecondariesQueuedMarker( _logger, sagaId, acquired );
 
         return acquired;
+    }
+
+    /// <summary>
+    /// Atomically claims the exclusive right to finalize a saga, so exactly one concurrent
+    /// trigger performs the PDS write.
+    /// </summary>
+    /// <param name="sagaId">The saga to claim finalization for.</param>
+    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
+    /// <returns>True if this caller won the claim (and must finalize); false if another caller already holds it.</returns>
+    /// <remarks>Uses a hash set with "when not exists" semantics (HSETNX) so exactly one caller wins.</remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
+    public async Task<bool> TryClaimFinalizeAsync( string sagaId, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+
+        string key = GetSagaKey( sagaId );
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+
+        bool acquired = await db.HashSetAsync( key, FieldFinalizeClaimed, true.ToString( ), When.NotExists );
+        _ = await db.KeyExpireAsync( key, ttl );
+
+        LogFinalizeClaimMarker( _logger, sagaId, acquired );
+
+        return acquired;
+    }
+
+    /// <summary>
+    /// Releases a finalize claim so a legitimate retry can re-finalize after a failed PDS write.
+    /// Must only be called on the failure path; successful finalizations leave the claim set until TTL expiry.
+    /// </summary>
+    /// <param name="sagaId">The saga whose finalize claim should be released.</param>
+    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
+    /// <returns>A task that completes once the claim field has been deleted.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
+    public async Task ReleaseFinalizeClaimAsync( string sagaId, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+
+        string key = GetSagaKey( sagaId );
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+
+        _ = await db.HashDeleteAsync( key, FieldFinalizeClaimed );
+        _ = await db.KeyExpireAsync( key, ttl );
+
+        LogFinalizeClaimReleased( _logger, sagaId );
     }
 
     /// <summary>
@@ -884,6 +932,25 @@ public sealed partial class RedisSagaStateManager(
         Level = LogLevel.Debug,
         Message = "Secondaries-queued marker for saga {SagaId}: acquired={Acquired}" )]
     internal static partial void LogSecondariesQueuedMarker( ILogger logger, string sagaId, bool acquired );
+
+    /// <summary>Logs the outcome of the atomic finalize claim attempt.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="sagaId">The saga id.</param>
+    /// <param name="acquired">Whether this caller won the claim.</param>
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerFinalizeClaimMarker,
+        Level = LogLevel.Debug,
+        Message = "Finalize claim for saga {SagaId}: acquired={Acquired}" )]
+    internal static partial void LogFinalizeClaimMarker( ILogger logger, string sagaId, bool acquired );
+
+    /// <summary>Logs that a finalize claim was released so a retry can re-finalize.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="sagaId">The saga id.</param>
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerFinalizeClaimReleased,
+        Level = LogLevel.Debug,
+        Message = "Finalize claim released for saga {SagaId}" )]
+    internal static partial void LogFinalizeClaimReleased( ILogger logger, string sagaId );
 
     #endregion
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/BridgeBeats.Worker.SagaCoordinator.csproj
+++ b/src/BridgeBeats.Worker.SagaCoordinator/BridgeBeats.Worker.SagaCoordinator.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\BridgeBeats.Core\BridgeBeats.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BridgeBeats.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
@@ -164,4 +164,7 @@ public static class LogEventIds {
 
     /// <summary>No secondary lookups could be enqueued; finalization is deferred so waiters get a partial result and the saga is retried after it expires.</summary>
     public const int NoSecondariesEnqueued = 5053;
+
+    /// <summary>The finalize claim for a saga was already held by another handler; this handler is skipping finalization.</summary>
+    public const int FinalizationClaimLost = 5054;
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -413,14 +413,27 @@ public sealed partial class SagaCoordinatorBackgroundService(
             return;
         }
 
+        // Atomically claim the exclusive right to finalize this saga. Exactly one concurrent
+        // handler wins; losers return silently so only one PDS write occurs.
+        bool claimed = await _sagaManager.TryClaimFinalizeAsync( saga.SagaId, ct );
+        if (!claimed) {
+            LogFinalizationClaimLost( _logger, saga.SagaId );
+            return;
+        }
+
+        bool uriRecorded = false;
+
         try {
             // Write to ATProto
             string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( finalResult, ct );
 
             LogWroteFinalToAtProto( _logger, saga.SagaId, recordUri );
 
-            // Update saga with final result URI
+            // Update saga with final result URI. The durability line: once this returns the URI is
+            // durably stored. A failure after this point must NOT release the claim — re-entering
+            // would issue a second PDS write against an already-recorded URI.
             await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
+            uriRecorded = true;
 
             // Clear the partial flag - the saga now represents a complete result
             await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
@@ -434,13 +447,39 @@ public sealed partial class SagaCoordinatorBackgroundService(
             await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
 
             LogSuccessfullyFinalized( _logger, saga.SagaId, finalResult.Results.Count );
+        } catch (OperationCanceledException) {
+            // Before the durability line: release the claim so the next host restart can re-finalize.
+            // After the durability line: retain the claim — re-entering would issue a second PDS write
+            // against a URI that is already recorded. The dedup lock is never released here in either
+            // case (the saga is healthy; no premature empty completion).
+            if (!uriRecorded) {
+                await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, CancellationToken.None );
+            }
+            throw;
         } catch (Exception ex) {
             LogFailedToWriteFinal( _logger, ex, saga.SagaId );
 
-            // Release the lock anyway to unblock waiters
-            await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+            // Only release the claim and dedup lock when the URI has not yet been durably recorded.
+            // If the URI is already recorded, retaining the claim prevents a re-entrant PDS write;
+            // releasing the dedup lock with null here would hand waiters an empty result for a saga
+            // that succeeded — a clean lock timeout is strictly better in that case.
+            if (!uriRecorded) {
+                await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, ct );
+                await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+            }
         }
     }
+
+    /// <summary>
+    /// Test-only entry point that delegates directly to <see cref="WriteFinalResultAsync"/> so
+    /// integration tests can drive the finalize claim path without running the full
+    /// <see cref="ExecuteAsync"/> polling loop. Not used in production code paths.
+    /// </summary>
+    /// <param name="saga">The saga to finalize.</param>
+    /// <param name="ct">A token that cancels the operation.</param>
+    /// <returns>A task that completes when finalization (or its failure cleanup) is done.</returns>
+    internal Task InvokeFinalizeForTestAsync( LookupSagaState saga, CancellationToken ct )
+        => WriteFinalResultAsync( saga, ct );
 
     /// <summary>
     /// Writes an interim partial result for a saga whose providers have not all completed (for example
@@ -690,8 +729,11 @@ public sealed partial class SagaCoordinatorBackgroundService(
             // set, so finalizing now would publish a result that is missing providers as
             // complete and overwrite richer cached data. Waiters receive the honest partial
             // instead; the cache marks partial results stale, so the lookup is retried once
-            // the saga expires.
+            // the queue backend recovers. Remove the saga from the reconciliation index so
+            // it does not strand as an actionable pending entry until TTL expiry. The saga
+            // record itself remains readable until TTL so late GetAsync calls still resolve.
             LogNoSecondariesEnqueued( _logger, originalSaga.SagaId, externalId );
+            await _sagaManager.RemoveFromPendingIndexAsync( originalSaga.SagaId, ct );
         }
 
         // Pending provider states exist and the saga is marked partial, so the caller must
@@ -1003,6 +1045,15 @@ public sealed partial class SagaCoordinatorBackgroundService(
         Level = LogLevel.Warning,
         Message = "Saga {SagaId} completed with no successful results, cleaning up" )]
     private static partial void LogNoSuccessfulResults( ILogger logger, string sagaId );
+
+    /// <summary>Logs that this handler lost the finalize claim race and is deferring to the winner.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="sagaId">The saga whose finalize claim was already held.</param>
+    [LoggerMessage(
+        EventId = LogEventIds.FinalizationClaimLost,
+        Level = LogLevel.Debug,
+        Message = "Finalize claim for saga {SagaId} already held by another handler; skipping" )]
+    private static partial void LogFinalizationClaimLost( ILogger logger, string sagaId );
 
     /// <summary>Logs that the final result was written to the ATProto PDS.</summary>
     /// <param name="logger">The logger to write to.</param>


### PR DESCRIPTION
Closes the saga-finalize duplicate-write amplification (runtime-confirmed at ~8× typical, 66× worst-case), makes the queue/saga failure modes observable, and repairs test isolation that was blinding the queue suite.

# Changes

## Saga finalize — single-winner claim
Finalization had no atomic guard, so three trigger paths (completion channel, pattern subscription, 30-second poll) each performed their own PDS write. Adds an atomic set-if-absent claim (TryClaimFinalizeAsync/ReleaseFinalizeClaimAsync, mirroring the existing secondaries-queued guard) taken before the PDS write; losers return silently. The claim is released only on a failure before the result URI is durably recorded — a failure after that point retains it to prevent a re-entrant write. The final-URI write is also made first-writer-wins as defense-in-depth. Emitters now acknowledge before publishing so redelivery can't re-finalize, and a saga whose secondaries all fail to enqueue reaches a terminal state instead of stranding until expiry.

## Queue-depth alarms now emit
The OpenTelemetry queue/saga-depth gauges were registered inside an unresolved lazy singleton and never instantiated. Reworked into an eagerly-started hosted service so they register after host build — no host Program.cs changes.

## Test isolation
Two integration test classes cleared the shared queue:* keyspace in setup and wiped each other under parallel runs. Keys are now namespaced per run, with regression guards that fail if a bare-keyspace wipe ever returns.

## Test-naming cleanup (independent)
Renames camelCase const locals to PascalCase in LookupOrchestratorTests.cs to satisfy the project's naming convention. Behavior-neutral; can be split into its own commit.