### PR TITLE
Resolve assorted issues and bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -176,7 +176,6 @@ dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_diagnostic.CA1838.severity = suggestion
 dotnet_diagnostic.CA1848.severity = suggestion
-dotnet_diagnostic.CA1873.severity = suggestion
 dotnet_diagnostic.CA5350.severity = error
 dotnet_diagnostic.CA5351.severity = error
 dotnet_diagnostic.CA5359.severity = warning

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,11 @@ jobs:
           for lockfile in $(find . -name "packages.lock.json" ! -name "*.backup"); do
             backup="${lockfile}.backup"
             if [ -f "$backup" ]; then
-              pwsh containers/Test-LockFileChanges.ps1 -BackupPath "$backup" -CurrentPath "$lockfile" -ToPlatform "linux-x64"
+              from_rid=$(grep -oE '"net[0-9.]+/(linux|win|osx)-(x64|x86|arm64|arm)"' "$backup" \
+                | head -n1 | sed -E 's#.*/([a-z0-9-]+)"#\1#')
+              [ -z "$from_rid" ] && from_rid="linux-x64"
+              pwsh containers/Test-LockFileChanges.ps1 -BackupPath "$backup" -CurrentPath "$lockfile" \
+                -FromPlatform "$from_rid" -ToPlatform "linux-x64"
               rm -f "$backup"
             fi
           done

--- a/Tests/CustomWebApplicationFactory.cs
+++ b/Tests/CustomWebApplicationFactory.cs
@@ -30,6 +30,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Web.Program> {
     private readonly Dictionary<string, string?> _configData;
     /// <summary>Filesystem path of this instance's isolated SQLite identity database.</summary>
     private readonly string _identityDbPath;
+    /// <summary>ATProto environment variables overridden for this factory, with their prior process values, restored on dispose to prevent cross-test contamination.</summary>
+    private readonly List<(string Name, string? PriorValue)> _atProtoEnvRestore;
 
     /// <summary>
     /// Creates a factory with the default test configuration and no overrides.
@@ -69,13 +71,23 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Web.Program> {
             ["Aspire:StackExchange:Redis:ConnectionString"] = redisConnectionString,
         };
 
-        // CRITICAL: Set environment variables for ATProto settings to ensure they override user secrets.
-        // The WebApplicationFactory's ConfigureAppConfiguration runs AFTER the app binds configuration,
-        // but environment variables are loaded via AddEnvironmentVariables() which runs during app startup.
-        // This ensures test overrides take effect before DID validation runs.
-        Environment.SetEnvironmentVariable( "BridgeBeats__ATProtoIdentifier", "" );
-        Environment.SetEnvironmentVariable( "BridgeBeats__ATProtoPassword", "" );
-        Environment.SetEnvironmentVariable( "BridgeBeats__ATProtoUserDID", "" );
+        // Force the three ATProto settings empty so the host does not pick up a developer's
+        // local user-secret credentials (which would trip DID validation during service
+        // registration). These must be environment variables: the host binds AppSettings and
+        // runs ATProto validation during eager service registration, before this factory's
+        // in-memory configuration is applied, so the in-memory overlay would land too late.
+        // Prior values are captured and restored in Dispose to keep the override scoped to
+        // this factory's lifetime.
+        string[] atProtoKeys = [
+            "BridgeBeats__ATProtoIdentifier",
+            "BridgeBeats__ATProtoPassword",
+            "BridgeBeats__ATProtoUserDID",
+        ];
+        _atProtoEnvRestore = [];
+        foreach (string key in atProtoKeys) {
+            _atProtoEnvRestore.Add( (key, Environment.GetEnvironmentVariable( key )) );
+            Environment.SetEnvironmentVariable( key, "" );
+        }
 
         // Merge overrides onto defaults (overrides win), EXCEPT for critical test infrastructure keys
         // that must always use the test container connection
@@ -259,13 +271,20 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Web.Program> {
     }
 
     /// <summary>
-    /// Disposes the test host and deletes this instance's SQLite identity database file.
+    /// Disposes the test host, restores ATProto environment variables to their pre-construction
+    /// values, and deletes this instance's SQLite identity database file.
     /// </summary>
     /// <param name="disposing"><c>true</c> when called from <c>Dispose</c> rather than a finalizer.</param>
     protected override void Dispose( bool disposing ) {
         base.Dispose( disposing );
 
         if (disposing) {
+            // Restore the ATProto env vars captured in the constructor so this factory does
+            // not leak empty ATProto settings into other tests in the same process.
+            foreach ((string name, string? priorValue) in _atProtoEnvRestore) {
+                Environment.SetEnvironmentVariable( name, priorValue );
+            }
+
             // Clean up temp database files
             TryDeleteFile( _identityDbPath );
         }

--- a/Tests/Integration/CustomWebApplicationFactoryEnvIsolationTests.cs
+++ b/Tests/Integration/CustomWebApplicationFactoryEnvIsolationTests.cs
@@ -1,0 +1,170 @@
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>
+/// Verifies that <see cref="CustomWebApplicationFactory"/> captures the prior process values of the
+/// three ATProto environment variables in its constructor and fully restores them on dispose,
+/// with no residual state after dispose — including when the keys started unset (null, not empty string).
+/// </summary>
+/// <remarks>
+/// [DoNotParallelize]: the factory constructor sets process-wide environment variables
+/// (BridgeBeats__ATProtoIdentifier, BridgeBeats__ATProtoPassword, BridgeBeats__ATProtoUserDID)
+/// and restores them in Dispose. Running in parallel with another class that mutates overlapping
+/// keys would cause order-dependent contamination. This class must run in the serial phase.
+/// </remarks>
+[TestClass]
+[DoNotParallelize]
+[TestCategory( "Integration" )]
+[TestCategory( "Docker" )]
+public class CustomWebApplicationFactoryEnvIsolationTests {
+
+    private const string IdentifierKey = "BridgeBeats__ATProtoIdentifier";
+    private const string PasswordKey   = "BridgeBeats__ATProtoPassword";
+    private const string UserDidKey    = "BridgeBeats__ATProtoUserDID";
+
+    private static readonly string[] s_atProtoKeys = [ IdentifierKey, PasswordKey, UserDidKey ];
+
+    // Ambient env values captured before each test; restored after each test so this class
+    // does not itself contaminate the suite.
+    private readonly Dictionary<string, string?> _ambientSnapshot = [];
+
+    /// <summary>Snapshot the ambient env values before each test.</summary>
+    [TestInitialize]
+    public void SnapshotAmbient( ) {
+        foreach (string key in s_atProtoKeys) {
+            _ambientSnapshot[key] = Environment.GetEnvironmentVariable( key );
+        }
+    }
+
+    /// <summary>Restore the ambient env values after each test.</summary>
+    [TestCleanup]
+    public void RestoreAmbient( ) {
+        foreach (string key in s_atProtoKeys) {
+            Environment.SetEnvironmentVariable( key, _ambientSnapshot.TryGetValue( key, out string? v ) ? v : null );
+        }
+    }
+
+    /// <summary>
+    /// After construction, the three ATProto keys are forced to the empty string; after dispose,
+    /// they are restored to their pre-construction values (non-empty sentinel case).
+    /// The mid-construction check ensures the ctor actually set the keys, ruling out a vacuous restore.
+    /// </summary>
+    [TestMethod]
+    public void DisposedFactory_RestoresPriorValue_WhenKeysHadNonEmptyValues( ) {
+        // Arrange: plant known non-empty baseline values
+        Environment.SetEnvironmentVariable( IdentifierKey, "QA_PRIOR_SENTINEL_Identifier" );
+        Environment.SetEnvironmentVariable( PasswordKey, "QA_PRIOR_SENTINEL_Password" );
+        Environment.SetEnvironmentVariable( UserDidKey, "QA_PRIOR_SENTINEL_UserDID" );
+
+        CustomWebApplicationFactory factory = new( );
+
+        // Positive control: verify the ctor forced each key empty
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( IdentifierKey ), "ctor must force key to \"\" (IdentifierKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( PasswordKey ), "ctor must force key to \"\" (PasswordKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( UserDidKey ), "ctor must force key to \"\" (UserDidKey)" );
+
+        // Act
+        factory.Dispose( );
+
+        // Assert: keys are restored to their pre-construction sentinel values
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_Identifier", Environment.GetEnvironmentVariable( IdentifierKey ) );
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_Password", Environment.GetEnvironmentVariable( PasswordKey ) );
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_UserDID", Environment.GetEnvironmentVariable( UserDidKey ) );
+    }
+
+    /// <summary>
+    /// After construction, the three ATProto keys are forced to the empty string; after dispose,
+    /// they are restored to null (absent) — not to the empty string — when the keys started unset.
+    /// This is the null-correctness discriminator: a wrong implementation that coerces null to ""
+    /// will pass the sentinel test above but fail here.
+    /// </summary>
+    [TestMethod]
+    public void DisposedFactory_RestoresAbsent_WhenKeysWereUnset( ) {
+        // Arrange: ensure the keys are unset before construction
+        foreach (string key in s_atProtoKeys) {
+            Environment.SetEnvironmentVariable( key, null );
+        }
+
+        CustomWebApplicationFactory factory = new( );
+
+        // Positive control: verify the ctor forced each key empty
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( IdentifierKey ), "ctor must force key to \"\" (IdentifierKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( PasswordKey ), "ctor must force key to \"\" (PasswordKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( UserDidKey ), "ctor must force key to \"\" (UserDidKey)" );
+
+        // Act
+        factory.Dispose( );
+
+        // Assert: keys are absent (null), not empty-string sentinels
+        Assert.IsNull( Environment.GetEnvironmentVariable( IdentifierKey ), "key must be absent (null) after dispose — not coerced to \"\"" );
+        Assert.IsNull( Environment.GetEnvironmentVariable( PasswordKey ), "key must be absent (null) after dispose — not coerced to \"\"" );
+        Assert.IsNull( Environment.GetEnvironmentVariable( UserDidKey ), "key must be absent (null) after dispose — not coerced to \"\"" );
+    }
+
+    /// <summary>
+    /// Two factories constructed and disposed sequentially leave the keys absent when they started
+    /// absent. Catches static/once-only capture, A-residue capture (factory A failing to restore
+    /// before factory B captures), and coerce-to-"" across two lifetimes simultaneously.
+    /// </summary>
+    [TestMethod]
+    public void TwoSequentialFactories_LeaveAbsentBaseline_WhenKeysStartedUnset( ) {
+        // Arrange: ensure the keys are unset
+        foreach (string key in s_atProtoKeys) {
+            Environment.SetEnvironmentVariable( key, null );
+        }
+
+        // Factory A lifetime
+        CustomWebApplicationFactory factoryA = new( );
+
+        // Positive control: A's ctor forced the keys empty
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( IdentifierKey ), "A's ctor must force key to \"\" (IdentifierKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( PasswordKey ), "A's ctor must force key to \"\" (PasswordKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( UserDidKey ), "A's ctor must force key to \"\" (UserDidKey)" );
+
+        factoryA.Dispose( );
+
+        // After A's dispose the absent baseline is restored
+        Assert.IsNull( Environment.GetEnvironmentVariable( IdentifierKey ), "keys must be absent after A's dispose" );
+        Assert.IsNull( Environment.GetEnvironmentVariable( PasswordKey ), "keys must be absent after A's dispose" );
+        Assert.IsNull( Environment.GetEnvironmentVariable( UserDidKey ), "keys must be absent after A's dispose" );
+
+        // Factory B lifetime — B's captured-prior must be null (restored by A), not ""
+        CustomWebApplicationFactory factoryB = new( );
+
+        // Positive control: B's ctor forced the keys empty
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( IdentifierKey ), "B's ctor must force key to \"\" (IdentifierKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( PasswordKey ), "B's ctor must force key to \"\" (PasswordKey)" );
+        Assert.AreEqual( "", Environment.GetEnvironmentVariable( UserDidKey ), "B's ctor must force key to \"\" (UserDidKey)" );
+
+        factoryB.Dispose( );
+
+        // Final assertion: still absent after both lifetimes
+        Assert.IsNull( Environment.GetEnvironmentVariable( IdentifierKey ) );
+        Assert.IsNull( Environment.GetEnvironmentVariable( PasswordKey ) );
+        Assert.IsNull( Environment.GetEnvironmentVariable( UserDidKey ) );
+    }
+
+    /// <summary>
+    /// Two factories constructed and disposed sequentially preserve a non-empty sentinel baseline.
+    /// Confirms the value-present path is lifetime-stable across two factory instances.
+    /// </summary>
+    [TestMethod]
+    public void TwoSequentialFactories_PreserveSentinelBaseline_WhenKeysHadNonEmptyValues( ) {
+        // Arrange: plant known sentinel values
+        Environment.SetEnvironmentVariable( IdentifierKey, "QA_PRIOR_SENTINEL_Identifier" );
+        Environment.SetEnvironmentVariable( PasswordKey, "QA_PRIOR_SENTINEL_Password" );
+        Environment.SetEnvironmentVariable( UserDidKey, "QA_PRIOR_SENTINEL_UserDID" );
+
+        // Factory A lifetime
+        CustomWebApplicationFactory factoryA = new( );
+        factoryA.Dispose( );
+
+        // Factory B lifetime
+        CustomWebApplicationFactory factoryB = new( );
+        factoryB.Dispose( );
+
+        // Both lifetimes must leave the sentinel intact
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_Identifier", Environment.GetEnvironmentVariable( IdentifierKey ) );
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_Password", Environment.GetEnvironmentVariable( PasswordKey ) );
+        Assert.AreEqual( "QA_PRIOR_SENTINEL_UserDID", Environment.GetEnvironmentVariable( UserDidKey ) );
+    }
+}

--- a/Tests/Unit/JetStreamWatcherServiceTests.cs
+++ b/Tests/Unit/JetStreamWatcherServiceTests.cs
@@ -1,0 +1,300 @@
+using System.Text.Json;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Worker.JetStreamWatcher;
+using BridgeBeats.Worker.JetStreamWatcher.Logging;
+using idunno.Bluesky;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="JetStreamWatcherService.HandleCommitRecordAsync"/>, the extracted
+/// per-record dispatch method that is the validation boundary for firehose records. Verifies that
+/// malformed records are skipped cleanly and logged at Warning exactly once; that well-formed records
+/// reaching a recognized music link are enqueued; that benign parser errors remain silent; and that
+/// the <c>subject</c> guard in the repost path handles malformed records without throwing.
+/// </summary>
+[TestClass]
+public class JetStreamWatcherServiceTests {
+
+    /// <summary>Mocked provider queue resolver injected into the service under test.</summary>
+    private Mock<IProviderQueueResolver<QueuedLookupRequest>> _queueResolverMock = null!;
+    /// <summary>Mocked per-provider queue the resolver returns.</summary>
+    private Mock<IRequestQueue<QueuedLookupRequest>> _queueMock = null!;
+    /// <summary>Mocked logger used to assert log-level and EventId assertions.</summary>
+    private Mock<ILogger<JetStreamWatcherService>> _loggerMock = null!;
+
+    /// <summary>MSTest-injected test context; provides per-test cancellation.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Creates fresh mocks before each test.</summary>
+    [TestInitialize]
+    public void Initialize( ) {
+        _queueResolverMock = new Mock<IProviderQueueResolver<QueuedLookupRequest>>( );
+        _queueMock = new Mock<IRequestQueue<QueuedLookupRequest>>( );
+        _loggerMock = new Mock<ILogger<JetStreamWatcherService>>( );
+
+        // Stub IsEnabled true so [LoggerMessage]-gated calls reach Log() and Verify() is non-vacuous.
+        // This is required because [LoggerMessage] source-generated code gates every call with
+        // IsEnabled(); without this setup Moq returns false and Times.Once is vacuously unsatisfied.
+        _ = _loggerMock.Setup( l => l.IsEnabled( It.IsAny<LogLevel>( ) ) ).Returns( true );
+
+        // Stub the resolver to return the queue mock for any provider
+        _ = _queueResolverMock.Setup( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ) )
+            .Returns( _queueMock.Object );
+        _ = _queueMock.Setup( q => q.EnqueueAsync(
+                It.IsAny<QueuedLookupRequest>( ),
+                It.IsAny<QueuePriority>( ),
+                It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+    }
+
+    /// <summary>
+    /// A repost record missing the <c>subject</c> property is skipped cleanly (nothing enqueued)
+    /// and <c>LogRecordProcessingError</c> is never invoked, because the <c>TryGetProperty</c>
+    /// guard returns before throwing. The method completes without exception.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithRepostMissingSubject_ShouldSkipAndNotErrorLog( ) {
+        // Arrange: syntactically valid JSON, but the repost shape is missing 'subject'
+        JsonDocument record = JsonDocument.Parse( """{"$type":"app.bsky.feed.repost","missing":"field"}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act: must not throw
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.repost", agent, TestContext.CancellationToken );
+
+        // Assert: nothing enqueued — skipped cleanly
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        // Assert: the error log must NOT fire for a graceful early-return (this is not a crash path)
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A repost record with <c>subject</c> present but missing the <c>uri</c> field within it is
+    /// also skipped cleanly and does not trigger the error log.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithRepostSubjectMissingUri_ShouldSkipAndNotErrorLog( ) {
+        // Arrange: subject present but no uri inside it
+        JsonDocument record = JsonDocument.Parse( """{"$type":"app.bsky.feed.repost","subject":{"cid":"bafyreiabc123"}}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.repost", agent, TestContext.CancellationToken );
+
+        // Assert: nothing enqueued
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A post record that cannot be deserialized to a <c>Post</c> (returns null) is skipped
+    /// without invoking the error log, because null deserialization is handled by an early-return
+    /// guard and is not an unexpected error.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithNonDeserializablePostRecord_ShouldSkipWithoutErrorLog( ) {
+        // Arrange: JSON that parses but does not deserialize to a valid Post
+        JsonDocument record = JsonDocument.Parse( """{"completely":"unrelated","data":42}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.post", agent, TestContext.CancellationToken );
+
+        // Assert: nothing enqueued
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        // Assert: the error log must NOT fire — null deserialization is handled by early-return
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// An unrecognized collection is ignored without enqueuing or error-logging, confirming the
+    /// dispatch ignores unknown collections cleanly.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithUnknownCollection_ShouldSkipWithoutErrorLog( ) {
+        // Arrange
+        JsonDocument record = JsonDocument.Parse( """{"data":"anything"}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act
+        await service.HandleCommitRecordAsync( record, "app.bsky.graph.follow", agent, TestContext.CancellationToken );
+
+        // Assert
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A post record containing a facet with an empty <c>features</c> array is skipped silently
+    /// without firing <c>LogRecordProcessingError</c>. The <see cref="idunno.Bluesky.RichText.Facet"/>
+    /// constructor enforces <c>features.Count &gt;= 1</c> and throws
+    /// <see cref="ArgumentOutOfRangeException"/> when this constraint is violated; that message
+    /// starts with <c>"features.Count"</c>, which the <c>IsExpectedParsingError</c> allowlist
+    /// matches, so the exception is swallowed rather than promoted to a Warning. This confirms
+    /// that the floor-lift from Debug to Warning does not affect benign-allowlisted errors.
+    /// The discriminating property: if <c>IsExpectedParsingError</c> were removed or its allowlist
+    /// did not cover <c>"features.Count"</c>, the <see cref="ArgumentOutOfRangeException"/> would
+    /// reach <c>LogRecordProcessingError</c> and the <c>Times.Never</c> assertion below would fail.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithExpectedBenignParserError_ShouldSkipSilentlyWithoutErrorLog( ) {
+        // Arrange: a post with a facet whose features array is empty. The Facet JsonConstructor
+        // calls ArgumentOutOfRangeException.ThrowIfZero(features.Count, "features.Count"), which
+        // throws a non-JsonException with a message starting with "features.Count". System.Text.Json
+        // does not wrap this in JsonException, so it propagates to the catch (Exception ex) block
+        // in HandleCommitRecordAsync, where IsExpectedParsingError returns true and suppresses it.
+        JsonDocument record = JsonDocument.Parse(
+            """{"$type":"app.bsky.feed.post","text":"hello","facets":[{"index":{"byteStart":0,"byteEnd":5},"features":[]}]}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act — must not propagate; the service must remain operational after the benign error
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.post", agent, TestContext.CancellationToken );
+
+        // Assert: the Warning RecordProcessingError must NOT fire for benign/expected errors.
+        // The IsEnabled(true) stub in Initialize() ensures this is a discriminating check:
+        // if IsExpectedParsingError did not suppress this ArgumentOutOfRangeException, Log()
+        // would be called and Times.Never would fail.
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A repost record where <c>subject</c> is present but is a JSON string (not an object) is
+    /// skipped silently: the type check on <c>subject.ValueKind</c> short-circuits before any
+    /// property access that would throw on a non-object element. Neither an enqueue nor a
+    /// Warning-level <c>LogRecordProcessingError</c> is emitted.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithRepostSubjectAsNonObject_ShouldSkipSilentlyWithoutErrorLog( ) {
+        // Arrange: subject is a JSON string, not an object — type-confused firehose input
+        JsonDocument record = JsonDocument.Parse( """{"$type":"app.bsky.feed.repost","subject":"not-an-object"}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act: must not throw
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.repost", agent, TestContext.CancellationToken );
+
+        // Assert: nothing enqueued — skipped cleanly
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        // Assert: the IsEnabled(true) stub ensures this Times.Never check is non-vacuous.
+        // Without the ValueKind guard, TryGetProperty on a non-object element throws
+        // InvalidOperationException, which propagates to LogRecordProcessingError at Warning.
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A repost record where <c>subject</c> is a valid object but <c>subject.uri</c> is a JSON
+    /// number (not a string) is skipped silently: the type check on <c>uriElement.ValueKind</c>
+    /// short-circuits before <c>GetString()</c>, which would throw on a non-string element.
+    /// Neither an enqueue nor a Warning-level <c>LogRecordProcessingError</c> is emitted.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task HandleRecord_WithRepostUriAsNonString_ShouldSkipSilentlyWithoutErrorLog( ) {
+        // Arrange: subject is an object but uri is a JSON number — type-confused firehose input
+        JsonDocument record = JsonDocument.Parse( """{"$type":"app.bsky.feed.repost","subject":{"uri":42,"cid":"bafyreiabc123"}}""" );
+        JetStreamWatcherService service = CreateService( );
+        using BlueskyAgent agent = new( );
+
+        // Act: must not throw
+        await service.HandleCommitRecordAsync( record, "app.bsky.feed.repost", agent, TestContext.CancellationToken );
+
+        // Assert: nothing enqueued — skipped cleanly
+        _queueMock.Verify(
+            q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+
+        // Assert: the IsEnabled(true) stub ensures this Times.Never check is non-vacuous.
+        // Without the ValueKind guard, GetString() on a Number element throws
+        // InvalidOperationException, which propagates to LogRecordProcessingError at Warning.
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                new EventId( LogEventIds.RecordProcessingError ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// Builds a <see cref="JetStreamWatcherService"/> with mocked dependencies.
+    /// </summary>
+    private JetStreamWatcherService CreateService( ) =>
+        new( _loggerMock.Object, _queueResolverMock.Object );
+}
+
+#pragma warning restore CS1591

--- a/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
+++ b/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
@@ -579,6 +579,221 @@ public class QueueProcessorBackgroundServiceTests {
         _lookupServiceMock.Verify( l => l.GetInfoAsync( "Test Song", "Test Artist" ), Times.Once );
     }
 
+    /// <summary>
+    /// A <see cref="LookupRequestType.ArtistLookup"/> request routes to <c>GetInfoAsync(title, artist)</c>,
+    /// drawing the title and artist from the request.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PerformLookup_WithArtistLookup_ShouldCallGetInfoAsyncWithTitleArtist( ) {
+        // Arrange
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.ArtistLookup, "ignored" ) with {
+            Title = "Test Album",
+            Artist = "Test Artist"
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoAsync( "Test Album", "Test Artist" ) )
+            .ReturnsAsync( CreateLookupResult( ) );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert: ArtistLookup arm routes to GetInfoAsync(title, artist)
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( "Test Album", "Test Artist" ), Times.Once );
+        // Negative discriminator: URI lookup is not called
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ) ), Times.Never );
+    }
+
+    /// <summary>
+    /// A <see cref="LookupRequestType.ArtistAlbumLookup"/> request with title and artist present
+    /// routes to <c>GetInfoAsync(title, artist)</c>, which performs the artist-to-album expansion
+    /// internally. This verifies that the arm dispatches through the title+artist path and does not
+    /// throw.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PerformLookup_WithArtistAlbumLookupAndTitleArtist_ShouldCallGetInfoAsyncWithTitleArtist( ) {
+        // Arrange
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.ArtistAlbumLookup, "ignored" ) with {
+            Title = "Test Album",
+            Artist = "Test Artist"
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoAsync( "Test Album", "Test Artist" ) )
+            .ReturnsAsync( CreateLookupResult( ) );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act: test failed before implementation (threw NotImplementedException); passes after
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert: dispatches to GetInfoAsync(title, artist) — does not error-path
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( "Test Album", "Test Artist" ), Times.Once );
+        // Discriminator: single-arg URI overload must not be called (only title+artist overload is used)
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ) ), Times.Never );
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                request.SagaId,
+                It.Is<ProviderLookupState>( state => state.IsSuccess ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once );
+    }
+
+    /// <summary>
+    /// A <see cref="LookupRequestType.AlbumTrackLookup"/> request with title and artist present
+    /// routes to <c>GetInfoAsync(title, artist)</c>, which performs the album-to-track expansion
+    /// internally. This verifies that the arm dispatches through the title+artist path and does not
+    /// throw.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PerformLookup_WithAlbumTrackLookupAndTitleArtist_ShouldCallGetInfoAsyncWithTitleArtist( ) {
+        // Arrange
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.AlbumTrackLookup, "ignored" ) with {
+            Title = "Test Track",
+            Artist = "Test Artist"
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoAsync( "Test Track", "Test Artist" ) )
+            .ReturnsAsync( CreateLookupResult( ) );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act: test failed before implementation (threw NotImplementedException); passes after
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert: dispatches to GetInfoAsync(title, artist) — does not error-path
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( "Test Track", "Test Artist" ), Times.Once );
+        // Discriminator: single-arg URI overload must not be called (only title+artist overload is used)
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ) ), Times.Never );
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                request.SagaId,
+                It.Is<ProviderLookupState>( state => state.IsSuccess ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once );
+    }
+
+    /// <summary>
+    /// A <see cref="LookupRequestType.ArtistAlbumLookup"/> request missing title or artist falls
+    /// through to the <see cref="InvalidOperationException"/> arm, records a failed provider state,
+    /// and does not call any lookup method.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PerformLookup_WithArtistAlbumLookupMissingTitleArtist_ShouldRecordFailedState( ) {
+        // Arrange: no Title or Artist on the request
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.ArtistAlbumLookup, "some-value" ) with {
+            AttemptCount = 1  // below max so it goes through HandleProcessingExceptionAsync
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert: falls through to error handling — IsSuccess == false, ErrorMessage != null
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                request.SagaId,
+                It.Is<ProviderLookupState>( state =>
+                    !state.IsSuccess &&
+                    state.ErrorMessage != null
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once );
+        // The lookup service is never called
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ), It.IsAny<string>( ) ), Times.Never );
+    }
+
+    /// <summary>
+    /// A <see cref="LookupRequestType.AlbumTrackLookup"/> request missing title or artist falls
+    /// through to the <see cref="InvalidOperationException"/> arm and records a failed provider state.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PerformLookup_WithAlbumTrackLookupMissingTitleArtist_ShouldRecordFailedState( ) {
+        // Arrange: no Title or Artist on the request
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.AlbumTrackLookup, "some-value" ) with {
+            AttemptCount = 1
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+
+        SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
+
+        int callCount = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
+
+        // Act
+        using CancellationTokenSource cts = new( );
+        Task serviceTask = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        // Assert: falls through to error handling
+        _sagaManagerMock.Verify(
+            s => s.UpdateProviderStateAsync(
+                request.SagaId,
+                It.Is<ProviderLookupState>( state =>
+                    !state.IsSuccess &&
+                    state.ErrorMessage != null
+                ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once );
+        _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ), It.IsAny<string>( ) ), Times.Never );
+    }
+
     #endregion
 
     #region Rate Limit Exception Handling Tests

--- a/Tests/Unit/StatisticsServiceTests.cs
+++ b/Tests/Unit/StatisticsServiceTests.cs
@@ -33,6 +33,9 @@ public class StatisticsServiceTests {
     /// <summary>Statistics settings (PDS URI, user DID, refresh interval, cache TTL) under test.</summary>
     private StatisticsSettings _settings = null!;
 
+    /// <summary>MSTest-injected context; provides per-test cancellation tokens.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
     /// <summary>Test PDS URI the service enumerates records from.</summary>
     private static readonly Uri s_testPdsUri = new( "https://pds.test.example" );
     /// <summary>Test user DID whose repository is enumerated.</summary>
@@ -354,6 +357,150 @@ public class StatisticsServiceTests {
             URL = "https://open.spotify.com/album/test"
         } );
         return (atUri, result);
+    }
+
+    /// <summary>
+    /// Verifies that two successive periodic refreshes (with a non-trivial simulated compute
+    /// duration) both proceed without the second being skipped. This test is designed to
+    /// discriminate between the fixed START-anchored expiry and the old COMPLETION-anchored expiry.
+    ///
+    /// Timing (all relative to the first refresh START):
+    /// <list type="bullet">
+    ///   <item>t=0ms: first refresh starts; <c>refreshStart</c> is captured.</item>
+    ///   <item>t≈100ms: first refresh completes (simulated 100 ms compute delay).</item>
+    ///   <item>Fixed code: <c>_cacheExpiry = refreshStart + 150ms = t150</c>.</item>
+    ///   <item>Old (buggy) code: <c>_cacheExpiry = completion + 150ms ≈ t250</c>.</item>
+    ///   <item>t≈160ms: second refresh fires (60 ms post-completion wait).</item>
+    ///   <item>t160 &gt; t150 (fixed expiry) → fixed code recomputes (correct).</item>
+    ///   <item>t160 &lt; t250 (old expiry) → old code would still see cache as fresh and skip (bug).</item>
+    /// </list>
+    ///
+    /// If the production code were reverted to completion-anchored expiry, the second refresh at
+    /// t≈160 ms would find <c>now &lt; _cacheExpiry</c> (160 &lt; 250) and skip, making
+    /// <c>countAfterSecond == 1</c> rather than 2, causing the assertion below to fail.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RefreshStatisticsAsync_TwoSuccessivePeriodicRefreshes_NeitherSkipped( ) {
+        // Arrange
+        // CacheDuration = 150ms, ComputeDelay = 100ms, PostCompleteWait = 60ms.
+        // This places the second call at ~t160ms, inside the discriminating window (t150, t250)
+        // where fixed and old code diverge: fixed sees an expired cache (recomputes), old sees a
+        // fresh cache (skips).
+        const int CacheDurationMs = 150;
+        const int ComputeDelayMs = 100;
+        const int PostCompleteWaitMs = 60;
+
+        StatisticsSettings fastSettings = new(
+            s_testPdsUri,
+            TestUserDid,
+            TimeSpan.FromMilliseconds( CacheDurationMs ),
+            TimeSpan.Zero
+        );
+
+        _ = _atProtoStorageMock
+            .Setup( x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( SimulatedSlowEnumerable );
+
+        StatisticsService service = new(
+            _atProtoStorageMock.Object,
+            _redisMock.Object,
+            fastSettings,
+            _loggerMock.Object
+        );
+
+        // Act: first refresh (non-forced, simulates periodic tick 1)
+        _ = await service.RefreshStatisticsAsync( false, CancellationToken.None );
+        int countAfterFirst = _atProtoStorageMock.Invocations.Count( i =>
+            i.Method.Name == nameof( IATProtoStorageService.ListAllRecordsAsync ) );
+
+        // Wait PostCompleteWaitMs after completion (~t160ms from start) — inside the
+        // discriminating window (t150ms fixed expiry, t250ms old completion-anchored expiry).
+        await Task.Delay( PostCompleteWaitMs, TestContext.CancellationToken );
+
+        // Second refresh (non-forced, simulates periodic tick 2)
+        _ = await service.RefreshStatisticsAsync( false, CancellationToken.None );
+        int countAfterSecond = _atProtoStorageMock.Invocations.Count( i =>
+            i.Method.Name == nameof( IATProtoStorageService.ListAllRecordsAsync ) );
+
+        // Assert: both ticks must have resulted in a recompute; the second must not be skipped.
+        Assert.AreEqual( 1, countAfterFirst,
+            "First periodic refresh must enumerate records (not skipped)" );
+        Assert.AreEqual( 2, countAfterSecond,
+            "Second periodic refresh must enumerate records; completion-anchored expiry would still show cache as fresh (~t250ms) at the second call (~t160ms) and skip it" );
+
+        return;
+
+        async IAsyncEnumerable<(string AtUri, MediaLinkResult Result)> SimulatedSlowEnumerable( ) {
+            await Task.Delay( ComputeDelayMs, CancellationToken.None );
+            yield break;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a forced refresh (manual trigger) bypasses the fresh-cache skip guard even
+    /// when the computed expiry would still be in the future, confirming that the start-anchored
+    /// expiry fix preserves the manual-coalescing behavior.
+    /// </summary>
+    [TestMethod]
+    public async Task RefreshStatisticsAsync_ForcedRefreshWhileFresh_AlwaysRecomputes( ) {
+        // Arrange: use a very long cache duration so the cache stays fresh
+        StatisticsSettings longCacheSettings = new(
+            s_testPdsUri,
+            TestUserDid,
+            TimeSpan.FromHours( 24 ),
+            TimeSpan.Zero
+        );
+
+        SetupEmptyRecordList( );
+        StatisticsService service = new(
+            _atProtoStorageMock.Object,
+            _redisMock.Object,
+            longCacheSettings,
+            _loggerMock.Object
+        );
+
+        // First refresh populates cache
+        _ = await service.RefreshStatisticsAsync( false, CancellationToken.None );
+
+        // Force refresh while still fresh
+        _ = await service.RefreshStatisticsAsync( true, CancellationToken.None );
+
+        // Assert: both calls enumerate records — forced bypass is preserved
+        _atProtoStorageMock.Verify(
+            x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 ) );
+    }
+
+    /// <summary>
+    /// Verifies that when the cache has not yet expired, a non-forced refresh is skipped as
+    /// intended (the manual-coalescing guard remains intact after the expiry-anchor fix).
+    /// </summary>
+    [TestMethod]
+    public async Task RefreshStatisticsAsync_NonForcedRefreshWhileFresh_IsSkipped( ) {
+        // Arrange: long cache duration so the second non-forced call sees a fresh cache
+        StatisticsSettings longCacheSettings = new(
+            s_testPdsUri,
+            TestUserDid,
+            TimeSpan.FromHours( 24 ),
+            TimeSpan.Zero
+        );
+
+        SetupEmptyRecordList( );
+        StatisticsService service = new(
+            _atProtoStorageMock.Object,
+            _redisMock.Object,
+            longCacheSettings,
+            _loggerMock.Object
+        );
+
+        _ = await service.RefreshStatisticsAsync( false, CancellationToken.None );
+        _ = await service.RefreshStatisticsAsync( false, CancellationToken.None );
+
+        // Assert: second non-forced call inside the cache window is skipped — only one enumerate
+        _atProtoStorageMock.Verify(
+            x => x.ListAllRecordsAsync( It.IsAny<Uri>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once );
     }
 
     /// <summary>

--- a/Tests/Unit/TidalLinkParserTests.cs
+++ b/Tests/Unit/TidalLinkParserTests.cs
@@ -1,0 +1,218 @@
+using System.Collections.Specialized;
+using System.Web;
+using BridgeBeats.Providers.Tidal;
+
+#pragma warning disable CS1591
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="TidalLinkParser"/> URI builders, verifying that all request templates
+/// emit a single comma-separated <c>include</c> query parameter rather than duplicate parameters.
+/// The TIDAL Open API is JSON:API-compliant; JSON:API requires the <c>include</c> value to be a
+/// single comma-separated list. Duplicate <c>include</c> keys are non-conformant and cause HTTP 400.
+/// Also verifies that the non-<c>include</c> parameters survive template substitution unchanged.
+/// </summary>
+[TestClass]
+public class TidalLinkParserTests {
+
+    /// <summary>
+    /// Verifies that <c>GetTracksIsrcURI</c> emits exactly one <c>include</c> parameter whose value
+    /// is the comma-separated set of albums and artists, and that the ISRC filter and country code
+    /// parameters are preserved.
+    /// </summary>
+    [TestMethod]
+    public void GetTracksIsrcURI_ShouldEmitSingleIncludeParameter( ) {
+        // Arrange
+        string storefront = "US";
+        string isrc = "USRC12345678";
+
+        // Act
+        string uri = TidalLinkParser.GetTracksIsrcURI( storefront, isrc );
+
+        // Assert: parse the query string and count 'include' keys
+        NameValueCollection parsed = ParseQueryString( uri );
+        string[] includeValues = parsed.GetValues( "include" ) ?? [];
+
+        // Exactly one 'include' key — duplicate keys violate JSON:API
+        Assert.HasCount( 1, includeValues,
+            $"Expected exactly 1 'include' key in '{uri}'. Duplicate include keys violate JSON:API." );
+
+        // The value must be comma-separated and contain both relationships
+        string[] parts = includeValues[0].Split( ',' );
+        CollectionAssert.AreEquivalent(
+            new[] { "albums", "artists" },
+            parts,
+            $"Expected include value to contain exactly albums and artists; got '{includeValues[0]}'" );
+
+        // The other params must survive the template substitution
+        Assert.AreEqual( isrc, parsed["filter[isrc]"],
+            "filter[isrc] must be preserved after collapsing include params" );
+        Assert.AreEqual( storefront, parsed["countryCode"],
+            "countryCode must be preserved after collapsing include params" );
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetAlbumUpcURI</c> emits exactly one <c>include</c> parameter whose value
+    /// is the comma-separated set of artists and coverArt, and that the UPC filter and country code
+    /// parameters are preserved.
+    /// </summary>
+    [TestMethod]
+    public void GetAlbumUpcURI_ShouldEmitSingleIncludeParameter( ) {
+        // Arrange
+        string storefront = "US";
+        string upc = "123456789012";
+
+        // Act
+        string uri = TidalLinkParser.GetAlbumUpcURI( storefront, upc );
+
+        // Assert: parse the query string and count 'include' keys
+        NameValueCollection parsed = ParseQueryString( uri );
+        string[] includeValues = parsed.GetValues( "include" ) ?? [];
+
+        Assert.HasCount( 1, includeValues,
+            $"Expected exactly 1 'include' key in '{uri}'. Duplicate include keys violate JSON:API." );
+
+        string[] parts = includeValues[0].Split( ',' );
+        CollectionAssert.AreEquivalent(
+            new[] { "artists", "coverArt" },
+            parts,
+            $"Expected include value to contain exactly artists and coverArt; got '{includeValues[0]}'" );
+
+        Assert.AreEqual( upc, parsed["filter[barcodeId]"],
+            "filter[barcodeId] must be preserved after collapsing include params" );
+        Assert.AreEqual( storefront, parsed["countryCode"],
+            "countryCode must be preserved after collapsing include params" );
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetTrackIdURI</c> emits exactly one <c>include</c> parameter whose value
+    /// is the comma-separated set of albums and artists, and that the country code is preserved.
+    /// </summary>
+    [TestMethod]
+    public void GetTrackIdURI_ShouldEmitSingleIncludeParameter( ) {
+        // Arrange
+        string storefront = "US";
+        string trackId = "12345678";
+
+        // Act
+        string uri = TidalLinkParser.GetTrackIdURI( storefront, trackId );
+
+        // Assert
+        NameValueCollection parsed = ParseQueryString( uri );
+        string[] includeValues = parsed.GetValues( "include" ) ?? [];
+
+        Assert.HasCount( 1, includeValues,
+            $"Expected exactly 1 'include' key in '{uri}'. Duplicate include keys violate JSON:API." );
+
+        string[] parts = includeValues[0].Split( ',' );
+        CollectionAssert.AreEquivalent(
+            new[] { "albums", "artists" },
+            parts,
+            $"Expected include value to contain exactly albums and artists; got '{includeValues[0]}'" );
+
+        Assert.AreEqual( storefront, parsed["countryCode"],
+            "countryCode must be preserved after collapsing include params" );
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetAlbumIdURI</c> emits exactly one <c>include</c> parameter whose value
+    /// is the comma-separated set of artists and coverArt, and that the country code is preserved.
+    /// </summary>
+    [TestMethod]
+    public void GetAlbumIdURI_ShouldEmitSingleIncludeParameter( ) {
+        // Arrange
+        string storefront = "GB";
+        string albumId = "87654321";
+
+        // Act
+        string uri = TidalLinkParser.GetAlbumIdURI( storefront, albumId );
+
+        // Assert
+        NameValueCollection parsed = ParseQueryString( uri );
+        string[] includeValues = parsed.GetValues( "include" ) ?? [];
+
+        Assert.HasCount( 1, includeValues,
+            $"Expected exactly 1 'include' key in '{uri}'. Duplicate include keys violate JSON:API." );
+
+        string[] parts = includeValues[0].Split( ',' );
+        CollectionAssert.AreEquivalent(
+            new[] { "artists", "coverArt" },
+            parts,
+            $"Expected include value to contain exactly artists and coverArt; got '{includeValues[0]}'" );
+
+        Assert.AreEqual( storefront, parsed["countryCode"],
+            "countryCode must be preserved after collapsing include params" );
+    }
+
+    /// <summary>
+    /// Suite-wide guard: every Tidal URI builder that emits an <c>include</c> parameter must emit
+    /// at most one, with a comma-separated value. This catches the class of bug (duplicate
+    /// <c>include</c> keys) across all builders so a future edit cannot silently re-introduce it.
+    /// </summary>
+    [TestMethod]
+    public void AllTidalIncludeUris_ShouldHaveAtMostOneIncludeKey( ) {
+        // Arrange: representative arguments for each builder that uses include
+        (string label, string uri)[] uris = [
+            ("GetTracksIsrcURI", TidalLinkParser.GetTracksIsrcURI( "US", "USRC12345678" )),
+            ("GetAlbumUpcURI", TidalLinkParser.GetAlbumUpcURI( "US", "123456789012" )),
+            ("GetTrackIdURI", TidalLinkParser.GetTrackIdURI( "US", "12345678" )),
+            ("GetAlbumIdURI", TidalLinkParser.GetAlbumIdURI( "US", "87654321" )),
+            ("GetArtistSearchUri", TidalLinkParser.GetArtistSearchUri( "US", "Test Artist" )),
+            ("GetArtistTracksUri", TidalLinkParser.GetArtistTracksUri( "US", "11111" )),
+            ("GetArtistAlbumsUri", TidalLinkParser.GetArtistAlbumsUri( "US", "11111" )),
+        ];
+
+        // Assert: each URI that has an include key must have exactly one
+        foreach ((string label, string uri) in uris) {
+            NameValueCollection parsed = ParseQueryString( uri );
+            string[]? values = parsed.GetValues( "include" );
+
+            if (values is null) {
+                continue; // No include key — fine
+            }
+
+            Assert.HasCount( 1, values,
+                $"{label}: expected at most 1 'include' key; got {values.Length} in '{uri}'" );
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a well-formed ISRC produces a URI whose query string round-trips cleanly:
+    /// the ISRC value is present and the URI path begins with "tracks". This guards that
+    /// collapsing the duplicate include params did not corrupt the rest of the template.
+    /// </summary>
+    [TestMethod]
+    public void GetTracksIsrcURI_WithKnownIsrc_ShouldProduceParseableRequest( ) {
+        // Arrange
+        string storefront = "CA";
+        string isrc = "CAB771234567";
+
+        // Act
+        string uri = TidalLinkParser.GetTracksIsrcURI( storefront, isrc );
+
+        // Assert: URI starts with 'tracks' path
+        Assert.IsTrue( uri.StartsWith( "tracks", StringComparison.Ordinal ),
+            $"Expected URI to begin with 'tracks'; got '{uri}'" );
+
+        // Assert: ISRC value is present in the parsed query
+        NameValueCollection parsed = ParseQueryString( uri );
+        Assert.AreEqual( isrc, parsed["filter[isrc]"],
+            $"Expected filter[isrc]={isrc} in parsed query; got '{parsed["filter[isrc]"]}'" );
+
+        Assert.AreEqual( storefront, parsed["countryCode"],
+            $"Expected countryCode={storefront}; got '{parsed["countryCode"]}'" );
+    }
+
+    /// <summary>
+    /// Parses the query string from a relative URI (splitting off the path at '?') and decodes
+    /// percent-encoded parameter names such as <c>filter%5Bisrc%5D</c> → <c>filter[isrc]</c>.
+    /// </summary>
+    private static NameValueCollection ParseQueryString( string relativeUri ) {
+        int queryStart = relativeUri.IndexOf( '?' );
+        string queryPart = queryStart >= 0 ? relativeUri[(queryStart + 1)..] : relativeUri;
+        return HttpUtility.ParseQueryString( queryPart );
+    }
+}
+
+#pragma warning restore CS1591

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -22,8 +22,8 @@ RUN DOTNET_RID="linux-x64"; \
     if [ "$TARGETARCH" = "arm64" ]; then DOTNET_RID="linux-arm64"; fi; \
     mkdir -p /build/publish/tools/dcp && \
     mkdir -p /build/publish/tools/dashboard && \
-    DCP_PACKAGE_DIR=$(ls -d /root/.nuget/packages/aspire.hosting.orchestration.${DOTNET_RID}/* | head -n 1) && \
-    DASHBOARD_PACKAGE_DIR=$(ls -d /root/.nuget/packages/aspire.dashboard.sdk.${DOTNET_RID}/* | head -n 1) && \
+    DCP_PACKAGE_DIR=$(ls -d /root/.nuget/packages/aspire.hosting.orchestration.${DOTNET_RID}/* | sort -V | tail -n 1) && \
+    DASHBOARD_PACKAGE_DIR=$(ls -d /root/.nuget/packages/aspire.dashboard.sdk.${DOTNET_RID}/* | sort -V | tail -n 1) && \
     cp -r "${DCP_PACKAGE_DIR}/tools"/* /build/publish/tools/dcp/ && \
     cp -r "${DASHBOARD_PACKAGE_DIR}/tools"/* /build/publish/tools/dashboard/ && \
     chmod +x /build/publish/tools/dcp/dcp

--- a/containers/Test-LockFileChanges.ps1
+++ b/containers/Test-LockFileChanges.ps1
@@ -161,9 +161,13 @@ function Test-LockEntryDifferent {
         return $false
     }
 
-    $backupJson = $BackupEntry | ConvertTo-Json -Compress
-    $currentJson = $CurrentEntry | ConvertTo-Json -Compress
-    return $backupJson -ne $currentJson
+    # Fallback: compare the stable identity fields directly. Key order from
+    # ConvertFrom-Json -AsHashtable is nondeterministic, so a whole-object JSON
+    # string compare can report a false difference for identical entries.
+    foreach ($field in @('type', 'requested', 'resolved', 'contentHash')) {
+        if ($BackupEntry[$field] -ne $CurrentEntry[$field]) { return $true }
+    }
+    return $false
 }
 
 # Read and parse both lock files

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - internal
     environment:
       - DOMAIN=${DOMAIN:-bridgebeats.link}
-      - NODE_NUMBER=${NODE_NUMBER:-100}
+      - NODE_NUMBER=${NODE_NUMBER:-0}
       - DEFAULT_LOGLEVEL=${DEFAULT_LOGLEVEL:-Information}
       - HOSTING_DEFAULT_LOGLEVEL=${HOSTING_DEFAULT_LOGLEVEL:-Information}
       - APPLE_TEAM_ID=${APPLE_TEAM_ID:-}

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -115,7 +115,7 @@ RESILIENCE_ATTEMPT_TIMEOUT_SECONDS="${RESILIENCE_ATTEMPT_TIMEOUT_SECONDS:-120}"
 escape_bs() { printf '%s' "$1" | sed 's/\\/\\\\/g'; }
 
 # 0) Create required directories
-mkdir -p /app/data/logs
+mkdir -p "$LOG_DIR_PATH"
 mkdir -p "$DATA_PROTECTION_KEY_PATH"
 
 # 1) Remove existing appsettings.json from /src/BridgeBeats.Web/ if present

--- a/containers/install.ps1
+++ b/containers/install.ps1
@@ -4,7 +4,10 @@
     BridgeBeats Installation Script for Windows
 
 .DESCRIPTION
-    This script downloads and configures BridgeBeats for Docker deployment.
+    This script downloads and configures BridgeBeats for Docker deployment on Windows.
+    Linux and macOS hosts must use install.sh instead — it sets the required file ownership
+    and permissions that this Windows installer does not apply.
+
     It validates dependencies, downloads configuration files, sets up secrets,
     and prepares the environment for running BridgeBeats via Docker Compose.
 
@@ -342,6 +345,18 @@ if (Test-Path $logsDir) {
     Write-Ok "Created logs directory: $logsDir"
 }
 
+$dataDirs = @(
+    (Join-Path $Directory 'data\app'),
+    (Join-Path $Directory 'data\dp-keys'),
+    (Join-Path $Directory 'data\redis'),
+    (Join-Path $Directory 'data\pds'),
+    (Join-Path $Directory 'logs\caddy')
+)
+foreach ($d in $dataDirs) {
+    if (-not (Test-Path $d)) { New-Item -Path $d -ItemType Directory -Force | Out-Null }
+}
+Write-Ok 'Data directories present: data\{app,dp-keys,redis,pds}, logs\caddy'
+
 # =============================================================================
 # Check for Existing Containers
 # =============================================================================
@@ -452,9 +467,8 @@ if ($containersExist) {
 # =============================================================================
 Write-Section 'Setting Up Secrets'
 
-# TODO: Test and implement proper Windows ACL permissions for secrets folder
-# The secrets directory should have restricted access similar to Linux (chmod 700)
-# Consider using Set-Acl to restrict access to the current user and container service account
+# On Windows, the secrets directory inherits the current user's profile ACL.
+# Linux-style ownership and mode-700 permission hardening is handled by install.sh on Linux hosts.
 
 if (Test-Path $secretsDir) {
     Write-Ok "Secrets directory already exists: $secretsDir"

--- a/containers/install.sh
+++ b/containers/install.sh
@@ -131,76 +131,68 @@ secret_has_content() {
     return 1
 }
 
-# Generate a random string using available methods
+# Generate a cryptographically secure random string using openssl
 generate_random_string() {
-    if command -v openssl &> /dev/null; then
-        openssl rand -base64 32
-    elif [[ -f /dev/urandom ]]; then
-        head -c 32 /dev/urandom | base64
-    else
-        # Fallback - not cryptographically secure but better than nothing
-        echo "REPLACE_WITH_RANDOM_VALUE_$(date +%s)_$$"
-    fi
+    openssl rand -base64 32
 }
 
 # Generate an ES256 (P-256) signing key in JWK format
 generate_es256_jwk() {
-    if command -v openssl &> /dev/null; then
-        # Generate an EC P-256 key pair with openssl
-        local privkey
-        privkey=$(openssl ecparam -genkey -name prime256v1 -noout 2>/dev/null)
+    # Generate an EC P-256 key pair with openssl
+    local privkey
+    privkey=$(openssl ecparam -genkey -name prime256v1 -noout 2>/dev/null)
 
-        # Export key parameters as human-readable text
-        local params
-        params=$(echo "$privkey" | openssl ec -text -noout 2>/dev/null)
+    # Export key parameters as human-readable text
+    local params
+    params=$(echo "$privkey" | openssl ec -text -noout 2>/dev/null)
 
-        # Extract the private-key hex lines (between "priv:" and "pub:") and strip colons
-        local priv_hex
-        priv_hex=$(echo "$params" \
-            | awk '/^priv:/{found=1; next} /^pub:/{found=0} found{print}' \
-            | tr -d ' :\n')
+    # Extract the private-key hex lines (between "priv:" and "pub:") and strip colons
+    local priv_hex
+    priv_hex=$(echo "$params" \
+        | awk '/^priv:/{found=1; next} /^pub:/{found=0} found{print}' \
+        | tr -d ' :\n')
 
-        # Extract the public-key hex lines (between "pub:" and "ASN1 OID:") and strip colons
-        local pub_hex
-        pub_hex=$(echo "$params" \
-            | awk '/^pub:/{found=1; next} /^ASN1 OID:/{found=0} found{print}' \
-            | tr -d ' :\n')
+    # Extract the public-key hex lines (between "pub:" and "ASN1 OID:") and strip colons
+    local pub_hex
+    pub_hex=$(echo "$params" \
+        | awk '/^pub:/{found=1; next} /^ASN1 OID:/{found=0} found{print}' \
+        | tr -d ' :\n')
 
-        # Validate the public key starts with 04 (uncompressed point prefix)
-        if [ "${pub_hex:0:2}" != "04" ]; then
-            echo "[WARN] openssl ec output format unexpected - ATProto OAuth key needs manual generation" >&2
-            return 1
-        fi
-
-        # Slice x and y from the uncompressed public key (04 || x[32] || y[32])
-        # Each coordinate is 32 bytes = 64 hex chars; skip the leading "04" (2 hex chars)
-        local x_hex="${pub_hex:2:64}"
-        local y_hex="${pub_hex:66:64}"
-
-        # Left-pad d to exactly 32 bytes (64 hex chars) with leading zeros
-        # openssl may emit fewer than 32 bytes when the leading byte(s) are zero
-        local d_hex
-        d_hex=$(printf '%064s' "$priv_hex" | tr ' ' '0')
-        # Take the rightmost 64 hex chars in case openssl emitted more than 32 bytes
-        d_hex="${d_hex: -64}"
-
-        # base64url-encode a hex string: decode hex to binary, base64-encode, apply URL-safe charset
-        b64url_from_hex() {
-            printf '%s' "$1" | xxd -r -p | base64 | tr '+/' '-_' | tr -d '='
-        }
-
-        local x_b64 y_b64 d_b64 kid
-        x_b64=$(b64url_from_hex "$x_hex")
-        y_b64=$(b64url_from_hex "$y_hex")
-        d_b64=$(b64url_from_hex "$d_hex")
-        kid=$(openssl rand -hex 16)
-
-        printf '{"kty":"EC","crv":"P-256","x":"%s","y":"%s","d":"%s","kid":"%s","alg":"ES256","use":"sig"}\n' \
-            "$x_b64" "$y_b64" "$d_b64" "$kid"
-    else
-        echo "[WARN] openssl not found - ATProto OAuth key needs manual generation" >&2
+    # Validate the public key starts with 04 (uncompressed point prefix)
+    if [ "${pub_hex:0:2}" != "04" ]; then
+        echo "[WARN] openssl ec output format unexpected - ATProto OAuth key needs manual generation" >&2
         return 1
     fi
+
+    # Slice x and y from the uncompressed public key (04 || x[32] || y[32])
+    # Each coordinate is 32 bytes = 64 hex chars; skip the leading "04" (2 hex chars)
+    local x_hex="${pub_hex:2:64}"
+    local y_hex="${pub_hex:66:64}"
+
+    # Left-pad d to exactly 32 bytes (64 hex chars) with leading zeros
+    # openssl may emit fewer than 32 bytes when the leading byte(s) are zero
+    local d_hex
+    d_hex=$(printf '%064s' "$priv_hex" | tr ' ' '0')
+    # Take the rightmost 64 hex chars in case openssl emitted more than 32 bytes
+    d_hex="${d_hex: -64}"
+
+    # base64url-encode a hex string: convert hex pairs to \xNN escapes, emit binary via
+    # printf, then encode with openssl base64 (no line-wrap) and apply URL-safe charset.
+    # Input is strictly validated hex [0-9a-f] — no % characters, safe as printf format.
+    b64url_from_hex() {
+        local hex_escapes
+        hex_escapes=$(printf '%s' "$1" | sed 's/\(..\)/\\x\1/g')
+        printf "$hex_escapes" | openssl base64 -A | tr '+/' '-_' | tr -d '='
+    }
+
+    local x_b64 y_b64 d_b64 kid
+    x_b64=$(b64url_from_hex "$x_hex")
+    y_b64=$(b64url_from_hex "$y_hex")
+    d_b64=$(b64url_from_hex "$d_hex")
+    kid=$(openssl rand -hex 16)
+
+    printf '{"kty":"EC","crv":"P-256","x":"%s","y":"%s","d":"%s","kid":"%s","alg":"ES256","use":"sig"}\n' \
+        "$x_b64" "$y_b64" "$d_b64" "$kid"
 }
 
 # Get environment variable names from a file
@@ -262,11 +254,11 @@ else
     missing_deps+=("curl or wget - Required for downloading files")
 fi
 
-# Check for openssl (optional but recommended)
+# Check for openssl (required for generating secure secrets and the ATProto OAuth signing key)
 if command -v openssl &> /dev/null; then
     echo "[OK] openssl: available (for generating secure random secrets)"
 else
-    warnings+=("openssl not found - Will use fallback for generating random secrets")
+    missing_deps+=("openssl - Required for generating secure secrets and the ATProto OAuth signing key. Install via your package manager, e.g. apt-get install -y openssl")
 fi
 
 # Report missing dependencies

--- a/containers/install.sh
+++ b/containers/install.sh
@@ -150,81 +150,56 @@ generate_es256_jwk() {
         local privkey
         privkey=$(openssl ecparam -genkey -name prime256v1 -noout 2>/dev/null)
 
-        # Export key parameters
+        # Export key parameters as human-readable text
         local params
         params=$(echo "$privkey" | openssl ec -text -noout 2>/dev/null)
 
-        # Use a small inline Python/Python3 script to parse and emit JWK
-        if command -v python3 &> /dev/null; then
-            echo "$privkey" | python3 -c "
-import sys, json, hashlib, base64, uuid
-from subprocess import run, PIPE
+        # Extract the private-key hex lines (between "priv:" and "pub:") and strip colons
+        local priv_hex
+        priv_hex=$(echo "$params" \
+            | awk '/^priv:/{found=1; next} /^pub:/{found=0} found{print}' \
+            | tr -d ' :\n')
 
-pem = sys.stdin.read()
-# Use openssl to get the raw key bytes
-result = run(['openssl', 'ec', '-text', '-noout'], input=pem, capture_output=True, text=True)
-lines = result.stdout.strip().split('\n')
+        # Extract the public-key hex lines (between "pub:" and "ASN1 OID:") and strip colons
+        local pub_hex
+        pub_hex=$(echo "$params" \
+            | awk '/^pub:/{found=1; next} /^ASN1 OID:/{found=0} found{print}' \
+            | tr -d ' :\n')
 
-# Parse the hex bytes from openssl output
-hex_bytes = ''
-in_priv = False
-in_pub = False
-priv_hex = ''
-pub_hex = ''
-for line in lines:
-    line = line.strip()
-    if 'priv:' in line:
-        in_priv = True
-        in_pub = False
-        continue
-    elif 'pub:' in line:
-        in_priv = False
-        in_pub = True
-        continue
-    elif 'ASN1 OID:' in line or 'NIST CURVE:' in line:
-        in_priv = False
-        in_pub = False
-        continue
-    if in_priv:
-        priv_hex += line.replace(':', '')
-    if in_pub:
-        pub_hex += line.replace(':', '')
-
-priv_bytes = bytes.fromhex(priv_hex)
-pub_bytes = bytes.fromhex(pub_hex)
-
-# Public key is 04 || x || y (uncompressed)
-if pub_bytes[0] == 0x04:
-    x = pub_bytes[1:33]
-    y = pub_bytes[33:65]
-else:
-    sys.exit(1)
-
-# Ensure d is exactly 32 bytes (pad with leading zeros if needed)
-d = priv_bytes[-32:] if len(priv_bytes) >= 32 else priv_bytes.rjust(32, b'\x00')
-
-def b64url(b):
-    return base64.urlsafe_b64encode(b).rstrip(b'=').decode()
-
-jwk = {
-    'kty': 'EC',
-    'crv': 'P-256',
-    'x': b64url(x),
-    'y': b64url(y),
-    'd': b64url(d),
-    'kid': uuid.uuid4().hex,
-    'alg': 'ES256',
-    'use': 'sig'
-}
-print(json.dumps(jwk))
-"
-        else
-            echo '{}' # Placeholder if python3 not available
-            echo "[WARN] python3 not found - ATProto OAuth key needs manual generation" >&2
+        # Validate the public key starts with 04 (uncompressed point prefix)
+        if [ "${pub_hex:0:2}" != "04" ]; then
+            echo "[WARN] openssl ec output format unexpected - ATProto OAuth key needs manual generation" >&2
+            return 1
         fi
+
+        # Slice x and y from the uncompressed public key (04 || x[32] || y[32])
+        # Each coordinate is 32 bytes = 64 hex chars; skip the leading "04" (2 hex chars)
+        local x_hex="${pub_hex:2:64}"
+        local y_hex="${pub_hex:66:64}"
+
+        # Left-pad d to exactly 32 bytes (64 hex chars) with leading zeros
+        # openssl may emit fewer than 32 bytes when the leading byte(s) are zero
+        local d_hex
+        d_hex=$(printf '%064s' "$priv_hex" | tr ' ' '0')
+        # Take the rightmost 64 hex chars in case openssl emitted more than 32 bytes
+        d_hex="${d_hex: -64}"
+
+        # base64url-encode a hex string: decode hex to binary, base64-encode, apply URL-safe charset
+        b64url_from_hex() {
+            printf '%s' "$1" | xxd -r -p | base64 | tr '+/' '-_' | tr -d '='
+        }
+
+        local x_b64 y_b64 d_b64 kid
+        x_b64=$(b64url_from_hex "$x_hex")
+        y_b64=$(b64url_from_hex "$y_hex")
+        d_b64=$(b64url_from_hex "$d_hex")
+        kid=$(openssl rand -hex 16)
+
+        printf '{"kty":"EC","crv":"P-256","x":"%s","y":"%s","d":"%s","kid":"%s","alg":"ES256","use":"sig"}\n' \
+            "$x_b64" "$y_b64" "$d_b64" "$kid"
     else
-        echo '{}' # Placeholder if openssl not available
         echo "[WARN] openssl not found - ATProto OAuth key needs manual generation" >&2
+        return 1
     fi
 }
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,6 +20,22 @@ curl -sSL https://raw.githubusercontent.com/tsmarvin/BridgeBeats/develop/contain
 iwr -useb https://raw.githubusercontent.com/tsmarvin/BridgeBeats/develop/containers/install.ps1 | iex
 ```
 
+**Reviewing the installer before running it.** The one-liners above download and execute a script in a single step. To inspect it first:
+
+```bash
+curl -fsSL -o install.sh https://raw.githubusercontent.com/tsmarvin/BridgeBeats/develop/containers/install.sh
+less install.sh   # review
+bash install.sh   # run after review
+```
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/tsmarvin/BridgeBeats/develop/containers/install.ps1 -OutFile install.ps1
+# review install.ps1, then:
+.\install.ps1
+```
+
+Piping straight to `bash`/`iex` runs unreviewed remote code as your user. Prefer the reviewed flow on hosts you do not control. If signed releases with published checksums become available, verify the checksum before executing.
+
 ### Installation Options
 
 Customize the installation with parameters:
@@ -210,7 +226,7 @@ NODE_NUMBER=0
 NODE_NUMBER=1
 ```
 
-> **Verify:** multi-shard Discord operation depends on the node-number wiring in `src/BridgeBeats.AppHost/Program.cs` and the Discord worker. The single-host compose stack runs one instance (default `NODE_NUMBER=100`); confirm shard assignment before deploying multiple Discord-connected instances.
+> **Verify:** multi-shard Discord operation depends on the node-number wiring in `src/BridgeBeats.AppHost/Program.cs` and the Discord worker. The single-host compose stack runs one instance (default `NODE_NUMBER=0`); confirm shard assignment before deploying multiple Discord-connected instances.
 
 ## Security Considerations
 

--- a/src/BridgeBeats.Core/Domain/Providers/Tidal/TidalLinkParser.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Tidal/TidalLinkParser.cs
@@ -169,10 +169,10 @@ namespace BridgeBeats.Providers.Tidal {
                 .Replace( "{trackId}", trackId );
 
         /// <summary>Template for the ISRC-filtered tracks request, side-loading albums and artists.</summary>
-        private const string TracksIsrcURI = "tracks?filter%5Bisrc%5D={isrc}&countryCode={storefront}&include=albums&include=artists";
+        private const string TracksIsrcURI = "tracks?filter%5Bisrc%5D={isrc}&countryCode={storefront}&include=albums,artists";
 
         /// <summary>Template for the UPC-filtered albums request, side-loading artists and cover art.</summary>
-        private const string AlbumsUpcURI = "albums?filter%5BbarcodeId%5D={upc}&countryCode={storefront}&include=artists&include=coverArt";
+        private const string AlbumsUpcURI = "albums?filter%5BbarcodeId%5D={upc}&countryCode={storefront}&include=artists,coverArt";
 
         /// <summary>Template for the artist search request, side-loading matching artist resources.</summary>
         private const string ArtistSearchURI = "searchResults/{artist}?countryCode={storefront}&explicitFilter=include&include=artists";
@@ -184,10 +184,10 @@ namespace BridgeBeats.Providers.Tidal {
         private const string ArtistTrackRelationshipsUri = "artists/{artistId}/relationships/tracks?countryCode={storefront}&collapseBy=FINGERPRINT&include=tracks";
 
         /// <summary>Template for the track-by-id request, side-loading albums and artists.</summary>
-        private const string TrackIdUri = "tracks/{trackId}?countryCode={storefront}&include=albums&include=artists";
+        private const string TrackIdUri = "tracks/{trackId}?countryCode={storefront}&include=albums,artists";
 
         /// <summary>Template for the album-by-id request, side-loading artists and cover art.</summary>
-        private const string AlbumIdUri = "albums/{albumId}?countryCode={storefront}&include=artists&include=coverArt";
+        private const string AlbumIdUri = "albums/{albumId}?countryCode={storefront}&include=artists,coverArt";
 
     }
 }

--- a/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
@@ -245,16 +245,16 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// <param name="ct">Cancels the lookup; checked before dispatch.</param>
     /// <returns>The provider result, or <see langword="null"/> when the provider found no match.</returns>
     /// <remarks>
-    /// <see cref="LookupRequestType.ArtistAlbumLookup"/> and <see cref="LookupRequestType.AlbumTrackLookup"/>
-    /// intentionally throw <see cref="NotImplementedException"/>: they are intra-provider sub-steps, not
-    /// top-level queueable requests, so they are not supported as a dispatch target here. Any other
+    /// Title+artist lookup types (<see cref="LookupRequestType.ArtistLookup"/>,
+    /// <see cref="LookupRequestType.SongLookup"/>, <see cref="LookupRequestType.AlbumLookup"/>,
+    /// <see cref="LookupRequestType.ArtistAlbumLookup"/>, and <see cref="LookupRequestType.AlbumTrackLookup"/>)
+    /// all resolve through <see cref="IMusicLookupService.GetInfoAsync(string, string)"/>, which performs
+    /// the artist-to-album and album-to-track expansion internally. The request must carry non-null
+    /// <see cref="QueuedLookupRequest.Title"/> and <see cref="QueuedLookupRequest.Artist"/> values; a
+    /// request missing either falls through to the <see cref="InvalidOperationException"/> arm. Any other
     /// unrecognized type, or a search type missing its title/artist, throws
     /// <see cref="InvalidOperationException"/>.
     /// </remarks>
-    /// <exception cref="NotImplementedException">
-    /// Thrown for <see cref="LookupRequestType.ArtistAlbumLookup"/> and
-    /// <see cref="LookupRequestType.AlbumTrackLookup"/>, which are not supported as standalone requests.
-    /// </exception>
     /// <exception cref="InvalidOperationException">Thrown for an unsupported lookup type or missing required parameters.</exception>
     private async Task<MusicLookupResult?> PerformLookupAsync( QueuedLookupRequest request, CancellationToken ct ) {
         // Check for cancellation before performing the lookup
@@ -273,8 +273,10 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
                 await _lookupService.GetInfoAsync( request.Title, request.Artist ),
             LookupRequestType.AlbumLookup when request is { Title: not null, Artist: not null } =>
                 await _lookupService.GetInfoAsync( request.Title, request.Artist ),
-            LookupRequestType.ArtistAlbumLookup => throw new NotImplementedException( ),
-            LookupRequestType.AlbumTrackLookup => throw new NotImplementedException( ),
+            LookupRequestType.ArtistAlbumLookup when request is { Title: not null, Artist: not null } =>
+                await _lookupService.GetInfoAsync( request.Title, request.Artist ),
+            LookupRequestType.AlbumTrackLookup when request is { Title: not null, Artist: not null } =>
+                await _lookupService.GetInfoAsync( request.Title, request.Artist ),
             _ => throw new InvalidOperationException(
                             $"Unsupported lookup type {request.LookupType} or missing required parameters"
                         )

--- a/src/BridgeBeats.Core/Domain/Services/Statistics/StatisticsService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Statistics/StatisticsService.cs
@@ -129,10 +129,11 @@ public sealed partial class StatisticsService(
                     LogRefreshingStatistics( logger, pdsUriString, settings.UserDid );
                 }
 
+                DateTimeOffset refreshStart = DateTimeOffset.UtcNow;
                 LookupStatistics stats = await ComputeStatisticsAsync(cancellationToken);
 
                 _cachedStats = stats;
-                _cacheExpiry = DateTimeOffset.UtcNow + settings.CacheDuration;
+                _cacheExpiry = refreshStart + settings.CacheDuration;
 
                 LogStatisticsRefreshed( logger, stats.TotalRecords, _cacheExpiry );
 

--- a/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
@@ -66,9 +66,10 @@ public sealed partial class JetStreamWatcherService(
 
     /// <summary>
     /// Establishes one Jetstream connection and processes records until cancellation or disconnect.
-    /// Subscribes to the post and repost collections, dispatches each created record to the post or
-    /// repost handler, then polls connection state every 500 ms and closes cleanly when the loop
-    /// ends. Known benign parser errors are suppressed (see <see cref="IsExpectedParsingError"/>).
+    /// Subscribes to the post and repost collections, dispatches each created record through
+    /// <see cref="HandleCommitRecordAsync"/>, then polls connection state every 500 ms and closes
+    /// cleanly when the loop ends. Known benign parser errors are suppressed (see
+    /// <see cref="IsExpectedParsingError"/>).
     /// </summary>
     /// <param name="stoppingToken">Signals host shutdown.</param>
     /// <returns>A task that completes when the connection closes.</returns>
@@ -84,24 +85,7 @@ public sealed partial class JetStreamWatcherService(
                 string.Equals( commitEvent.Commit.Operation, "create", StringComparison.OrdinalIgnoreCase ) &&
                 commitEvent.Commit.Record is not null
             ) {
-                try {
-                    string collection = commitEvent.Commit.Collection.ToString( );
-
-                    if (collection == "app.bsky.feed.post") {
-                        await ProcessPostAsync( commitEvent.Commit.Record, blueskyAgent, stoppingToken );
-                    } else if (collection == "app.bsky.feed.repost") {
-                        await ProcessRepostAsync( commitEvent.Commit.Record, blueskyAgent, stoppingToken );
-                    }
-                } catch (JsonException) {
-                    // Skip records that can't be deserialized - this is expected for some record types
-                } catch (OperationCanceledException) {
-                    // Shutdown in progress
-                } catch (Exception ex) {
-                    // Log unexpected errors but continue processing
-                    if (!IsExpectedParsingError( ex )) {
-                        LogRecordProcessingError( logger, ex );
-                    }
-                }
+                await HandleCommitRecordAsync( commitEvent.Commit.Record, commitEvent.Commit.Collection.ToString( ), blueskyAgent, stoppingToken );
             }
         };
 
@@ -116,6 +100,40 @@ public sealed partial class JetStreamWatcherService(
 
         await jetStream.CloseAsync( cancellationToken: stoppingToken );
         LogDisconnected( logger );
+    }
+
+    /// <summary>
+    /// Dispatches a single committed record to the appropriate handler based on its collection, skipping
+    /// malformed or unrecognized records cleanly. Known benign parsing errors are swallowed silently;
+    /// unexpected errors are logged at Warning so they are visible above the file-sink floor.
+    /// </summary>
+    /// <param name="record">The raw record document from the commit event.</param>
+    /// <param name="collection">The collection name (e.g. <c>app.bsky.feed.post</c>).</param>
+    /// <param name="blueskyAgent">The agent used to hydrate quoted posts and reposts.</param>
+    /// <param name="cancellationToken">Signals host shutdown.</param>
+    /// <returns>A task that completes when the record has been processed or skipped.</returns>
+    internal async Task HandleCommitRecordAsync(
+        JsonDocument record,
+        string collection,
+        BlueskyAgent blueskyAgent,
+        CancellationToken cancellationToken
+    ) {
+        try {
+            if (collection == "app.bsky.feed.post") {
+                await ProcessPostAsync( record, blueskyAgent, cancellationToken );
+            } else if (collection == "app.bsky.feed.repost") {
+                await ProcessRepostAsync( record, blueskyAgent, cancellationToken );
+            }
+        } catch (JsonException) {
+            // Skip records that can't be deserialized - this is expected for some record types
+        } catch (OperationCanceledException) {
+            // Shutdown in progress
+        } catch (Exception ex) {
+            // Log unexpected errors but continue processing
+            if (!IsExpectedParsingError( ex )) {
+                LogRecordProcessingError( logger, ex );
+            }
+        }
     }
 
     /// <summary>
@@ -188,8 +206,19 @@ public sealed partial class JetStreamWatcherService(
         BlueskyAgent blueskyAgent,
         CancellationToken cancellationToken
     ) {
-        JsonElement repostSubject = record.RootElement.GetProperty( "subject" );
+        if (!record.RootElement.TryGetProperty( "subject", out JsonElement repostSubject )) {
+            return;
+        }
+
+        if (repostSubject.ValueKind != JsonValueKind.Object) {
+            return;
+        }
+
         if (!repostSubject.TryGetProperty( "uri", out JsonElement uriElement )) {
+            return;
+        }
+
+        if (uriElement.ValueKind != JsonValueKind.String) {
             return;
         }
 
@@ -476,7 +505,7 @@ public sealed partial class JetStreamWatcherService(
     /// <param name="ex">The processing exception.</param>
     [LoggerMessage(
         EventId = LogEventIds.RecordProcessingError,
-        Level = LogLevel.Debug,
+        Level = LogLevel.Warning,
         Message = "Error processing Jetstream record" )]
     private static partial void LogRecordProcessingError( ILogger logger, Exception ex );
 


### PR DESCRIPTION
This pull request improves the handling and isolation of process-wide environment variables in the `CustomWebApplicationFactory` used for integration testing, ensuring that test runs do not leak or contaminate ATProto-related environment variable state between tests. It also adds comprehensive integration tests to verify this behavior. Additionally, there are minor workflow and configuration updates.

**Test environment isolation improvements:**

* The `CustomWebApplicationFactory` now captures the prior values of the three ATProto environment variables (`BridgeBeats__ATProtoIdentifier`, `BridgeBeats__ATProtoPassword`, `BridgeBeats__ATProtoUserDID`) in its constructor, sets them to empty strings for the duration of the factory instance, and restores the original values on disposal. This prevents cross-test contamination and ensures that test overrides are properly scoped. [[1]](diffhunk://#diff-dab4a6061cfb7748ae2dbcebf1f542a39e9b418a0c0acd04f96dafd02f586cabL72-R90) [[2]](diffhunk://#diff-dab4a6061cfb7748ae2dbcebf1f542a39e9b418a0c0acd04f96dafd02f586cabL262-R287) [[3]](diffhunk://#diff-dab4a6061cfb7748ae2dbcebf1f542a39e9b418a0c0acd04f96dafd02f586cabR33-R34)
* A new test class `CustomWebApplicationFactoryEnvIsolationTests.cs` is added, containing integration tests that verify the environment variable isolation logic in various scenarios, including when the variables are initially unset or set to specific values, and across multiple sequential factory instances.

**Build and configuration updates:**

* The test workflow script now detects the originating platform (`from_rid`) from the lockfile backup and passes it to the lockfile comparison script, improving platform-specific test accuracy.
* The `.editorconfig` file removes the `dotnet_diagnostic.CA1873.severity` setting