### PR TITLE
Fix PDS Write Amplification

### DIFF
--- a/Tests/Integration/RedisMediaLinkCacheTests.cs
+++ b/Tests/Integration/RedisMediaLinkCacheTests.cs
@@ -87,29 +87,24 @@ public class RedisMediaLinkCacheTests {
     }
 
     /// <summary>
-    /// Verifies caching a track result writes the ISRC index key in Redis pointing at the stored record
-    /// URI.
+    /// Verifies indexing a track result writes the ISRC index key in Redis pointing at the record URI.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task CacheResultAsync_StoresLookupKeys_InRedis( ) {
+    public async Task IndexResultAsync_StoresLookupKeys_InRedis( ) {
         // Arrange
         MediaLinkResult result = CreateTestResult( "USRC12345678", false );
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:USRC12345678";
-
-        _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
 
         _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
         // Act
-        string cachedUri = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
-        // Assert
-        Assert.AreEqual( recordUri, cachedUri );
+        // Assert — body not re-stored inside the cache method
+        _mockAtProto.Verify( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
 
         // Verify ISRC key exists
         IDatabase db = s_redis!.GetDatabase( );
@@ -130,14 +125,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:ISRC999888777";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -160,14 +151,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/album:123456789012";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -192,14 +179,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:TESTISRC001";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -222,14 +205,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:CARDTEST123";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Get the card ID from the result
         string rkey = RecordKeyGenerator.GenerateRkey( result );
@@ -256,14 +235,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:PROVIDERTEST";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -280,7 +255,7 @@ public class RedisMediaLinkCacheTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task CacheResultAsync_CleansUpOldKeys_OnRefresh( ) {
+    public async Task IndexResultAsync_CleansUpOldKeys_OnRefresh( ) {
         // Arrange
         MediaLinkResult result1 = CreateTestResult( "REFRESHTEST1", false );
         result1.InputLinks.Add( "https://old.url/track1" );
@@ -288,14 +263,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:REFRESHTEST1";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result1 );
 
-        _ = await _cache.CacheResultAsync( result1, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result1, recordUri, TestContext.CancellationToken );
 
         // Verify old URL is cached
         IDatabase db = s_redis!.GetDatabase( );
@@ -303,7 +274,7 @@ public class RedisMediaLinkCacheTests {
         RedisValue oldValue = await db.StringGetAsync( $"lookup:url:{oldUrlHash}" );
         Assert.IsFalse( oldValue.IsNullOrEmpty, "Old URL should be cached" );
 
-        // Now cache the same result with a different URL (simulating refresh)
+        // Now index the same result with a different URL (simulating refresh)
         MediaLinkResult result2 = CreateTestResult( "REFRESHTEST1", false );
         result2.InputLinks.Add( "https://new.url/track1" );
 
@@ -311,7 +282,10 @@ public class RedisMediaLinkCacheTests {
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result2 );
 
-        _ = await _cache.CacheResultAsync( result2, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result2, recordUri, TestContext.CancellationToken );
+
+        // Assert — body not re-stored inside the cache method
+        _mockAtProto.Verify( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
 
         // Assert: Old URL key should be removed
         RedisValue oldValueAfterRefresh = await db.StringGetAsync( $"lookup:url:{oldUrlHash}" );
@@ -350,14 +324,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:STALETEST123";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -381,14 +351,10 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:PARTIALTEST123";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Act
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
@@ -411,15 +377,11 @@ public class RedisMediaLinkCacheTests {
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:SKIPTEST123";
 
         _ = _mockAtProto
-            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( recordUri );
-
-        _ = _mockAtProto
             .Setup( s => s.GetMediaLinkResultAsync( recordUri ) )
             .ReturnsAsync( result );
 
         // First call - should write to Redis
-        _ = await _cache.CacheResultAsync( result, TestContext.CancellationToken );
+        await _cache.IndexResultAsync( result, recordUri, TestContext.CancellationToken );
 
         // Get the ISRC key value and TTL after first write
         IDatabase db = s_redis!.GetDatabase( );

--- a/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
+++ b/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
@@ -138,8 +138,8 @@ public class SagaFinalizeClaimIntegrationTests {
 
         Mock<IMediaLinkCacheRepository> cacheMock = new( );
         _ = cacheMock
-            .Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( "at://cached" );
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         Mock<IRequestDeduplicator> deduplicatorMock = new( );
         Mock<IProviderQueueResolver<QueuedLookupRequest>> queueResolverMock = new( );
@@ -159,6 +159,12 @@ public class SagaFinalizeClaimIntegrationTests {
         _ = sagaMgrWrapper
             .Setup( s => s.ReleaseFinalizeClaimAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .Returns( ( string _, CancellationToken ct ) => _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, ct ) );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+        _ = sagaMgrWrapper
+            .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
         _ = sagaMgrWrapper
             .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );

--- a/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
+++ b/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
@@ -346,12 +346,13 @@ public class SagaWriteGenerationIntegrationTests {
     }
 
     /// <summary>
-    /// Positive control: sequential handlers for distinct generations 1 then 2 each produce one
-    /// write. This distinguishes the duplicate-suppression mechanism from accidental total suppression.
+    /// Verifies that sequential advances through distinct generations 0→1→2 are each accepted by
+    /// the strict-less-than CAS. Each new generation is strictly greater than the stored value, so
+    /// <c>TryAdvanceWriteGenerationAsync</c> returns <see langword="true"/> for both calls.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task SequentialDistinctGenerations_EachProduceOnePdsWrite( ) {
+    public async Task SequentialDistinctGenerations_AreEachAcceptedByTheCas( ) {
         // Arrange - seed the saga
         _ = await _sagaManager.GetOrCreateAsync(
             TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",

--- a/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
+++ b/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
@@ -1,0 +1,489 @@
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Domain.Services.Queue;
+using BridgeBeats.Core.Infrastructure.Queue;
+using BridgeBeats.Worker.SagaCoordinator;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the write-generation compare-and-set (CAS) guard against a real Redis
+/// instance. Verifies that concurrent handlers for the same generation level produce exactly one
+/// PDS write, that sequential distinct generations produce one write each, that the CAS primitive
+/// itself behaves correctly, and that a reset followed by re-advance works. Covers both the
+/// terminal (finalize-claim) path and the non-terminal (partial-write) path. The shared Redis
+/// Testcontainer is required; tests are tagged Integration and Docker so the CI filter handles
+/// them consistently.
+/// </summary>
+[TestClass]
+[TestCategory( "Integration" )]
+[TestCategory( "Docker" )]
+[DoNotParallelize]
+public class SagaWriteGenerationIntegrationTests {
+
+    /// <summary>The shared Redis connection used by the tests.</summary>
+    private static IConnectionMultiplexer? s_redis;
+
+    /// <summary>Queue settings supplied to the saga manager.</summary>
+    private IOptions<QueueSettings> _settings = null!;
+
+    /// <summary>The saga state manager backed by real Redis.</summary>
+    private RedisSagaStateManager _sagaManager = null!;
+
+    /// <summary>MSTest-injected context; its cancellation token bounds in-test delays.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Fixed saga id used across tests in this class.</summary>
+    private const string TestSagaId = "saga-wgen-integ-0001";
+
+    /// <summary>Fixed lookup key used in the saga fixture.</summary>
+    private const string TestLookupKey = "isrc:USRC99999002";
+
+    /// <summary>
+    /// Requires the shared Redis container and opens a connection used by all tests in this class.
+    /// </summary>
+    /// <param name="_">The MSTest class context (unused).</param>
+    [ClassInitialize]
+    public static async Task ClassInitialize( TestContext _ ) {
+        SharedTestInfrastructure.RequireRedis( );
+        s_redis = await ConnectionMultiplexer.ConnectAsync( SharedTestInfrastructure.RedisConnectionString );
+    }
+
+    /// <summary>Closes and disposes the Redis connection after all tests in this class complete.</summary>
+    [ClassCleanup]
+    public static async Task ClassCleanup( ) {
+        if (s_redis is not null) {
+            await s_redis.CloseAsync( );
+            s_redis.Dispose( );
+        }
+    }
+
+    /// <summary>Clears saga keys and creates a fresh saga manager before each test.</summary>
+    [TestInitialize]
+    public async Task TestInitialize( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        IServer server = s_redis.GetServer( s_redis.GetEndPoints( )[0] );
+        await foreach (RedisKey key in server.KeysAsync( pattern: "saga:*" )) {
+            _ = await db.KeyDeleteAsync( key );
+        }
+
+        _settings = Options.Create( new QueueSettings { JobExpirationMinutes = 60 } );
+        _sagaManager = new RedisSagaStateManager(
+            s_redis,
+            new Mock<ILogger<RedisSagaStateManager>>( ).Object,
+            _settings
+        );
+    }
+
+    /// <summary>
+    /// N=8 concurrent handlers all racing to finalize the same completion through the terminal path
+    /// (<see cref="SagaCoordinatorBackgroundService.InvokeFinalizeForTestAsync"/>). The finalize-claim
+    /// CAS ensures exactly one handler wins the claim and performs the PDS write; all others are
+    /// rejected by <see cref="ISagaStateManager.TryClaimFinalizeAsync"/> before writing. This is the
+    /// concurrent-terminal-trigger proof for the #315 claim-dedup guard.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ConcurrentTerminalTriggers_SameCompletion_ProducesExactlyOnePdsWrite( ) {
+        // Arrange - seed one complete, finalizable saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+        await _sagaManager.AddToPendingIndexAsync( TestSagaId, TestContext.CancellationToken );
+
+        // Shared PDS write counter — the discriminator
+        int pdsWriteCount = 0;
+        Mock<IATProtoStorageService> storageDouble = new( );
+        _ = storageDouble
+            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref pdsWriteCount );
+                string rkey = Guid.NewGuid( ).ToString( "N" );
+                return $"at://did:plc:test/com.bridgebeats.medialink/{rkey}";
+            } );
+
+        string resultJson = """{"isrc":"USRC99999002","trackName":"Race Test","artistName":"Test","url":"https://spotify.com/t/1"}""";
+        LookupSagaState completeSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC99999002",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -5 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = false
+        };
+
+        SagaCoordinatorBackgroundService BuildService( ) {
+            Mock<IConnectionMultiplexer> redisMock = new( );
+            Mock<ISubscriber> subscriberMock = new( );
+            _ = redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( subscriberMock.Object );
+
+            Mock<IMediaLinkCacheRepository> cacheMock = new( );
+            _ = cacheMock
+                .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+
+            Mock<IRequestDeduplicator> deduplicatorMock = new( );
+            Mock<IProviderQueueResolver<QueuedLookupRequest>> queueResolverMock = new( );
+            Mock<ILogger<SagaResultCombiner>> combinerLoggerMock = new( );
+            SagaResultCombiner resultCombiner = new( combinerLoggerMock.Object );
+            Mock<ILogger<SagaCoordinatorBackgroundService>> loggerMock = new( );
+            HashSet<SupportedProviders> enabledProviders = [SupportedProviders.Spotify];
+
+            Mock<ISagaStateManager> sagaMgrWrapper = new( );
+            _ = sagaMgrWrapper
+                .Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( completeSaga );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.ReleaseFinalizeClaimAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, CancellationToken ct ) => _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+            _ = sagaMgrWrapper
+                .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+            _ = sagaMgrWrapper
+                .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( true );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( false );
+
+            return new SagaCoordinatorBackgroundService(
+                redisMock.Object,
+                sagaMgrWrapper.Object,
+                storageDouble.Object,
+                cacheMock.Object,
+                deduplicatorMock.Object,
+                resultCombiner,
+                queueResolverMock.Object,
+                enabledProviders,
+                loggerMock.Object
+            );
+        }
+
+        // N=8 concurrent handlers through a release gate
+        const int Concurrency = 8;
+        TaskCompletionSource gate = new( TaskCreationOptions.RunContinuationsAsynchronously );
+
+        async Task RunHandler( int _ ) {
+            await gate.Task;
+            SagaCoordinatorBackgroundService svc = BuildService( );
+            using CancellationTokenSource cts = new( TimeSpan.FromSeconds( 10 ) );
+            await svc.InvokeFinalizeForTestAsync( completeSaga, cts.Token );
+        }
+
+        Task<Task>[] racers = [.. Enumerable.Range( 0, Concurrency )
+            .Select( i => Task.Factory.StartNew(
+                ( ) => RunHandler( i ),
+                TestContext.CancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default
+            ) )];
+
+        await Task.Delay( 50, TestContext.CancellationToken );
+        gate.SetResult( );
+        await Task.WhenAll( racers.Select( t => t.Unwrap( ) ) );
+
+        // Assert - exactly one PDS write across all N concurrent handlers
+        Assert.AreEqual( 1, pdsWriteCount,
+            $"Expected exactly 1 PDS write under {Concurrency} concurrent handlers for the same generation, got {pdsWriteCount}" );
+    }
+
+    /// <summary>
+    /// N=8 concurrent handlers all racing to write the same generation (k=1) through the
+    /// non-terminal partial path (<see cref="SagaCoordinatorBackgroundService.InvokeWriteForTestAsync"/>
+    /// with <c>terminal: false</c>). The write-generation CAS (<see cref="ISagaStateManager.TryAdvanceWriteGenerationAsync"/>)
+    /// must ensure exactly one PDS write — the first racer to advance the generation wins; all
+    /// others find the CAS already advanced and return without writing. This is the direct
+    /// concurrent-partial-write dedup proof for the generation CAS.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ConcurrentPartialHandlers_SameGeneration_ProducesExactlyOnePdsWrite( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // Shared PDS write counter — the discriminator
+        int pdsWriteCount = 0;
+        Mock<IATProtoStorageService> storageDouble = new( );
+        _ = storageDouble
+            .Setup( s => s.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref pdsWriteCount );
+                string rkey = Guid.NewGuid( ).ToString( "N" );
+                return $"at://did:plc:test/com.bridgebeats.medialink/{rkey}";
+            } );
+
+        // One successful Spotify provider result — generation = Results.Count = 1
+        string resultJson = """{"isrc":"USRC99999002","trackName":"Race Test","artistName":"Test","url":"https://spotify.com/t/1"}""";
+        LookupSagaState partialSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC99999002",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -5 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        SagaCoordinatorBackgroundService BuildPartialService( ) {
+            Mock<IConnectionMultiplexer> redisMock = new( );
+            Mock<ISubscriber> subscriberMock = new( );
+            _ = redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( subscriberMock.Object );
+
+            Mock<IMediaLinkCacheRepository> cacheMock = new( );
+            _ = cacheMock
+                .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+
+            Mock<IRequestDeduplicator> deduplicatorMock = new( );
+            _ = deduplicatorMock
+                .Setup( d => d.ReleaseAsync( It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+
+            Mock<IProviderQueueResolver<QueuedLookupRequest>> queueResolverMock = new( );
+            Mock<ILogger<SagaResultCombiner>> combinerLoggerMock = new( );
+            SagaResultCombiner resultCombiner = new( combinerLoggerMock.Object );
+            Mock<ILogger<SagaCoordinatorBackgroundService>> loggerMock = new( );
+            HashSet<SupportedProviders> enabledProviders = [SupportedProviders.Spotify];
+
+            Mock<ISagaStateManager> sagaMgrWrapper = new( );
+            // Only TryAdvanceWriteGenerationAsync and ResetWriteGenerationAsync hit real Redis;
+            // all other saga manager calls are mocked to succeed without side effects.
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
+            _ = sagaMgrWrapper
+                .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Returns( Task.CompletedTask );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( false );
+
+            return new SagaCoordinatorBackgroundService(
+                redisMock.Object,
+                sagaMgrWrapper.Object,
+                storageDouble.Object,
+                cacheMock.Object,
+                deduplicatorMock.Object,
+                resultCombiner,
+                queueResolverMock.Object,
+                enabledProviders,
+                loggerMock.Object
+            );
+        }
+
+        // N=8 concurrent handlers through a release gate
+        const int Concurrency = 8;
+        TaskCompletionSource gate = new( TaskCreationOptions.RunContinuationsAsynchronously );
+
+        async Task RunHandler( int _ ) {
+            await gate.Task;
+            SagaCoordinatorBackgroundService svc = BuildPartialService( );
+            using CancellationTokenSource cts = new( TimeSpan.FromSeconds( 10 ) );
+            await svc.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+        }
+
+        Task<Task>[] racers = [.. Enumerable.Range( 0, Concurrency )
+            .Select( i => Task.Factory.StartNew(
+                ( ) => RunHandler( i ),
+                TestContext.CancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default
+            ) )];
+
+        await Task.Delay( 50, TestContext.CancellationToken );
+        gate.SetResult( );
+        await Task.WhenAll( racers.Select( t => t.Unwrap( ) ) );
+
+        // Assert - exactly one PDS write across all N concurrent handlers
+        Assert.AreEqual( 1, pdsWriteCount,
+            $"Expected exactly 1 PDS write under {Concurrency} concurrent partial handlers for the same generation, got {pdsWriteCount}" );
+    }
+
+    /// <summary>
+    /// Positive control: sequential handlers for distinct generations 1 then 2 each produce one
+    /// write. This distinguishes the duplicate-suppression mechanism from accidental total suppression.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SequentialDistinctGenerations_EachProduceOnePdsWrite( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // Generation 1: advance from 0 to 1 — must succeed
+        bool advancedToGen1 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 1, TestContext.CancellationToken
+        );
+        Assert.IsTrue( advancedToGen1, "Advancing from 0 to generation 1 must succeed" );
+
+        // Generation 2: advance from 1 to 2 — must succeed
+        bool advancedToGen2 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsTrue( advancedToGen2, "Advancing from 1 to generation 2 must succeed" );
+    }
+
+    /// <summary>
+    /// CAS primitive test: advance to 2, then attempt to advance to 1 (below stored) and 2
+    /// (equal to stored) — both must be rejected. Then advance to 3 (above stored) — must
+    /// succeed. Verifies the strict-less-than semantics of the Lua CAS.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task CasPrimitive_StrictlyLessThanSemantics( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // Advance to generation 2 — must succeed (stored is 0)
+        bool advancedTo2 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsTrue( advancedTo2, "Initial advance to generation 2 must succeed" );
+
+        // Attempt to advance to 1 (below stored 2) — must fail
+        bool advancedTo1 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 1, TestContext.CancellationToken
+        );
+        Assert.IsFalse( advancedTo1, "Advancing to generation 1 when stored is 2 must fail (below stored)" );
+
+        // Attempt to advance to 2 again (equal to stored 2) — must fail
+        bool advancedTo2Again = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsFalse( advancedTo2Again, "Advancing to generation 2 when stored is 2 must fail (equal to stored)" );
+
+        // Advance to 3 (above stored 2) — must succeed
+        bool advancedTo3 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 3, TestContext.CancellationToken
+        );
+        Assert.IsTrue( advancedTo3, "Advancing to generation 3 when stored is 2 must succeed" );
+    }
+
+    /// <summary>
+    /// Verifies the reset-then-re-advance round trip: advance to 2, reset back to 1 (the
+    /// prior generation, simulating a pre-durability write failure), then re-advance to 2
+    /// succeeds. This ensures the failure path leaves the saga in a retryable state.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ResetThenReAdvance_AllowsRetry( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // Advance to generation 2 — must succeed
+        bool firstAdvance = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsTrue( firstAdvance, "First advance to generation 2 must succeed" );
+
+        // Simulate pre-durability failure: advancedTo=2, prior=1
+        await _sagaManager.ResetWriteGenerationAsync( TestSagaId, 2, 1, TestContext.CancellationToken );
+
+        // After the conditional reset, stored=1, so re-advancing to 2 must succeed
+        bool reAdvance = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsTrue( reAdvance, "Re-advancing to generation 2 after reset to prior=1 must succeed" );
+    }
+
+    /// <summary>
+    /// Verifies the conditional semantics of <see cref="RedisSagaStateManager.ResetWriteGenerationAsync"/>:
+    /// a stale caller (handler A) that attempts to reset after a newer handler (handler B) has
+    /// already advanced the generation further must NOT clobber the higher generation. The stored
+    /// value must remain at the higher generation after the stale reset attempt.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ConditionalReset_StaleCallerDoesNotClobberHigherGeneration( ) {
+        // Arrange - seed the saga
+        _ = await _sagaManager.GetOrCreateAsync(
+            TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
+            QueuePriority.Interactive, TestContext.CancellationToken
+        );
+
+        // Handler A advances to generation 2
+        bool handlerAAdvance = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 2, TestContext.CancellationToken
+        );
+        Assert.IsTrue( handlerAAdvance, "Handler A must advance to generation 2" );
+
+        // Handler B advances further to generation 3 (overtakes handler A)
+        bool handlerBAdvance = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 3, TestContext.CancellationToken
+        );
+        Assert.IsTrue( handlerBAdvance, "Handler B must advance to generation 3" );
+
+        // Handler A's PDS write failed; it attempts a conditional reset from 2 back to 1.
+        // Because the stored generation is now 3 (not 2), the CAS condition fails and the
+        // reset must be skipped — stored must remain at 3.
+        await _sagaManager.ResetWriteGenerationAsync( TestSagaId, 2, 1, TestContext.CancellationToken );
+
+        // Verify by trying to advance to 3 again — must fail (stored is still 3, not 1)
+        bool reAdvanceTo3 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 3, TestContext.CancellationToken
+        );
+        Assert.IsFalse( reAdvanceTo3,
+            "Stored generation must still be 3 after the stale handler's conditional reset was refused" );
+
+        // Verify by advancing to 4 — must succeed (stored is 3)
+        bool advanceTo4 = await _sagaManager.TryAdvanceWriteGenerationAsync(
+            TestSagaId, 4, TestContext.CancellationToken
+        );
+        Assert.IsTrue( advanceTo4,
+            "Advancing to 4 from stored=3 must succeed, confirming the stale reset did not corrupt the generation" );
+    }
+}

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -1838,6 +1838,14 @@ public class SagaCoordinatorBackgroundServiceTests {
             s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
+
+        // Assert - dedup must never be released with null on this path; releasing null would hand
+        // waiters an empty completion for a saga whose result was already recorded
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), null, It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-URI failure must not release the dedup lock with null"
+        );
     }
 
     /// <summary>
@@ -2351,6 +2359,14 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Never,
             "Non-terminal write must not release a finalize claim it never held"
         );
+
+        // Assert - dedup must never be released with null on this path; releasing null would hand
+        // waiters an empty completion for a saga whose result was already recorded
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), null, It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-URI failure on the non-terminal path must not release the dedup lock with null"
+        );
     }
 
     /// <summary>
@@ -2543,6 +2559,207 @@ public class SagaCoordinatorBackgroundServiceTests {
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when <c>IndexResultAsync</c> throws after the durability line on the terminal
+    /// path, the deduplicator is still released with the non-null record URI and the method
+    /// completes without propagating the exception. The result is already durably written; cache
+    /// indexing is best-effort and must not interrupt waiter wakeup or bubble out.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenIndexFailsAfterDurability_StillReleasesDedupAndDoesNotThrow( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "cache indexing failed" ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — must complete without throwing even though IndexResultAsync fails
+        await service.InvokeWriteForTestAsync( completeSaga, terminal: true, cts.Token );
+
+        // Assert - dedup released with the non-null URI; the null sentinel must never reach waiters
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( TestLookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Dedup must be released with the record URI even when post-release indexing fails"
+        );
+
+        // Assert - URI was durably stored before the release
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert - finalize claim was never returned; it is retained to prevent re-entrant writes
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-release index failure must not release the finalize claim"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when <c>IndexResultAsync</c> throws after the durability line on the
+    /// non-terminal path, the deduplicator is still released with the non-null record URI and the
+    /// method completes without propagating the exception. The partial result is already durably
+    /// written; cache indexing is best-effort and must not interrupt waiter wakeup or bubble out.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WritePartial_WhenIndexFailsAfterDurability_StillReleasesDedupAndDoesNotThrow( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState partialSaga = CreateCompleteSaga( ) with { IsPartial = true };
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "cache indexing failed" ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — must complete without throwing even though IndexResultAsync fails
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - dedup released with the non-null URI; the null sentinel must never reach waiters
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( TestLookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Dedup must be released with the record URI even when post-release indexing fails"
+        );
+
+        // Assert - write generation was not reset; the durability line was crossed
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-release index failure must not reset the write generation"
+        );
+
+        // Assert - finalize claim was never acquired or released on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not call TryClaimFinalizeAsync"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when <c>IndexResultAsync</c> throws <see cref="OperationCanceledException"/>
+    /// after the durability line on the terminal path, the deduplicator is still released with the
+    /// non-null record URI and the method completes without propagating the exception. The result is
+    /// already durably written; an OCE from best-effort cache indexing must not interrupt waiter
+    /// wakeup or bubble to the outer rethrowing <c>catch (OperationCanceledException)</c>.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Finalize_WhenIndexCanceledAfterDurability_StillReleasesDedupAndDoesNotThrow( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new OperationCanceledException( ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — must complete without throwing even though IndexResultAsync is canceled
+        await service.InvokeWriteForTestAsync( completeSaga, terminal: true, cts.Token );
+
+        // Assert - dedup released with the non-null URI; an OCE from indexing must not suppress waiter wakeup
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( TestLookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Dedup must be released with the record URI even when post-release indexing is canceled"
+        );
+
+        // Assert - finalize claim was never returned; it is retained to prevent re-entrant writes
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-release OCE from indexing must not release the finalize claim"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when <c>IndexResultAsync</c> throws <see cref="OperationCanceledException"/>
+    /// after the durability line on the non-terminal path, the deduplicator is still released with
+    /// the non-null record URI and the method completes without propagating the exception. An OCE
+    /// from best-effort cache indexing must not interrupt waiter wakeup or bubble out.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WritePartial_WhenIndexCanceledAfterDurability_StillReleasesDedupAndDoesNotThrow( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState partialSaga = CreateCompleteSaga( ) with { IsPartial = true };
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _sagaManagerMock
+            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new OperationCanceledException( ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — must complete without throwing even though IndexResultAsync is canceled
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - dedup released with the non-null URI; an OCE from indexing must not suppress waiter wakeup
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( TestLookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Dedup must be released with the record URI even when post-release indexing is canceled"
+        );
+
+        // Assert - write generation was not reset; the durability line was crossed
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Post-release OCE from indexing must not reset the write generation"
+        );
+
+        // Assert - finalize claim was never acquired or released on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not call TryClaimFinalizeAsync"
         );
     }
 

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -85,6 +85,11 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock
             .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
+
+        // By default the write-generation CAS advances (first call wins per generation)
+        _ = _sagaManagerMock
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
     }
 
     #region Constructor Tests
@@ -273,8 +278,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - Start and quickly cancel after one poll cycle
         using CancellationTokenSource cts = new( );
@@ -356,8 +361,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -385,7 +390,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Should have cached the result
         _cacheRepositoryMock.Verify(
-            c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -421,8 +426,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -476,8 +481,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                 return callCount == 1 ? throw new InvalidOperationException( "Simulated write failure" ) : TestRecordUri;
             } );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -577,8 +582,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -646,8 +651,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -729,8 +734,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -839,8 +844,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -944,8 +949,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -1027,8 +1032,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -1132,8 +1137,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -1204,8 +1209,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - start the service, then simulate a saga completion event via Pub/Sub
         using CancellationTokenSource cts = new( );
@@ -1308,8 +1313,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -1378,8 +1383,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - polling runs immediately on startup
         using CancellationTokenSource cts = new( );
@@ -1415,12 +1420,13 @@ public class SagaCoordinatorBackgroundServiceTests {
     #region Finalize Claim Tests
 
     /// <summary>
-    /// Verifies that a handler that loses the finalize claim performs no PDS write and does not
-    /// call SetFinalResultUriAsync. The loser must be completely silent.
+    /// Verifies that a terminal handler that loses the finalize claim performs no PDS write and
+    /// does not call SetFinalResultUriAsync or ResetWriteGenerationAsync. The terminal path is
+    /// gated by the claim only (not the generation CAS), so the loser is completely silent.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task Finalize_WhenClaimLost_DoesNotWrite( ) {
+    public async Task Finalize_WhenClaimLost_IsCompletelySilent( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
@@ -1432,7 +1438,7 @@ public class SagaCoordinatorBackgroundServiceTests {
             ) )
             .ReturnsAsync( [completeSaga] );
 
-        // The claim is already held by another handler
+        // Finalize claim is already held by a concurrent handler
         _ = _sagaManagerMock
             .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( false );
@@ -1466,6 +1472,75 @@ public class SagaCoordinatorBackgroundServiceTests {
             d => d.ReleaseAsync( It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
+
+        // Assert - No generation reset: the terminal path does not advance the generation, so
+        // there is nothing to roll back when the claim is lost.
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a non-terminal handler that loses the write-generation CAS (the generation was
+    /// already advanced by a concurrent handler to the same level) performs no PDS write and is
+    /// completely silent. The non-terminal path is gated by the CAS; the terminal path uses the
+    /// finalize claim instead.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_NonTerminal_WhenGenerationCasLost_IsCompletelySilent( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        string resultJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        LookupSagaState partialSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -1 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        // The generation was already advanced by a concurrent handler
+        _ = _sagaManagerMock
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act - drive via the parameterized write entry point
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - No PDS write (the loser must be completely silent)
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - No partial URI recorded
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - Finalize claim never acquired on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
     }
 
     /// <summary>
@@ -1489,8 +1564,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -1524,8 +1599,9 @@ public class SagaCoordinatorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// Verifies that a failed PDS write releases the finalize claim so the next poll cycle can
-    /// retry. The dedup lock is released with null to unblock waiters.
+    /// Verifies that a failed PDS write on the terminal path releases the finalize claim so the next
+    /// poll cycle can retry, and releases the dedup lock with null to unblock waiters. The generation
+    /// is NOT reset on the terminal path because the terminal path never advances the generation.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -1558,7 +1634,14 @@ public class SagaCoordinatorBackgroundServiceTests {
             // Expected
         }
 
-        // Assert - Claim released so the next poll can retry
+        // Assert - Generation NOT reset: the terminal path never advances the generation,
+        // so there is nothing to roll back after a PDS write failure.
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
+        // Assert - Claim released so the next poll can re-finalize
         _sagaManagerMock.Verify(
             s => s.ReleaseFinalizeClaimAsync( completeSaga.SagaId, It.IsAny<CancellationToken>( ) ),
             Times.Once
@@ -1670,8 +1753,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -1698,15 +1781,14 @@ public class SagaCoordinatorBackgroundServiceTests {
 
     /// <summary>
     /// Verifies that a failure occurring after the final result URI has been durably recorded does
-    /// NOT release the finalize claim. Retaining the claim prevents a re-entrant PDS write against
-    /// a URI that was already written. Pairs with
+    /// NOT reset the write generation or release the finalize claim. Retaining both prevents a
+    /// re-entrant PDS write against a URI that was already written. Pairs with
     /// <see cref="Finalize_WhenPdsWriteFails_ReleasesClaimAndDedup"/> (pre-URI failure) as a
-    /// discriminator: together they prove the release is conditioned on the durability line, not
-    /// unconditional.
+    /// discriminator: together they prove the release is conditioned on the durability line.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task Finalize_WhenFailureAfterUriRecorded_DoesNotReleaseClaim( ) {
+    public async Task Finalize_WhenFailureAfterUriRecorded_DoesNotResetGenerationOrReleaseClaim( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
@@ -1745,6 +1827,12 @@ public class SagaCoordinatorBackgroundServiceTests {
             // Expected
         }
 
+        // Assert - No generation reset after the durability line
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
         // Assert - A failure after the URI is recorded must retain the claim (no release)
         _sagaManagerMock.Verify(
             s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
@@ -1754,9 +1842,10 @@ public class SagaCoordinatorBackgroundServiceTests {
 
     /// <summary>
     /// Verifies that a cancellation mid-finalize (before the PDS write returns) releases the
-    /// finalize claim so the next host restart can re-finalize, but does NOT release the dedup lock
-    /// with a null URI (which would hand waiters a stale empty completion for a healthy saga) and
-    /// does NOT delete the saga.
+    /// finalize claim so the next host restart can re-finalize, but does NOT reset the write
+    /// generation (the terminal path never advances it), does NOT release the dedup lock with a
+    /// null URI (which would hand waiters a stale empty completion for a healthy saga), and does
+    /// NOT delete the saga.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -1793,6 +1882,12 @@ public class SagaCoordinatorBackgroundServiceTests {
             // Expected
         }
 
+        // Assert - Generation NOT reset: the terminal path never advances the generation.
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
         // Assert - Claim must be released so the next host can re-finalize
         _sagaManagerMock.Verify(
             s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
@@ -1814,14 +1909,14 @@ public class SagaCoordinatorBackgroundServiceTests {
 
     /// <summary>
     /// Verifies that a cancellation arriving after the final result URI is durably recorded does NOT
-    /// release the finalize claim. Retaining the claim prevents a re-entrant PDS write against an
-    /// already-recorded URI. The dedup lock is also never released here. Pairs with
-    /// <see cref="Finalize_WhenCancelledMidFinalize_ReleasesClaimButNotDedup"/> (pre-URI cancellation
-    /// → claim released) to prove the cancellation catch is conditioned on the durability line.
+    /// reset the write generation or release the finalize claim. Retaining both prevents a re-entrant
+    /// PDS write against an already-recorded URI. The dedup lock is also never released here. Pairs
+    /// with <see cref="Finalize_WhenCancelledMidFinalize_ReleasesClaimButNotDedup"/>
+    /// (pre-URI cancellation → claim released) to prove the release is conditioned on the durability line.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task Finalize_WhenCancelledAfterUriRecorded_DoesNotReleaseClaim( ) {
+    public async Task Finalize_WhenCancelledAfterUriRecorded_DoesNotResetGenerationOrReleaseClaim( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
@@ -1860,6 +1955,12 @@ public class SagaCoordinatorBackgroundServiceTests {
             // Expected
         }
 
+        // Assert - No generation reset after the durability line
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
+        );
+
         // Assert - Claim must NOT be released; releasing would allow a re-entrant PDS write against
         // a URI that is already recorded
         _sagaManagerMock.Verify(
@@ -1877,6 +1978,378 @@ public class SagaCoordinatorBackgroundServiceTests {
         _sagaManagerMock.Verify(
             s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
+        );
+    }
+
+    /// <summary>
+    /// Verifies the generation-bounded write count for an N=3 saga. The non-terminal (partial)
+    /// path is CAS-gated: calling it with result counts 1, 2, 3 produces three writes (one per
+    /// distinct generation level), and two redundant calls at generation 3 are silently dropped
+    /// by the CAS. The terminal write uses the finalize claim instead of the CAS.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_GenerationBoundedWrites_ProducesOneWritePerDistinctGeneration( ) {
+        // Arrange - N=3 provider saga with results at counts 1, 2, 3
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        // Set up mock to advance generation monotonically using a local counter
+        int storedGeneration = 0;
+        _ = _sagaManagerMock
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string _, int gen, CancellationToken _ ) => {
+                if (gen > storedGeneration) {
+                    storedGeneration = gen;
+                    return true;
+                }
+                return false;
+            } );
+
+        // Build three sagas representing distinct generations k=1, k=2, k=3
+        string spotifyJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        string appleMusicJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://music.apple.com/album/1"}""";
+        string tidalJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://tidal.com/track/1"}""";
+
+        LookupSagaState sagaGen1 = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -5 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify, IsComplete: true, IsSuccess: true,
+                    ResultJson: spotifyJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null )
+            },
+            FinalResultUri = null,
+            IsPartial = false
+        };
+
+        LookupSagaState sagaGen2 = sagaGen1 with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify, IsComplete: true, IsSuccess: true,
+                    ResultJson: spotifyJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null ),
+                [SupportedProviders.AppleMusic] = new(
+                    Provider: SupportedProviders.AppleMusic, IsComplete: true, IsSuccess: true,
+                    ResultJson: appleMusicJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null )
+            }
+        };
+
+        LookupSagaState sagaGen3 = sagaGen1 with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify, IsComplete: true, IsSuccess: true,
+                    ResultJson: spotifyJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null ),
+                [SupportedProviders.AppleMusic] = new(
+                    Provider: SupportedProviders.AppleMusic, IsComplete: true, IsSuccess: true,
+                    ResultJson: appleMusicJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null ),
+                [SupportedProviders.Tidal] = new(
+                    Provider: SupportedProviders.Tidal, IsComplete: true, IsSuccess: true,
+                    ResultJson: tidalJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null )
+            }
+        };
+
+        // Also set up the claim mock to only allow the first terminal winner through
+        bool claimHeld = false;
+        _ = _sagaManagerMock
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, CancellationToken _ ) => {
+                bool won = !claimHeld;
+                claimHeld = true;
+                return Task.FromResult( won );
+            } );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act - invoke 5 times:
+        //   k=1 non-terminal: CAS advances, partial write
+        //   k=2 non-terminal: CAS advances, partial write
+        //   k=3 terminal (first): claim won, final write
+        //   k=3 terminal (dup):   claim lost, no write
+        //   k=3 terminal (dup):   claim lost, no write
+        await service.InvokeWriteForTestAsync( sagaGen1, terminal: false, cts.Token );
+        await service.InvokeWriteForTestAsync( sagaGen2, terminal: false, cts.Token );
+        await service.InvokeWriteForTestAsync( sagaGen3, terminal: true, cts.Token );
+        await service.InvokeWriteForTestAsync( sagaGen3, terminal: true, cts.Token );
+        await service.InvokeWriteForTestAsync( sagaGen3, terminal: true, cts.Token );
+
+        // Assert - exactly 3 PDS writes (two partial at k=1, k=2; one terminal at k=3)
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 3 ),
+            "Expected exactly two partial writes (k=1, k=2) and one terminal write (k=3)"
+        );
+    }
+
+    /// <summary>
+    /// Verifies the non-terminal write path: <c>terminal=false</c> sets <c>IsPartial=true</c> on
+    /// the combined result, calls <c>SetPartialResultUriAsync</c> (not <c>SetFinalResultUriAsync</c>),
+    /// and never calls <c>SetIsPartialAsync(false)</c> or <c>TryClaimFinalizeAsync</c>.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_NonTerminal_WritesPartialAndDoesNotClaimFinalize( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        string resultJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        LookupSagaState partialSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -1 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act - non-terminal write
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - the combined result written to PDS carries IsPartial=true
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync(
+                It.Is<MediaLinkResult>( r => r.IsPartial ),
+                It.IsAny<CancellationToken>( )
+            ),
+            Times.Once,
+            "Non-terminal write must produce a result with IsPartial=true"
+        );
+
+        // Assert - partial URI stored, not final URI
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not set the final result URI"
+        );
+
+        // Assert - the finalize claim is never acquired on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not call TryClaimFinalizeAsync"
+        );
+
+        // Assert - IsPartial flag is never cleared on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( It.IsAny<string>( ), false, It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not clear the IsPartial flag"
+        );
+    }
+
+    /// <summary>
+    /// Verifies the terminal write path: <c>terminal=true</c> clears <c>IsPartial</c> (calls
+    /// <c>SetIsPartialAsync(false)</c>) exactly once after recording the final URI. This is the
+    /// positive control that distinguishes the two write paths.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_Terminal_ClearsIsPartialAfterFinalUri( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState completeSaga = CreateCompleteSaga( );
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act - terminal write
+        await service.InvokeWriteForTestAsync( completeSaga, terminal: true, cts.Token );
+
+        // Assert - IsPartial cleared exactly once after the final URI
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( TestSagaId, false, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Terminal write must clear the IsPartial flag once"
+        );
+
+        // Assert - final URI recorded (not partial)
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Terminal write must not call SetPartialResultUriAsync"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a PDS write failure on the non-terminal path resets the write generation
+    /// but does NOT release the finalize claim (which was never acquired on the non-terminal
+    /// path). The dedup lock is also not released with null on the non-terminal failure path.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_NonTerminal_WhenPdsWriteFails_ResetsGenerationAndDoesNotReleaseClaim( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        string resultJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        LookupSagaState partialSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -1 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        // PDS write fails before the durability line
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "PDS unavailable" ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - generation conditionally reset so the next trigger can re-advance and retry
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Non-terminal pre-durability failure must reset the write generation"
+        );
+
+        // Assert - finalize claim NEVER acquired or released on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not call TryClaimFinalizeAsync"
+        );
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not release a finalize claim it never held"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a failure occurring after the partial result URI has been durably recorded
+    /// (<c>SetPartialResultUriAsync</c> succeeds) does NOT reset the write generation. Retaining
+    /// the generation prevents a re-entrant duplicate partial write against a URI that was already
+    /// written. Pairs with <see cref="WriteResult_NonTerminal_WhenPdsWriteFails_ResetsGenerationAndDoesNotReleaseClaim"/>
+    /// (pre-durability failure → generation reset) as a discriminator: together they prove the
+    /// reset is conditioned on the durability line.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_NonTerminal_WhenFailureAfterPartialUriRecorded_DoesNotResetGeneration( ) {
+        // Arrange
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        string resultJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        LookupSagaState partialSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -1 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: resultJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        // PDS write succeeds and returns a URI
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        // SetPartialResultUriAsync succeeds — partial URI durably recorded (uriRecorded = true)
+        _ = _sagaManagerMock
+            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        // The first post-durability step throws — simulates a failure after the durability line
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "cache indexing failed" ) );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act
+        await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
+
+        // Assert - generation must NOT be reset after the durability line; retaining it prevents
+        // a re-entrant duplicate partial write
+        _sagaManagerMock.Verify(
+            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal post-durability failure must not reset the write generation"
+        );
+
+        // Assert - finalize claim NEVER acquired or released on the non-terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not call TryClaimFinalizeAsync"
+        );
+        _sagaManagerMock.Verify(
+            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal write must not release a finalize claim it never held"
         );
     }
 
@@ -1905,8 +2378,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _atProtoStorageMock.Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( TestRecordUri );
 
-        _ = _cacheRepositoryMock.Setup( c => c.CacheResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( TestRecordUri );
+        _ = _cacheRepositoryMock.Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
 
         // Act - polling processes both sagas
         using CancellationTokenSource cts = new( );
@@ -1924,6 +2397,152 @@ public class SagaCoordinatorBackgroundServiceTests {
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
             Times.Exactly( 2 )
+        );
+    }
+
+    /// <summary>
+    /// Regression guard: a saga that becomes complete with its final leg FAILING (so the successful
+    /// provider count, the generation, does not grow) must still finalize. The terminal write is
+    /// gated by the finalize claim only; it must NOT be skipped by the CAS even when the generation
+    /// is unchanged from the previous partial write.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Terminal_WhenCompletedViaFailingLeg_StillFinalizes( ) {
+        // Arrange — Spotify succeeded (generation=1 partial written), Tidal failed.
+        // The saga is now complete but the successful count (generation) stayed at 1.
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        string spotifyJson = """{"isrc":"USRC12345678","trackName":"Test Song","artistName":"Test Artist","url":"https://open.spotify.com/track/abc123"}""";
+        LookupSagaState completedViaFailure = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -2 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: true,
+                    ResultJson: spotifyJson,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: null
+                ),
+                [SupportedProviders.Tidal] = new(
+                    Provider: SupportedProviders.Tidal,
+                    IsComplete: true,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: "Rate limited"
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = true
+        };
+
+        _ = _atProtoStorageMock
+            .Setup( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+
+        _ = _cacheRepositoryMock
+            .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — drive the terminal write directly
+        await service.InvokeWriteForTestAsync( completedViaFailure, terminal: true, cts.Token );
+
+        // Assert — final URI recorded (saga finalized despite unchanged generation)
+        _sagaManagerMock.Verify(
+            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once,
+            "Terminal write must call SetFinalResultUriAsync even when the generation did not grow"
+        );
+
+        // Assert — partial flag cleared
+        _sagaManagerMock.Verify(
+            s => s.SetIsPartialAsync( TestSagaId, false, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+
+        // Assert — generation CAS was never consulted on the terminal path
+        _sagaManagerMock.Verify(
+            s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Terminal write must not call TryAdvanceWriteGenerationAsync"
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a non-terminal <see cref="SagaCoordinatorBackgroundService.InvokeWriteForTestAsync"/>
+    /// with a null combine result (no successful results yet) does NOT delete the saga and does NOT
+    /// release the dedup lock. More providers are still outstanding; the saga must survive to receive
+    /// their results.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task WriteResult_NonTerminal_WhenNullCombineResult_DoesNotDeleteOrRelease( ) {
+        // Arrange — saga with only a failed provider; combiner returns null for allowIncomplete=true
+        SagaCoordinatorBackgroundService service = CreateService( );
+
+        LookupSagaState sagaWithNoSuccesses = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes( -1 ),
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    Provider: SupportedProviders.Spotify,
+                    IsComplete: true,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: "Rate limited"
+                ),
+                [SupportedProviders.Tidal] = new(
+                    Provider: SupportedProviders.Tidal,
+                    IsComplete: false,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: null,
+                    ErrorMessage: null
+                )
+            },
+            FinalResultUri = null,
+            IsPartial = false
+        };
+
+        _ = _sagaManagerMock
+            .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
+
+        // Act — non-terminal write with no successful results yet
+        await service.InvokeWriteForTestAsync( sagaWithNoSuccesses, terminal: false, cts.Token );
+
+        // Assert — saga must NOT be deleted: more providers are still in flight
+        _sagaManagerMock.Verify(
+            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal null combine must not delete the saga"
+        );
+
+        // Assert — dedup lock must NOT be released: the saga is still live
+        _deduplicatorMock.Verify(
+            d => d.ReleaseAsync( It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Non-terminal null combine must not release the deduplication lock"
+        );
+
+        // Assert — no PDS write
+        _atProtoStorageMock.Verify(
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never
         );
     }
 

--- a/src/BridgeBeats.Contracts/Interfaces/IMediaLinkCacheRepository.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IMediaLinkCacheRepository.cs
@@ -82,13 +82,15 @@ public interface IMediaLinkCacheRepository {
     Task<(MediaLinkResult result, string recordUri, bool isStale)?> TryGetCachedResultByCardIdAsync( string cardId );
 
     /// <summary>
-    /// Stores or updates (upserts) a finished result, indexing it under all of its lookup keys,
-    /// and returns the AT-URI of the backing record.
+    /// Indexes an already-stored result by its <paramref name="recordUri"/>, (re)building all
+    /// Redis lookup pointers for the result. Does NOT write the result body to the PDS; the caller
+    /// is responsible for the durable PDS write and passes the resulting URI here.
     /// </summary>
-    /// <param name="result">The <see cref="MediaLinkResult"/> to cache.</param>
+    /// <param name="result">The <see cref="MediaLinkResult"/> whose lookup keys are indexed.</param>
+    /// <param name="recordUri">The AT-URI (<c>at://…</c>) of the already-stored PDS record.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task whose result is the AT-URI (<c>at://…</c>) of the cached record.</returns>
-    Task<string> CacheResultAsync( MediaLinkResult result, CancellationToken cancellationToken = default );
+    /// <returns>A task that completes when the Redis pointers have been (re)built.</returns>
+    Task IndexResultAsync( MediaLinkResult result, string recordUri, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Registers additional input-link aliases for a record that is already cached, so future

--- a/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
@@ -212,6 +212,40 @@ public interface ISagaStateManager {
     Task ReleaseFinalizeClaimAsync( string sagaId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Atomically advances the saga's write generation to <paramref name="generation"/> only when
+    /// the stored generation is strictly less than <paramref name="generation"/>. Guards against
+    /// redundant PDS writes: exactly one concurrent handler wins per generation level, so the
+    /// total number of writes is bounded by the number of providers.
+    /// </summary>
+    /// <param name="sagaId">The saga id to advance.</param>
+    /// <param name="generation">The generation to advance to; typically the number of provider results in the combined result.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>
+    /// A task whose result is <see langword="true"/> when this caller advanced the generation (and
+    /// must perform the PDS write), or <see langword="false"/> when the stored generation was
+    /// already at or above <paramref name="generation"/> and the write should be skipped.
+    /// </returns>
+    Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Conditionally resets the saga's write generation from <paramref name="advancedTo"/> back to
+    /// <paramref name="priorGeneration"/>, used exclusively on the non-terminal pre-durability PDS
+    /// write failure path so the next retry can re-advance and re-write. The reset is a conditional
+    /// compare-and-set: it only takes effect when the stored generation still equals
+    /// <paramref name="advancedTo"/>, so a concurrent handler that has already advanced further is
+    /// not regressed. Must not be called after a successful write.
+    /// </summary>
+    /// <param name="sagaId">The saga id whose write generation should be reset.</param>
+    /// <param name="advancedTo">
+    /// The generation this caller previously advanced to; the stored value must equal this for the
+    /// reset to take effect.
+    /// </param>
+    /// <param name="priorGeneration">The generation to restore; typically <c>advancedTo - 1</c>.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A task that completes when the conditional reset attempt has been made.</returns>
+    Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Seeds the saga with an initial, not-yet-complete provider state for each of the given
     /// providers at the start of a saga, so the set of providers that must complete is known.
     /// </summary>

--- a/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
+++ b/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
@@ -62,6 +62,15 @@ public sealed record LookupSagaState {
     [JsonPropertyName( "isPartial" )]
     public bool IsPartial { get; init; }
 
+    /// <summary>
+    /// The highest provider-count already durably written to the PDS for this saga. Guards
+    /// against redundant writes: a write for generation <c>k</c> proceeds only when the stored
+    /// generation is strictly less than <c>k</c>, ensuring each provider-count level is written
+    /// at most once and the write count is bounded by the number of providers.
+    /// </summary>
+    [JsonPropertyName( "writeGeneration" )]
+    public int WriteGeneration { get; init; }
+
     /// <summary>The provider that seeded this lookup (the source URL's provider), when known.</summary>
     [JsonPropertyName( "initialProvider" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]

--- a/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
@@ -233,23 +233,20 @@ public sealed partial class RedisMediaLinkCache : IMediaLinkCacheRepository {
     }
 
     /// <summary>
-    /// Stores a result on the PDS and (re)builds its Redis lookup pointers.
+    /// Indexes an already-stored result by its <paramref name="recordUri"/>, (re)building all
+    /// Redis lookup pointers. Does NOT write the result body to the PDS.
     /// </summary>
-    /// <param name="result">The result to store and index.</param>
-    /// <param name="cancellationToken">Token forwarded to the PDS write.</param>
-    /// <returns>The PDS record URI the pointers reference.</returns>
-    /// <remarks>
-    /// Writes the body to the PDS first (creating/updating with a deterministic rkey), then clears
-    /// any stale lookup keys for the record and adds the current set of pointers. The PDS write is
-    /// the durable step; the Redis pointers are derived and can be rebuilt.
-    /// </remarks>
+    /// <param name="result">The result whose lookup keys are indexed.</param>
+    /// <param name="recordUri">The AT-URI of the already-stored PDS record.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A task that completes when the Redis pointers have been (re)built.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="result"/> is null.</exception>
-    public async Task<string> CacheResultAsync( MediaLinkResult result, CancellationToken cancellationToken = default ) {
+    /// <exception cref="ArgumentException">Thrown when <paramref name="recordUri"/> is null, empty, or whitespace.</exception>
+    public async Task IndexResultAsync( MediaLinkResult result, string recordUri, CancellationToken cancellationToken = default ) {
         ArgumentNullException.ThrowIfNull( result );
+        ArgumentException.ThrowIfNullOrWhiteSpace( recordUri );
 
         try {
-            // Store on ATProto PDS first (creates/updates with deterministic rkey)
-            string recordUri = await _atprotoStorage.StoreMediaLinkResultAsync( result, cancellationToken );
             string rkey = RecordKeyGenerator.GenerateRkey( result );
 
             // Remove old lookup keys before adding new ones (explicit cleanup on refresh)
@@ -263,7 +260,6 @@ public sealed partial class RedisMediaLinkCache : IMediaLinkCacheRepository {
                 string sanitizedRecordUri = recordUri.SanitizeForLogging( );
                 LogCachedResult( _logger, sanitizedRkey, sanitizedRecordUri );
             }
-            return recordUri;
         } catch (Exception ex) {
             LogCacheError( _logger, ex );
             throw;

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -471,6 +471,16 @@ public static class LogEventIds {
             /// </summary>
             public const int RedisSagaStateManagerFinalizeClaimReleased = 1318;
 
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogWriteGenerationAdvanced"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerWriteGenerationAdvanced = 1319;
+
+            /// <summary>
+            /// EventId for <see cref="RedisSagaStateManager.LogWriteGenerationReset"/>.
+            /// </summary>
+            public const int RedisSagaStateManagerWriteGenerationReset = 1320;
+
             // RedisRequestDeduplicator (1350-1374)
 
             /// <summary>

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -86,6 +86,9 @@ public sealed partial class RedisSagaStateManager(
     /// <summary>Core hash field: single-winner marker that finalization has been claimed. Literal: <c>"finalizeClaimed"</c>.</summary>
     private const string FieldFinalizeClaimed = "finalizeClaimed";
 
+    /// <summary>Core hash field: the highest provider-count already durably written to the PDS. Literal: <c>"writeGeneration"</c>.</summary>
+    private const string FieldWriteGeneration = "writeGeneration";
+
     // Hash field names for provider state
 
     /// <summary>Provider hash field: whether the provider has finished. Literal: <c>"isComplete"</c>.</summary>
@@ -244,6 +247,7 @@ public sealed partial class RedisSagaStateManager(
         _ = fields.TryGetValue( FieldInitialProvider, out string? initialProviderStr );
         _ = fields.TryGetValue( FieldRateLimitInfo, out string? rateLimitInfoJson );
         _ = fields.TryGetValue( FieldOriginPriority, out string? originPriorityStr );
+        _ = fields.TryGetValue( FieldWriteGeneration, out string? writeGenerationStr );
 
         DateTimeOffset createdAt = !string.IsNullOrEmpty( createdAtStr )
             ? DateTimeOffset.Parse( createdAtStr )
@@ -267,6 +271,10 @@ public sealed partial class RedisSagaStateManager(
                 ? parsedPriority
                 : QueuePriority.Background;
 
+        // Pre-existing sagas that have no writeGeneration field default to 0, so the first
+        // write against them advances normally.
+        _ = int.TryParse( writeGenerationStr, out int writeGeneration );
+
         // Load provider states
         Dictionary<SupportedProviders, ProviderLookupState> providerStates = await LoadProviderStatesAsync( db, sagaId );
 
@@ -282,7 +290,8 @@ public sealed partial class RedisSagaStateManager(
             IsPartial = isPartial,
             InitialProvider = initialProvider,
             RateLimitInfo = rateLimitInfo,
-            OriginPriority = originPriority
+            OriginPriority = originPriority,
+            WriteGeneration = writeGeneration
         };
     }
 
@@ -548,6 +557,101 @@ public sealed partial class RedisSagaStateManager(
         _ = await db.KeyExpireAsync( key, ttl );
 
         LogFinalizeClaimReleased( _logger, sagaId );
+    }
+
+    /// <summary>
+    /// Atomically advances the write generation to <paramref name="generation"/> only when the
+    /// stored generation is strictly less than <paramref name="generation"/>, using a Lua
+    /// compare-and-set so the advancement is exactly one winner per generation level even under
+    /// concurrent callers. Refreshes the saga TTL after a successful advance.
+    /// </summary>
+    /// <param name="sagaId">The saga to advance.</param>
+    /// <param name="generation">The generation to advance to.</param>
+    /// <param name="ct">A cancellation token (not currently observed).</param>
+    /// <returns>
+    /// <see langword="true"/> when this caller advanced the generation (and must perform the PDS
+    /// write); <see langword="false"/> when the stored generation was already at or above
+    /// <paramref name="generation"/> and the write should be skipped.
+    /// </returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
+    public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken ct = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+
+        string key = GetSagaKey( sagaId );
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+
+        RedisResult result = await db.ScriptEvaluateAsync(
+            AdvanceWriteGenerationScript,
+            keys: [key],
+            values: [FieldWriteGeneration, generation]
+        );
+
+        bool advanced = (int)result == 1;
+
+        if (advanced) {
+            _ = await db.KeyExpireAsync( key, ttl );
+            LogWriteGenerationAdvanced( _logger, sagaId, generation );
+        }
+
+        return advanced;
+    }
+
+    /// <summary>
+    /// Lua script that advances the write-generation field only when the stored value is strictly
+    /// less than the requested generation. Returns 1 on advance, 0 when the stored value is
+    /// already at or above the requested generation.
+    /// </summary>
+    private const string AdvanceWriteGenerationScript =
+        "local cur = tonumber(redis.call('hget', KEYS[1], ARGV[1]) or '0'); " +
+        "if cur < tonumber(ARGV[2]) then redis.call('hset', KEYS[1], ARGV[1], ARGV[2]); return 1 " +
+        "else return 0 end";
+
+    /// <summary>
+    /// Lua script that resets the write-generation field from <c>ARGV[2]</c> back to <c>ARGV[3]</c>
+    /// only when the stored value still equals <c>ARGV[2]</c> (the value this caller advanced to).
+    /// Returns 1 when the reset took effect, 0 when a concurrent handler has already advanced
+    /// beyond the caller's generation and the reset is skipped to avoid clobbering a later write.
+    /// </summary>
+    private const string ResetWriteGenerationScript =
+        "local cur = tonumber(redis.call('hget', KEYS[1], ARGV[1]) or '0'); " +
+        "if cur == tonumber(ARGV[2]) then redis.call('hset', KEYS[1], ARGV[1], ARGV[3]); return 1 " +
+        "else return 0 end";
+
+    /// <summary>
+    /// Conditionally resets the write generation from <paramref name="advancedTo"/> back to
+    /// <paramref name="priorGeneration"/> after a non-terminal pre-durability PDS write failure,
+    /// so the next retry can re-advance and re-write. The reset only takes effect when the stored
+    /// generation still equals <paramref name="advancedTo"/>; if a concurrent handler has already
+    /// advanced the generation further, the stored value is left untouched. Refreshes the TTL on
+    /// a successful reset.
+    /// </summary>
+    /// <param name="sagaId">The saga whose write generation should be reset.</param>
+    /// <param name="advancedTo">The generation this caller advanced to; the stored value must equal this for the reset to take effect.</param>
+    /// <param name="priorGeneration">The generation to restore; typically <c>advancedTo - 1</c>.</param>
+    /// <param name="ct">A cancellation token (not currently observed).</param>
+    /// <returns>A task that completes when the conditional reset attempt has been made and the TTL optionally refreshed.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
+    public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken ct = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+
+        string key = GetSagaKey( sagaId );
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+
+        RedisResult result = await db.ScriptEvaluateAsync(
+            ResetWriteGenerationScript,
+            keys: [key],
+            values: [FieldWriteGeneration, advancedTo, priorGeneration]
+        );
+
+        bool reset = (int)result == 1;
+
+        if (reset) {
+            _ = await db.KeyExpireAsync( key, ttl );
+        }
+
+        LogWriteGenerationReset( _logger, sagaId, advancedTo, priorGeneration, reset );
     }
 
     /// <summary>
@@ -951,6 +1055,28 @@ public sealed partial class RedisSagaStateManager(
         Level = LogLevel.Debug,
         Message = "Finalize claim released for saga {SagaId}" )]
     internal static partial void LogFinalizeClaimReleased( ILogger logger, string sagaId );
+
+    /// <summary>Logs that the write generation was advanced for a saga.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="sagaId">The saga id.</param>
+    /// <param name="generation">The generation advanced to.</param>
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerWriteGenerationAdvanced,
+        Level = LogLevel.Debug,
+        Message = "Write generation advanced to {Generation} for saga {SagaId}" )]
+    internal static partial void LogWriteGenerationAdvanced( ILogger logger, string sagaId, int generation );
+
+    /// <summary>Logs the outcome of a conditional write-generation reset attempt after a pre-durability failure.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="sagaId">The saga id.</param>
+    /// <param name="advancedTo">The generation this caller had advanced to (the expected stored value).</param>
+    /// <param name="priorGeneration">The generation to restore.</param>
+    /// <param name="reset">Whether the conditional reset succeeded (false means a concurrent handler advanced further).</param>
+    [LoggerMessage(
+        EventId = LogEventIds.Infrastructure.Queue.RedisSagaStateManagerWriteGenerationReset,
+        Level = LogLevel.Debug,
+        Message = "Write generation conditional reset from {AdvancedTo} to {PriorGeneration} for saga {SagaId}: reset={Reset}" )]
+    internal static partial void LogWriteGenerationReset( ILogger logger, string sagaId, int advancedTo, int priorGeneration, bool reset );
 
     #endregion
 }

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -574,13 +574,13 @@ public sealed partial class RedisSagaStateManager(
     /// <paramref name="generation"/> and the write should be skipped.
     /// </returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken ct = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken ct = default ) {
+    ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+    ArgumentOutOfRangeException.ThrowIfLessThan( generation, 1 );
 
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
+    string key = GetSagaKey( sagaId );
+    IDatabase db = _redis.GetDatabase( );
+    TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
         RedisResult result = await db.ScriptEvaluateAsync(
             AdvanceWriteGenerationScript,
             keys: [key],
@@ -632,13 +632,15 @@ public sealed partial class RedisSagaStateManager(
     /// <param name="ct">A cancellation token (not currently observed).</param>
     /// <returns>A task that completes when the conditional reset attempt has been made and the TTL optionally refreshed.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken ct = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken ct = default ) {
+    ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+    ArgumentOutOfRangeException.ThrowIfLessThan( advancedTo, 1 );
+    ArgumentOutOfRangeException.ThrowIfLessThan( priorGeneration, 0 );
+    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( priorGeneration, advancedTo );
 
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
+    string key = GetSagaKey( sagaId );
+    IDatabase db = _redis.GetDatabase( );
+    TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
         RedisResult result = await db.ScriptEvaluateAsync(
             ResetWriteGenerationScript,
             keys: [key],

--- a/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/Logging/LogEventIds.cs
@@ -167,4 +167,7 @@ public static class LogEventIds {
 
     /// <summary>The finalize claim for a saga was already held by another handler; this handler is skipping finalization.</summary>
     public const int FinalizationClaimLost = 5054;
+
+    /// <summary>Post-release cache indexing failed; the result is already written and waiters are released, so the failure is swallowed.</summary>
+    public const int PostReleaseIndexFailed = 5055;
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -468,15 +468,22 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
                 uriRecorded = true;
 
+                // Clear the partial flag before releasing waiters so the waiter's isFinal read
+                // is already authoritative by the time it wakes.
                 await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
-
-                await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
-
-                LogCachedFinalResult( _logger, saga.SagaId );
 
                 await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
 
                 LogSuccessfullyFinalized( _logger, saga.SagaId, finalResult.Results.Count );
+
+                // Best-effort: index after releasing waiters so a cache failure never delays
+                // wakeup. Swallow all exceptions — the result is already durably written.
+                try {
+                    await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
+                    LogCachedFinalResult( _logger, saga.SagaId );
+                } catch (Exception indexEx) {
+                    LogPostReleaseIndexFailed( _logger, indexEx, saga.SagaId );
+                }
             } catch (OperationCanceledException) {
                 // Before the durability line: release the claim so the next host restart can
                 // re-finalize. After the durability line: retain the claim — re-entering would
@@ -520,11 +527,17 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 await _sagaManager.SetPartialResultUriAsync( saga.SagaId, recordUri, ct );
                 uriRecorded = true;
 
-                await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
-
                 await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
 
                 LogSuccessfullyWrotePartial( _logger, saga.SagaId, finalResult.Results.Count );
+
+                // Best-effort: index after releasing waiters so a cache failure never delays
+                // wakeup. Swallow all exceptions — the result is already durably written.
+                try {
+                    await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
+                } catch (Exception indexEx) {
+                    LogPostReleaseIndexFailed( _logger, indexEx, saga.SagaId );
+                }
             } catch (OperationCanceledException) {
                 // Before the durability line: reset the generation so the next trigger can
                 // re-advance and re-write. After the durability line: retain — re-entering
@@ -1290,6 +1303,16 @@ public sealed partial class SagaCoordinatorBackgroundService(
         Level = LogLevel.Warning,
         Message = "Failed to enqueue any secondary lookups for saga {SagaId} with external ID {ExternalId}; deferring finalization so waiters receive a partial result and the lookup is retried after the saga expires" )]
     private static partial void LogNoSecondariesEnqueued( ILogger logger, string sagaId, string externalId );
+
+    /// <summary>Logs that cache indexing failed after the result was written and waiters were released; the failure is non-fatal.</summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="ex">The exception that was thrown during indexing.</param>
+    /// <param name="sagaId">The saga whose post-release cache indexing failed.</param>
+    [LoggerMessage(
+        EventId = LogEventIds.PostReleaseIndexFailed,
+        Level = LogLevel.Warning,
+        Message = "Post-release cache indexing failed for saga {SagaId}; result is written and waiters are released" )]
+    private static partial void LogPostReleaseIndexFailed( ILogger logger, Exception ex, string sagaId );
 
     #endregion
 }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -243,12 +243,12 @@ public sealed partial class SagaCoordinatorBackgroundService(
                     // Write initial result as partial and notify waiters immediately
                     // while secondary lookups continue in the background
                     LogWaitingForSecondaryLookups( _logger, sagaId );
-                    await WritePartialResultAsync( saga, ct );
+                    await WriteResultAsync( saga, terminal: false, ct );
                     return;
                 }
             }
 
-            await WriteFinalResultAsync( saga, ct );
+            await WriteResultAsync( saga, terminal: true, ct );
         } catch (Exception ex) {
             LogFailedToProcessSaga( _logger, ex, sagaId );
         }
@@ -294,20 +294,20 @@ public sealed partial class SagaCoordinatorBackgroundService(
                         // Write initial result as partial and notify waiters immediately
                         // while secondary lookups continue in the background
                         LogWaitingForSecondaryLookups( _logger, sagaId );
-                        await WritePartialResultAsync( saga, ct );
+                        await WriteResultAsync( saga, terminal: false, ct );
                         return;
                     }
                 }
 
                 if (string.IsNullOrEmpty( saga.FinalResultUri )) {
-                    await WriteFinalResultAsync( saga, ct );
+                    await WriteResultAsync( saga, terminal: true, ct );
                 }
                 return;
             }
 
             // If saga is partial, handle partial result
             if (saga.IsPartial && string.IsNullOrEmpty( saga.PartialResultUri )) {
-                await WritePartialResultAsync( saga, ct );
+                await WriteResultAsync( saga, terminal: false, ct );
             }
         } catch (Exception ex) {
             LogFailedLookupCompletion( _logger, ex, sagaId );
@@ -360,7 +360,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
                             // Write initial result as partial and notify waiters immediately
                             // while secondary lookups continue in the background
                             LogWaitingForSecondaryLookups( _logger, saga.SagaId );
-                            await WritePartialResultAsync( saga, ct );
+                            await WriteResultAsync( saga, terminal: false, ct );
                             continue;
                         }
                     }
@@ -368,12 +368,12 @@ public sealed partial class SagaCoordinatorBackgroundService(
                     // Check if saga is partial and needs partial result written first
                     if (saga.IsPartial && string.IsNullOrEmpty( saga.PartialResultUri )) {
                         LogWritingPartialDuringPolling( _logger, saga.SagaId );
-                        await WritePartialResultAsync( saga, ct );
+                        await WriteResultAsync( saga, terminal: false, ct );
                     }
 
                     // Write final result
                     LogFinalizingDuringPolling( _logger, saga.SagaId );
-                    await WriteFinalResultAsync( saga, ct );
+                    await WriteResultAsync( saga, terminal: true, ct );
                 } catch (Exception ex) {
                     LogFailedDuringPolling( _logger, ex, saga.SagaId );
                     // Continue with next saga - don't fail the entire polling cycle
@@ -387,155 +387,192 @@ public sealed partial class SagaCoordinatorBackgroundService(
     }
 
     /// <summary>
-    /// Finalizes a saga. Combines the provider results; if none succeeded, releases the dedup lock with
-    /// no URI and deletes the saga. Otherwise writes the combined result to the ATProto PDS, records the
-    /// returned record URI on the saga, clears its partial flag, caches the result, and releases the
-    /// dedup lock with the final record URI so waiters receive it. On a write failure the dedup lock is
-    /// still released (with no URI) so callers are never left blocked.
+    /// Writes the saga result to the ATProto PDS. Drives both the terminal (all-providers-complete)
+    /// and non-terminal (partial, while secondaries are still outstanding) paths through a single
+    /// unified sequence: combine → generation CAS → PDS write → record URI → cache → release dedup.
     /// </summary>
-    /// <param name="saga">The saga to finalize.</param>
+    /// <remarks>
+    /// <para>
+    /// The write-generation compare-and-set ensures each provider-count level is written at most once,
+    /// bounding total PDS writes to the number of providers. When the CAS fails (stored generation
+    /// already at or above the requested generation) the method returns immediately with no write.
+    /// </para>
+    /// <para>
+    /// On the terminal path, <see cref="ISagaStateManager.TryClaimFinalizeAsync"/> provides the
+    /// exactly-once guarantee for post-write bookkeeping (URI recording, partial-flag clear, dedup
+    /// release). On the non-terminal path the write-generation CAS alone prevents double writes and
+    /// no finalize claim is used.
+    /// </para>
+    /// <para>
+    /// On a pre-durability PDS write failure, the write generation is reset to its prior value so
+    /// the next trigger can re-advance and re-write. After the durability line the generation is
+    /// retained and the finalize claim (terminal path) is not released, preventing re-entrant writes
+    /// against an already-recorded URI.
+    /// </para>
+    /// </remarks>
+    /// <param name="saga">The saga to write a result for.</param>
+    /// <param name="terminal">
+    /// <see langword="true"/> when every provider has reported in and the result is final;
+    /// <see langword="false"/> when secondary lookups are still outstanding.
+    /// </param>
     /// <param name="ct">A token that cancels the operation.</param>
-    /// <returns>A task that completes when finalization (or its failure cleanup) is done.</returns>
-    private async Task WriteFinalResultAsync( LookupSagaState saga, CancellationToken ct ) {
-        LogAssemblingFinalResult( _logger, saga.SagaId, saga.ProviderStates.Count );
+    /// <returns>A task that completes when the write (or its failure cleanup) is done.</returns>
+    private async Task WriteResultAsync( LookupSagaState saga, bool terminal, CancellationToken ct ) {
+        if (terminal) {
+            LogAssemblingFinalResult( _logger, saga.SagaId, saga.ProviderStates.Count );
+        } else if (_logger.IsEnabled( LogLevel.Information )) {
+            int completedCount = saga.ProviderStates.Count( kv => kv.Value.IsComplete );
+            int totalCount = saga.ProviderStates.Count;
+            LogAssemblingPartialResult( _logger, saga.SagaId, completedCount, totalCount );
+        }
 
-        // Combine results from all successful providers
-        MediaLinkResult? finalResult = _resultCombiner.CombineResults( saga );
+        MediaLinkResult? finalResult = _resultCombiner.CombineResults( saga, allowIncomplete: !terminal );
 
         if (finalResult is null) {
-            LogNoSuccessfulResults( _logger, saga.SagaId );
-
-            // Release the deduplication lock with null to indicate failure
-            await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
-
-            // Delete the saga
-            _ = await _sagaManager.DeleteAsync( saga.SagaId, ct );
-            return;
-        }
-
-        // Atomically claim the exclusive right to finalize this saga. Exactly one concurrent
-        // handler wins; losers return silently so only one PDS write occurs.
-        bool claimed = await _sagaManager.TryClaimFinalizeAsync( saga.SagaId, ct );
-        if (!claimed) {
-            LogFinalizationClaimLost( _logger, saga.SagaId );
-            return;
-        }
-
-        bool uriRecorded = false;
-
-        try {
-            // Write to ATProto
-            string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( finalResult, ct );
-
-            LogWroteFinalToAtProto( _logger, saga.SagaId, recordUri );
-
-            // Update saga with final result URI. The durability line: once this returns the URI is
-            // durably stored. A failure after this point must NOT release the claim — re-entering
-            // would issue a second PDS write against an already-recorded URI.
-            await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
-            uriRecorded = true;
-
-            // Clear the partial flag - the saga now represents a complete result
-            await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
-
-            // Update Redis cache
-            _ = await _cacheRepository.CacheResultAsync( finalResult, ct );
-
-            LogCachedFinalResult( _logger, saga.SagaId );
-
-            // Release the deduplication lock with the result URI
-            await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
-
-            LogSuccessfullyFinalized( _logger, saga.SagaId, finalResult.Results.Count );
-        } catch (OperationCanceledException) {
-            // Before the durability line: release the claim so the next host restart can re-finalize.
-            // After the durability line: retain the claim — re-entering would issue a second PDS write
-            // against a URI that is already recorded. The dedup lock is never released here in either
-            // case (the saga is healthy; no premature empty completion).
-            if (!uriRecorded) {
-                await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, CancellationToken.None );
-            }
-            throw;
-        } catch (Exception ex) {
-            LogFailedToWriteFinal( _logger, ex, saga.SagaId );
-
-            // Only release the claim and dedup lock when the URI has not yet been durably recorded.
-            // If the URI is already recorded, retaining the claim prevents a re-entrant PDS write;
-            // releasing the dedup lock with null here would hand waiters an empty result for a saga
-            // that succeeded — a clean lock timeout is strictly better in that case.
-            if (!uriRecorded) {
-                await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, ct );
+            if (terminal) {
+                // Complete saga with zero successes: release waiters and discard the saga.
+                LogNoSuccessfulResults( _logger, saga.SagaId );
                 await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+                _ = await _sagaManager.DeleteAsync( saga.SagaId, ct );
+            } else {
+                // No successful results yet on the non-terminal path: nothing to write.
+                // More providers are still outstanding; wait for the next trigger.
+                LogNoSuccessfulPartialResults( _logger, saga.SagaId );
+            }
+            return;
+        }
+
+        if (terminal) {
+            // Terminal path: gated by the finalize claim only. The generation CAS is not
+            // used here because the generation counts successful providers, and a saga that
+            // completes via the last leg failing has the same generation it had when the
+            // previous partial was written — the CAS would refuse to advance and the saga
+            // would never finalize. The finalize claim (HSETNX) provides the single-winner
+            // guarantee for this path.
+            bool claimed = await _sagaManager.TryClaimFinalizeAsync( saga.SagaId, ct );
+            if (!claimed) {
+                LogFinalizationClaimLost( _logger, saga.SagaId );
+                return;
+            }
+
+            bool uriRecorded = false;
+
+            try {
+                string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( finalResult, ct );
+
+                LogWroteFinalToAtProto( _logger, saga.SagaId, recordUri );
+
+                // Durability line: once this returns the URI is durably stored. A failure after
+                // this point must NOT release the claim — re-entering would issue a second PDS
+                // write against an already-recorded URI.
+                await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
+                uriRecorded = true;
+
+                await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
+
+                await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
+
+                LogCachedFinalResult( _logger, saga.SagaId );
+
+                await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
+
+                LogSuccessfullyFinalized( _logger, saga.SagaId, finalResult.Results.Count );
+            } catch (OperationCanceledException) {
+                // Before the durability line: release the claim so the next host restart can
+                // re-finalize. After the durability line: retain the claim — re-entering would
+                // issue a second PDS write against an already-recorded URI. The dedup lock is
+                // not released here in either case.
+                if (!uriRecorded) {
+                    await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, CancellationToken.None );
+                }
+                throw;
+            } catch (Exception ex) {
+                LogFailedToWriteFinal( _logger, ex, saga.SagaId );
+
+                // Only release the claim before the durability line. After the URI is recorded,
+                // retaining the claim prevents a re-entrant PDS write; releasing the dedup lock
+                // with null would hand waiters an empty result for a saga that succeeded.
+                if (!uriRecorded) {
+                    await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, ct );
+                    await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+                }
+            }
+        } else {
+            // Non-terminal (partial) path: gated by the write-generation CAS. This bounds the
+            // total partial writes to ≤ the number of distinct successful-provider-count levels
+            // observed, which is ≤ the number of providers N.
+            int generation = finalResult.Results.Count;
+
+            if (!await _sagaManager.TryAdvanceWriteGenerationAsync( saga.SagaId, generation, ct )) {
+                return;
+            }
+
+            finalResult.IsPartial = true;
+            finalResult.RateLimitedProviders = saga.RateLimitInfo?.Select( r => r.Provider ).ToList( );
+
+            bool uriRecorded = false;
+
+            try {
+                string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( finalResult, ct );
+
+                LogWrotePartialToAtProto( _logger, saga.SagaId, recordUri );
+
+                await _sagaManager.SetPartialResultUriAsync( saga.SagaId, recordUri, ct );
+                uriRecorded = true;
+
+                await _cacheRepository.IndexResultAsync( finalResult, recordUri, ct );
+
+                await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
+
+                LogSuccessfullyWrotePartial( _logger, saga.SagaId, finalResult.Results.Count );
+            } catch (OperationCanceledException) {
+                // Before the durability line: reset the generation so the next trigger can
+                // re-advance and re-write. After the durability line: retain — re-entering
+                // would issue a second partial write against a URI that is already recorded.
+                // The dedup lock is not released in either case.
+                if (!uriRecorded) {
+                    await _sagaManager.ResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, CancellationToken.None );
+                }
+                throw;
+            } catch (Exception ex) {
+                LogFailedToWritePartial( _logger, ex, saga.SagaId );
+
+                // Only reset the generation before the durability line. After the URI is
+                // recorded, retaining the generation prevents a re-entrant duplicate partial
+                // write.
+                if (!uriRecorded) {
+                    await _sagaManager.ResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, ct );
+                }
             }
         }
     }
 
     /// <summary>
-    /// Test-only entry point that delegates directly to <see cref="WriteFinalResultAsync"/> so
-    /// integration tests can drive the finalize claim path without running the full
-    /// <see cref="ExecuteAsync"/> polling loop. Not used in production code paths.
+    /// Test-only entry point that delegates directly to <see cref="WriteResultAsync"/> for the
+    /// terminal (final-result) path, so integration tests can drive the finalize claim path without
+    /// running the full <see cref="ExecuteAsync"/> polling loop. Not used in production code paths.
     /// </summary>
     /// <param name="saga">The saga to finalize.</param>
     /// <param name="ct">A token that cancels the operation.</param>
     /// <returns>A task that completes when finalization (or its failure cleanup) is done.</returns>
     internal Task InvokeFinalizeForTestAsync( LookupSagaState saga, CancellationToken ct )
-        => WriteFinalResultAsync( saga, ct );
+        => WriteResultAsync( saga, terminal: true, ct );
 
     /// <summary>
-    /// Writes an interim partial result for a saga whose providers have not all completed (for example
-    /// while secondary lookups are still in flight). Combines whatever provider results exist so far,
-    /// marks the result partial, records which providers were rate-limited, persists it to the PDS,
-    /// caches it, records the partial-result URI on the saga, and notifies waiters so they receive a
-    /// best-effort answer rather than blocking. Does nothing if no provider result is available yet.
+    /// Test-only entry point that delegates directly to <see cref="WriteResultAsync"/>, parameterized
+    /// by <paramref name="terminal"/>, so tests can drive both the final-result and partial-result
+    /// write paths without running the full <see cref="ExecuteAsync"/> polling loop. Not used in
+    /// production code paths.
     /// </summary>
-    /// <param name="saga">The saga to write a partial result for.</param>
+    /// <param name="saga">The saga to write a result for.</param>
+    /// <param name="terminal">
+    /// <see langword="true"/> to exercise the final-result path; <see langword="false"/> for the
+    /// partial-result path.
+    /// </param>
     /// <param name="ct">A token that cancels the operation.</param>
-    /// <returns>A task that completes when the partial result has been written (or skipped).</returns>
-    private async Task WritePartialResultAsync( LookupSagaState saga, CancellationToken ct ) {
-        if (_logger.IsEnabled( LogLevel.Debug )) {
-            int completedCount = saga.ProviderStates.Count( kv => kv.Value.IsComplete );
-            int totalCount = saga.ProviderStates.Count;
-            LogAssemblingPartialResult(
-                _logger,
-                saga.SagaId,
-                completedCount,
-                totalCount
-            );
-        }
-
-        // Combine results from completed providers (may be partial)
-        MediaLinkResult? partialResult = _resultCombiner.CombineResults( saga, allowIncomplete: true );
-
-        if (partialResult is null) {
-            LogNoSuccessfulPartialResults( _logger, saga.SagaId );
-            return;
-        }
-
-        // Mark the result as partial
-        partialResult.IsPartial = true;
-        partialResult.RateLimitedProviders = saga.RateLimitInfo?.Select( r => r.Provider ).ToList( );
-
-        try {
-            // Write partial result to ATProto
-            string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( partialResult, ct );
-
-            LogWrotePartialToAtProto( _logger, saga.SagaId, recordUri );
-
-            // Update saga with partial result URI
-            await _sagaManager.SetPartialResultUriAsync( saga.SagaId, recordUri, ct );
-
-            // Update Redis cache with partial result (can be refreshed later)
-            _ = await _cacheRepository.CacheResultAsync( partialResult, ct );
-
-            // Release the deduplication lock with the partial result URI
-            // This allows waiting clients to receive partial results immediately
-            await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
-
-            LogSuccessfullyWrotePartial( _logger, saga.SagaId, partialResult.Results.Count );
-        } catch (Exception ex) {
-            LogFailedToWritePartial( _logger, ex, saga.SagaId );
-        }
-    }
+    /// <returns>A task that completes when the write (or its failure cleanup) is done.</returns>
+    internal Task InvokeWriteForTestAsync( LookupSagaState saga, bool terminal, CancellationToken ct )
+        => WriteResultAsync( saga, terminal, ct );
 
     /// <summary>
     /// Publishes a saga id to the literal <c>saga:completed</c> Pub/Sub channel so the coordinator


### PR DESCRIPTION
This pull request refactors the caching and indexing logic for media link results, focusing on separating the concerns of storing result bodies and indexing lookup keys in Redis. The main changes include replacing the `CacheResultAsync` method with a new `IndexResultAsync` method throughout the codebase, updating related interfaces and documentation, and introducing new mechanisms to prevent redundant writes in concurrent scenarios. Test code has also been updated to reflect these changes.