### PR TITLE
fix: harden maintenance worker and Apple URL builders; finish worker rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 **Music is universal. Your links should be too.**
 
-BridgeBeats is a cross-platform music link converter that helps you share music effortlessly across streaming platforms. Share a link from Apple Music, Spotify, or Tidal, and BridgeBeats finds the same track or album on all supported services—ensuring every listener can enjoy the music, regardless of their preferred platform.
+BridgeBeats is a cross-platform music link converter that helps you share music effortlessly across streaming platforms. Share a link from Apple Music, Spotify, or Tidal, and BridgeBeats finds the same track or album on all supported services-ensuring every listener can enjoy the music, regardless of their preferred platform.
 
 ## ✨ Share once. Play anywhere.
 
-Ever wanted to share your favorite song, only to realize your friend uses a different streaming service? BridgeBeats solves this by automatically finding the same track or album on all major platforms—so everyone can listen, no matter where they stream.
+Ever wanted to share your favorite song, only to realize your friend uses a different streaming service? BridgeBeats solves this by automatically finding the same track or album on all major platforms-so everyone can listen, no matter where they stream.
 
 ## 🎵 Features
 
@@ -21,16 +21,14 @@ Ever wanted to share your favorite song, only to realize your friend uses a diff
 - **Web Interface** - Simple browser-based tool for quick conversions
 - **RESTful API** - Integrate music link conversion into your own apps
 - **Accurate Matching** - Uses ISRC (tracks) and UPC (albums) for precise cross-platform matches
-- **Rich Previews** - OpenGraph cards that work everywhere—Discord, Slack, Twitter, and more
+- **Rich Previews** - OpenGraph cards that work everywhere-Discord, Slack, Twitter, and more
 - **Aspire Dashboard** - Built-in observability and telemetry dashboard (role-based access)
 
 ## 🚀 Quick Start
 
-### Using the one-line installer (recommended)
+### Using the one-line installer
 
-The installer downloads the Compose files, creates `.env` and the `secrets/`
-directory, and generates the secrets that must be auto-generated (including the
-required `INTERNAL_SERVICE_KEY` and the ATProto OAuth signing key):
+The installer downloads the Compose files, creates `.env` and the `secrets/` directory, and generates the secrets that must be auto-generated (including the required `INTERNAL_SERVICE_KEY` and the ATProto OAuth signing key):
 
 ```bash
 # Linux / macOS
@@ -66,19 +64,11 @@ cp .env.example .env
 docker compose up -d
 ```
 
-`secrets/internal_service_key.txt` is required: it is the shared key the worker
-processes present to authenticate to the web API, and the container will not
-start without it. The installer generates it for you.
+`secrets/internal_service_key.txt` is required: it is the shared key the worker processes present to authenticate to the web API, and the container will not start without it. The installer generates it for you.
 
-`docker compose up -d` starts four containers: `bridgebeats` (the app, which
-also spawns the worker processes), `redis` (cache, request queue, and
-rate-limit tracking), `bridgebeats-pds` (a Bluesky Personal Data Server for
-ATProto caching), and `bridgebeats-caddy` (the reverse proxy that terminates
-HTTPS). Only Caddy publishes ports to the host (80 and 443); the app listens on
-port 10000 inside the internal Docker network and is reached through Caddy.
+`docker compose up -d` starts four containers: `bridgebeats` (the app, which also spawns the worker processes), `redis` (cache, request queue, and rate-limit tracking), `bridgebeats-pds` (a Bluesky Personal Data Server for ATProto caching), and `bridgebeats-caddy` (the reverse proxy that terminates HTTPS). Only Caddy publishes ports to the host (80 and 443); the app listens on port 10000 inside the internal Docker network and is reached through Caddy.
 
-Visit `https://localhost` to start converting links (accept the self-signed
-certificate warning for `localhost`).
+Visit `https://localhost` to start converting links (accept the self-signed certificate warning for `localhost`).
 
 📖 **[Complete Quick Start Guide →](docs/QUICKSTART.md)**
 
@@ -104,34 +94,31 @@ Then start the host from the repository root:
 aspire run
 ```
 
-This starts the app and the worker processes with the Aspire Dashboard for
-monitoring, tracing, and structured logging. If you prefer to run without the
-Aspire CLI, use `dotnet run --project src/BridgeBeats.AppHost`. See the
-[Local Development Guide](docs/LOCAL_DEVELOPMENT.md) for details.
+This starts the app and the worker processes with the Aspire Dashboard for monitoring, tracing, and structured logging. If you prefer to run without the Aspire CLI, use `dotnet run --project src/BridgeBeats.AppHost`. See the [Local Development Guide](docs/LOCAL_DEVELOPMENT.md) for details.
 
 ## 📁 Project Structure
 
 ```
 BridgeBeats/
 ├── src/
-│   ├── BridgeBeats.Web/                   # ASP.NET Core web app (MVC, controllers, views, API)
-│   ├── BridgeBeats.Core/                  # Domain logic and infrastructure (caching, identity, storage, queue)
-│   ├── BridgeBeats.Contracts/             # Shared DTOs, interfaces, enums, constants, records
-│   ├── BridgeBeats.AppHost/               # .NET Aspire orchestration
-│   ├── BridgeBeats.Worker.Spotify/        # Spotify lookup worker (incl. batch processor)
-│   ├── BridgeBeats.Worker.AppleMusic/     # Apple Music lookup worker
-│   ├── BridgeBeats.Worker.Tidal/          # Tidal lookup worker
-│   ├── BridgeBeats.Worker.Discord/        # Discord bot worker
+│   ├── BridgeBeats.Web/                     # ASP.NET Core web app (MVC, controllers, views, API)
+│   ├── BridgeBeats.Core/                    # Domain logic and infrastructure (caching, identity, storage, queue)
+│   ├── BridgeBeats.Contracts/               # Shared DTOs, interfaces, enums, constants, records
+│   ├── BridgeBeats.AppHost/                 # .NET Aspire orchestration
+│   ├── BridgeBeats.Worker.Spotify/          # Spotify lookup worker (incl. batch processor)
+│   ├── BridgeBeats.Worker.AppleMusic/       # Apple Music lookup worker
+│   ├── BridgeBeats.Worker.Tidal/            # Tidal lookup worker
+│   ├── BridgeBeats.Worker.Discord/          # Discord bot worker
 │   ├── BridgeBeats.Worker.JetStreamWatcher/ # AT Protocol firehose watcher
 │   ├── BridgeBeats.Worker.SagaCoordinator/  # Cross-provider lookup saga coordinator
-│   └── BridgeBeats.Worker.CacheBootstrap/   # Cache warm-up/refresh worker
-├── Tests/                                 # Single test project (BridgeBeats.Tests.csproj)
-│   ├── Unit/                              # Unit tests
-│   ├── Integration/                       # Integration tests (service interactions)
-│   └── EndToEnd/                          # End-to-end tests (full request/response flows)
-├── docs/                                  # Documentation (guides, API reference)
-├── containers/                            # Docker deployment configuration
-├── .github/                               # GitHub templates, workflows, and community files
+│   └── BridgeBeats.Worker.Maintenance/      # Cache warm-up/refresh/assorted maintenance worker
+├── Tests/                                   # Single test project (BridgeBeats.Tests.csproj)
+│   ├── Unit/                                # Unit tests
+│   ├── Integration/                         # Integration tests (service interactions)
+│   └── EndToEnd/                            # End-to-end tests (full request/response flows)
+├── docs/                                    # Documentation (guides, API reference)
+├── containers/                              # Docker deployment configuration
+├── .github/                                 # GitHub templates, workflows, and community files
 ```
 
 ## 📖 Documentation
@@ -212,8 +199,7 @@ curl -k -X POST https://localhost/music/lookup/urlList \
   -d '{"uri":"https://open.spotify.com/track/..."}'
 ```
 
-For the identifier and name-search endpoints (`isrc`, `upc`, `title`), register
-an account to get a one-time API key and send it in the `X-API-Key` header:
+For the identifier and name-search endpoints (`isrc`, `upc`, `title`), register an account to get a one-time API key and send it in the `X-API-Key` header:
 
 ```bash
 curl -k -X POST https://localhost/account/register \
@@ -262,4 +248,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-*Because music connects us—no matter where we listen.*
+*Because music connects us - no matter where we listen.*

--- a/Tests/Integration/AppleMusicPlaylistValidationTests.cs
+++ b/Tests/Integration/AppleMusicPlaylistValidationTests.cs
@@ -202,6 +202,182 @@ public class AppleMusicPlaylistValidationTests : IDisposable {
     }
 
     /// <summary>
+    /// Verifies that a <c>PlaylistId</c> of <c>".."</c> (dot-dot path traversal segment) returns HTTP
+    /// 400 from model validation before any outbound Apple Music API call is attempted. Without the
+    /// tightened regex, <c>Uri.EscapeDataString</c> does not escape dots, so <c>".."</c> would reach
+    /// the outbound URL and normalize to a different Apple API path.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: the prior regex <c>^[A-Za-z0-9._-]+$</c> accepted <c>".."</c>; model
+    /// validation passed and the action returned 401 (no Apple token) rather than 400. After
+    /// tightening to <c>^[A-Za-z0-9]+([._-][A-Za-z0-9]+)*$</c>, <c>ModelState.IsValid</c> is false
+    /// and the action returns 400 before any outbound call.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdDotDot_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( ".." );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the dot-dot id; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
+    /// Verifies that a <c>PlaylistId</c> of <c>"."</c> (standalone dot) returns HTTP 400 from model
+    /// validation before any outbound Apple Music API call is attempted.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: the prior regex <c>^[A-Za-z0-9._-]+$</c> accepted <c>"."</c>; model
+    /// validation passed and the action returned 401 rather than 400. The tightened regex rejects it
+    /// because the value does not start with an alphanumeric character.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdSingleDot_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "." );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the standalone dot; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
+    /// Verifies that a <c>PlaylistId</c> containing a doubled separator (<c>"a..b"</c>) returns HTTP
+    /// 400 from model validation before any outbound Apple Music API call is attempted. Consecutive
+    /// separators can degenerate into traversal-style sequences when interpolated into a URL.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: the prior regex <c>^[A-Za-z0-9._-]+$</c> accepted <c>"a..b"</c>;
+    /// model validation passed and the action returned 401 rather than 400. The tightened regex
+    /// requires a single separator followed by at least one alphanumeric character and therefore
+    /// rejects doubled separators.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdDoubledSeparator_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "a..b" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the doubled-separator id; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
+    /// Verifies that an <c>i.</c>-prefixed Apple library item id (e.g. <c>i.e5gmPS6rZ856</c>) passes
+    /// model validation. The action then proceeds to the user-token checks; because the test user has
+    /// no stored Apple Music token the endpoint returns 401, not 400.
+    /// </summary>
+    /// <remarks>
+    /// Regression guard: this positive case confirms the tightened regex does not over-restrict
+    /// well-formed Apple library item ids. Both the old and new regexes accept this form; no
+    /// meaningful failure-first ordering exists for a purely positive guard.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_LibraryItemPrefixedId_PassesModelValidation( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "i.e5gmPS6rZ856" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation passes; the action then fails at the user-token check (401),
+        // confirming the well-formed id did NOT trigger a 400 from ModelState.
+        Assert.AreNotEqual(
+            HttpStatusCode.BadRequest, response.StatusCode,
+            "An i.-prefixed Apple library item id must not be rejected by model validation."
+        );
+    }
+
+    /// <summary>
+    /// Verifies that a <c>pl.u-</c>-prefixed Apple catalog playlist id (e.g. <c>pl.u-abc123</c>)
+    /// passes model validation. The action then proceeds to the user-token checks; because the test
+    /// user has no stored Apple Music token the endpoint returns 401, not 400.
+    /// </summary>
+    /// <remarks>
+    /// Regression guard: this positive case confirms the tightened regex correctly handles ids that
+    /// contain both a dot and a hyphen as separators between alphanumeric runs. Both the old and new
+    /// regexes accept this form; no meaningful failure-first ordering exists for a purely positive guard.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_CatalogPlaylistHyphenatedId_PassesModelValidation( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "pl.u-abc123" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation passes; the action then fails at the user-token check (401),
+        // confirming the well-formed id did NOT trigger a 400 from ModelState.
+        Assert.AreNotEqual(
+            HttpStatusCode.BadRequest, response.StatusCode,
+            "A pl.u--prefixed Apple catalog playlist id must not be rejected by model validation."
+        );
+    }
+
+    /// <summary>
     /// A <see cref="CustomWebApplicationFactory"/> variant that installs a stub <c>TestScheme</c>
     /// authentication handler so these tests can present an authenticated principal without a real
     /// login flow. The Apple Music token is intentionally omitted from the test user so the action

--- a/Tests/Integration/AppleMusicPlaylistValidationTests.cs
+++ b/Tests/Integration/AppleMusicPlaylistValidationTests.cs
@@ -378,6 +378,45 @@ public class AppleMusicPlaylistValidationTests : IDisposable {
     }
 
     /// <summary>
+    /// Verifies that a <c>PlaylistId</c> with a trailing newline (<c>"p.ABCdef1234\n"</c>) returns HTTP 400
+    /// from model validation before any outbound Apple Music API call is attempted. This pins the
+    /// "must end with alphanumeric / full-string match" rule: the <c>\A</c>/<c>\z</c> anchors reject the
+    /// trailing <c>\n</c> where the <c>^</c>/<c>$</c> anchors previously allowed it because <c>$</c>
+    /// matches before a trailing newline in .NET multiline semantics.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: before the anchor change (<c>^...$</c> form), this test failed — model
+    /// validation accepted <c>"p.ABCdef1234\n"</c> and the action returned 401 (no Apple token) rather
+    /// than 400. After changing to <c>\A...\z</c>, <c>ModelState.IsValid</c> is false and the action
+    /// returns 400 before any outbound call.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdWithTrailingNewline_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        // A syntactically valid id plus a trailing newline. The \A...\z anchors reject this;
+        // the old ^...$ anchors accepted it because $ matches before a terminal \n in .NET.
+        ProcessPlaylistRequest request = new( "p.ABCdef1234\n" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the trailing-newline id; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
     /// A <see cref="CustomWebApplicationFactory"/> variant that installs a stub <c>TestScheme</c>
     /// authentication handler so these tests can present an authenticated principal without a real
     /// login flow. The Apple Music token is intentionally omitted from the test user so the action

--- a/Tests/Integration/AppleMusicPlaylistValidationTests.cs
+++ b/Tests/Integration/AppleMusicPlaylistValidationTests.cs
@@ -1,0 +1,318 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Identity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the <c>POST applemusic/process-playlist</c> endpoint's input-validation
+/// behavior, exercising the <see cref="BridgeBeats.Contracts.Records.ProcessPlaylistRequest"/>
+/// <c>[RegularExpression]</c> annotation and the controller's <c>ModelState.IsValid</c> guard.
+/// </summary>
+/// <remarks>
+/// Security context: the action builds a credential-bearing URL (Music-User-Token) from the
+/// <c>PlaylistId</c> field. These tests assert that injection-style ids (path traversal, encoded
+/// separators, raw slashes) are rejected with HTTP 400 before any outbound Apple API call is
+/// attempted, and that a well-formed id clears model validation (the action may still return a
+/// non-200 status for auth reasons, but it must not return 400).
+/// </remarks>
+[TestClass]
+[TestCategory( "Integration" )]
+public class AppleMusicPlaylistValidationTests : IDisposable {
+
+    /// <summary>The test web application factory with the stub authentication scheme installed.</summary>
+    private AppleMusicTestWebApplicationFactory? _factory;
+    /// <summary>The HTTP client connected to the test host.</summary>
+    private HttpClient? _client;
+
+    /// <summary>The MSTest-injected test context.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>
+    /// Builds the test host with worker services disabled, creates a client, and migrates the
+    /// identity database before each test.
+    /// </summary>
+    [TestInitialize]
+    public async Task Setup( ) {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddJsonFile( Path.Combine( "src", "BridgeBeats.Web", "appsettings.json" ), optional: true )
+            .AddUserSecrets<Web.Program>( optional: true )
+            .AddEnvironmentVariables()
+            .Build();
+
+        Dictionary<string, string?> configData = configuration
+            .AsEnumerable()
+            .Where( kv => kv.Value is not null )
+            .Where( kv => !kv.Key.EndsWith( "ConnectionString", StringComparison.OrdinalIgnoreCase ) )
+            .ToDictionary();
+
+        configData["BridgeBeats:DiscordToken"] = string.Empty;
+        configData["BridgeBeats:Workers:UseWorkerServices"] = "false";
+        configData["BridgeBeats:ATProtoIdentifier"] = string.Empty;
+        configData["BridgeBeats:ATProtoPassword"] = string.Empty;
+        configData["BridgeBeats:ATProtoUserDID"] = string.Empty;
+
+        _factory = new AppleMusicTestWebApplicationFactory( configData );
+        _factory.SetTestUser( "test-user-id", "appleMusicTest@example.com" );
+        _client = _factory.CreateClient( );
+        _client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue( "TestScheme" );
+
+        await _factory.InitializeDatabasesAsync( );
+    }
+
+    /// <summary>Tears down the test host after each test.</summary>
+    [TestCleanup]
+    public void Cleanup( ) {
+        Dispose( );
+    }
+
+    /// <inheritdoc/>
+    public void Dispose( ) {
+        _client?.Dispose( );
+        _client = null;
+
+        if (_factory != null) {
+            try {
+                using IServiceScope scope = _factory.Services.CreateScope();
+                ApplicationDbContext dbContext =
+                    scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                _ = dbContext.Database.EnsureDeleted( );
+            } catch (ObjectDisposedException) {
+                // Factory already disposed.
+            }
+            _factory.Dispose( );
+            _factory = null;
+        }
+
+        GC.SuppressFinalize( this );
+    }
+
+    /// <summary>
+    /// Verifies that a <c>PlaylistId</c> containing a raw slash returns HTTP 400 from model
+    /// validation, with no outbound Apple Music API call made. A raw slash in the path segment
+    /// would otherwise redirect the token-bearing request to a different Apple endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: before the <c>[RegularExpression]</c> annotation was added to
+    /// <c>ProcessPlaylistRequest.PlaylistId</c>, model validation passed for this value and the
+    /// action proceeded to the user-token check (returning 401 for a no-token user rather than 400).
+    /// After the annotation, <c>ModelState.IsValid</c> is false and the action returns 400 before
+    /// any Apple API call is attempted.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdWithSlash_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "pl.123/../../evil" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the id; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
+    /// Verifies that a <c>PlaylistId</c> containing a percent-encoded path separator
+    /// (<c>..%2f..</c>) returns HTTP 400 from model validation, with no outbound Apple Music API
+    /// call made. Without this guard, the URL-decoded separator could traverse to a different Apple
+    /// path segment, redirecting the Music-User-Token to an unintended resource.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: before the annotation was added, <c>SanitizeForLogging</c> stripped
+    /// only Unicode control characters, leaving <c>%</c>, <c>.</c>, and <c>/</c> in the value that
+    /// was interpolated into the URL. The annotation now catches this at the model-binding layer.
+    /// </remarks>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_PlaylistIdWithEncodedPathSeparator_Returns400BeforeOutboundCall( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "..%2f..%2fevil" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation rejects the id; no outbound call is ever made
+        Assert.AreEqual( HttpStatusCode.BadRequest, response.StatusCode );
+        SpyHttpMessageHandler spy = _factory!.Services.GetRequiredService<SpyHttpMessageHandler>( );
+        Assert.AreEqual( 0, spy.SendCount, "No outbound call must reach the musickit-api client when model validation rejects the request" );
+    }
+
+    /// <summary>
+    /// Verifies that a well-formed Apple library-playlist id (e.g. <c>p.ABCdef1234</c>) passes model
+    /// validation. The action then proceeds to the user-token checks; because the test user has no
+    /// stored Apple Music token the endpoint returns 401, not 400.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessPlaylist_WellFormedPlaylistId_PassesModelValidation( ) {
+        // Arrange
+        string antiforgeryToken = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync(
+            _client!, TestContext.CancellationToken
+        );
+        ProcessPlaylistRequest request = new( "p.ABCdef1234" );
+
+        // Act
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            _client!,
+            "applemusic/process-playlist",
+            JsonContent.Create( request ),
+            antiforgeryToken,
+            TestContext.CancellationToken
+        );
+
+        // Assert - model validation passes; the action then fails at the user-token check (401),
+        // confirming the well-formed id did NOT trigger a 400 from ModelState.
+        Assert.AreNotEqual(
+            HttpStatusCode.BadRequest, response.StatusCode,
+            "A well-formed playlist id must not be rejected by model validation."
+        );
+    }
+
+    /// <summary>
+    /// A <see cref="CustomWebApplicationFactory"/> variant that installs a stub <c>TestScheme</c>
+    /// authentication handler so these tests can present an authenticated principal without a real
+    /// login flow. The Apple Music token is intentionally omitted from the test user so the action
+    /// returns 401 at the token check rather than attempting an outbound API call.
+    /// </summary>
+    /// <param name="configOverrides">Configuration overrides forwarded to the base factory.</param>
+    private sealed class AppleMusicTestWebApplicationFactory(
+        Dictionary<string, string?>? configOverrides
+    ) : CustomWebApplicationFactory( configOverrides ) {
+
+        /// <summary>The identity id presented by the stub authentication handler.</summary>
+        private string? _testUserId;
+        /// <summary>The email presented by the stub authentication handler.</summary>
+        private string? _testUserEmail;
+
+        /// <summary>
+        /// Configures the stub authentication principal the handler will present on the next request.
+        /// </summary>
+        /// <param name="userId">The user id to place on the principal's NameIdentifier claim.</param>
+        /// <param name="email">The email to place on the principal's Name and Email claims.</param>
+        public void SetTestUser( string userId, string email ) {
+            _testUserId = userId;
+            _testUserEmail = email;
+        }
+
+        /// <summary>
+        /// Extends the base host configuration by registering the <c>TestScheme</c> authentication
+        /// handler, exposing this factory to it for principal construction, and installing the
+        /// <see cref="SpyHttpMessageHandler"/> as the primary transport for the
+        /// <c>musickit-api</c> named HTTP client so tests can assert zero outbound Apple calls.
+        /// </summary>
+        /// <param name="builder">The web host builder supplied by the test host.</param>
+        protected override void ConfigureWebHost( IWebHostBuilder builder ) {
+            base.ConfigureWebHost( builder );
+
+            _ = builder.ConfigureServices( services => {
+                _ = services.AddAuthentication( options => {
+                    options.DefaultAuthenticateScheme = "TestScheme";
+                    options.DefaultChallengeScheme = "TestScheme";
+                } )
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>( "TestScheme", _ => { } );
+
+                _ = services.AddSingleton( this );
+
+                _ = services.AddSingleton<SpyHttpMessageHandler>( );
+                _ = services.AddHttpClient( "musickit-api" )
+                    .ConfigurePrimaryHttpMessageHandler<SpyHttpMessageHandler>( );
+            } );
+        }
+
+        /// <summary>
+        /// Stub authentication handler for the <c>TestScheme</c>. Returns no result when no
+        /// Authorization header is present; otherwise authenticates a principal carrying only the
+        /// configured user id, name, and email claims (no Apple Music token state).
+        /// </summary>
+        private sealed class TestAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            AppleMusicTestWebApplicationFactory factory
+        ) : AuthenticationHandler<AuthenticationSchemeOptions>( options, logger, encoder ) {
+
+            /// <summary>
+            /// Returns an authenticated principal when the Authorization header is present; otherwise
+            /// returns no result so the <c>[Authorize]</c> filter can challenge the request.
+            /// </summary>
+            protected override Task<AuthenticateResult> HandleAuthenticateAsync( ) {
+                if (!Request.Headers.ContainsKey( "Authorization" )) {
+                    return Task.FromResult( AuthenticateResult.NoResult( ) );
+                }
+
+                if (string.IsNullOrEmpty( factory._testUserId ) || string.IsNullOrEmpty( factory._testUserEmail )) {
+                    return Task.FromResult( AuthenticateResult.Fail( "No test user configured" ) );
+                }
+
+                List<Claim> claims = [
+                    new Claim( ClaimTypes.NameIdentifier, factory._testUserId ),
+                    new Claim( ClaimTypes.Name, factory._testUserEmail ),
+                    new Claim( ClaimTypes.Email, factory._testUserEmail ),
+                ];
+
+                ClaimsIdentity identity = new( claims, "TestScheme" );
+                ClaimsPrincipal principal = new( identity );
+                AuthenticationTicket ticket = new( principal, "TestScheme" );
+
+                return Task.FromResult( AuthenticateResult.Success( ticket ) );
+            }
+        }
+    }
+
+    /// <summary>
+    /// A counting <see cref="HttpMessageHandler"/> that records how many times
+    /// <see cref="SendAsync"/> is invoked. Registered as the primary transport for the
+    /// <c>musickit-api</c> named HTTP client in the test host so 400-path tests can
+    /// assert that zero outbound Apple Music API calls are made when model validation
+    /// rejects the request before the action body runs.
+    /// </summary>
+    private sealed class SpyHttpMessageHandler : HttpMessageHandler {
+
+        private int _sendCount;
+
+        /// <summary>Gets the number of times <see cref="SendAsync"/> was called.</summary>
+        public int SendCount => _sendCount;
+
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) {
+            _ = Interlocked.Increment( ref _sendCount );
+            return Task.FromResult( new HttpResponseMessage( HttpStatusCode.ServiceUnavailable ) );
+        }
+    }
+}

--- a/Tests/Unit/AppleMusicLinkParserTests.cs
+++ b/Tests/Unit/AppleMusicLinkParserTests.cs
@@ -168,4 +168,115 @@ public class AppleMusicLinkParserTests {
         Assert.AreEqual( "us", storefront, "Should extract 'us' as storefront" );
         Assert.AreEqual( "us/songs/987654321", requestUri, "Should extract song ID '987654321' without query parameters" );
     }
+
+    /// <summary>
+    /// Verifies that <see cref="AppleMusicLinkParser.TryParseUri"/> returns <see langword="false"/>
+    /// and does NOT throw when a URL matches the album URL regex (via the loose <c>\w+</c> storefront
+    /// capture) but carries a storefront value that fails strict validation. Before the fix,
+    /// <c>TryParseUri</c> called <c>GetAlbumsURI</c> directly, which threw
+    /// <see cref="ArgumentException"/> on the invalid storefront—breaking the <c>bool Try*</c>
+    /// contract and propagating the exception into the queue-processor loop.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: before the guard was added to <c>TryParseUri</c>, this call threw
+    /// <see cref="ArgumentException"/> (validator rejection inside <c>GetAlbumsURI</c>); it now
+    /// returns <see langword="false"/> without throwing.
+    /// </remarks>
+    [TestMethod]
+    public void TryParseUri_RegexMatchButInvalidStorefront_ReturnsFalseWithoutThrowing( ) {
+        // Arrange - storefront "foo_bar" matches the loose \w+ album regex but fails ValidateStorefront
+        // (underscore is not a letter; length exceeds 3). The id "abc123" also fails ValidateCatalogId
+        // (non-numeric). Either failure is sufficient; the storefront check is the first guard.
+        string link = "https://music.apple.com/foo_bar/album/test-album/abc123";
+
+        // Act / Assert - must not throw; must return false
+        bool result = AppleMusicLinkParser.TryParseUri( link, out string requestUri, out string storefront, out bool isAlbum );
+
+        Assert.IsFalse( result, "TryParseUri must return false for an invalid storefront, not throw" );
+        Assert.AreEqual( string.Empty, requestUri, "requestUri must be empty on a false return" );
+        Assert.AreEqual( string.Empty, storefront, "storefront must be empty on a false return" );
+        Assert.IsFalse( isAlbum, "isAlbum must be false on a false return" );
+    }
+
+    /// <summary>
+    /// Verifies that URL builder methods reject a storefront value containing URL injection characters
+    /// (<c>&amp;</c>, <c>/</c>, <c>?</c>, and a percent-encoded separator). Before the validation fix,
+    /// these builders performed raw string substitution, so an attacker-controlled storefront could
+    /// inject extra query parameters or path segments into the JWT-bearing outbound Apple Music API
+    /// request. Post-fix, each builder validates against the expected 2–3-letter alphabetic pattern
+    /// and throws <see cref="ArgumentException"/>, ensuring no injected character survives into the
+    /// built URL.
+    /// </summary>
+    [TestMethod]
+    public void UrlBuilders_StorefrontWithInjectionCharacters_ThrowArgumentException( ) {
+        // Arrange - storefronts containing characters that could alter URL structure
+        string[] maliciousStorefronts = [
+            "us&evil=1",         // query-parameter injection via &
+            "us/../../etc",      // path traversal via /
+            "us?extra=param",    // query string injection via ?
+            "us%2fevil",         // percent-encoded path separator
+        ];
+
+        foreach (string badStorefront in maliciousStorefronts) {
+            // Assert - every builder must reject the bad storefront; no injection survives into any URL.
+            // Failure-first: before validation was added, these methods performed bare .Replace()
+            // and returned a URL containing the unescaped injection; they did NOT throw.
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetSongIdUri( badStorefront, "12345" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetAlbumIdUri( badStorefront, "12345" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetSongsIsrcURI( badStorefront, "USRC12345678" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetAlbumUpcURI( badStorefront, "012345678901" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetArtistAlbumsURI( badStorefront, "12345" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetArtistSongsURI( badStorefront, "12345" )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetArtistSearchUri( badStorefront, "Test Artist" )
+            );
+        }
+    }
+
+    /// <summary>
+    /// Verifies that URL builder methods reject an identifier value containing URL injection characters
+    /// (<c>&amp;</c>, <c>/</c>, <c>?</c>, and a percent-encoded separator). Post-fix, numeric catalog
+    /// ids are validated against <c>^[0-9]+$</c> and throw <see cref="ArgumentException"/> on any
+    /// non-numeric content, so no injected character survives into the built URL.
+    /// </summary>
+    [TestMethod]
+    public void UrlBuilders_IdWithInjectionCharacters_ThrowArgumentException( ) {
+        // Arrange - ids containing characters that could alter URL structure
+        string[] maliciousIds = [
+            "12345&evil=1",      // query-parameter injection via &
+            "12345/../../etc",   // path traversal via /
+            "12345?extra=param", // query string injection via ?
+            "12345%2fevil",      // percent-encoded path separator
+        ];
+
+        foreach (string badId in maliciousIds) {
+            // Assert - song and album id builders must both reject the bad id.
+            // Failure-first: before validation, these returned a URL with the raw injection; they
+            // did NOT throw.
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetSongIdUri( "us", badId )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetAlbumIdUri( "us", badId )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetArtistAlbumsURI( "us", badId )
+            );
+            _ = Assert.ThrowsExactly<ArgumentException>(
+                ( ) => AppleMusicLinkParser.GetArtistSongsURI( "us", badId )
+            );
+        }
+    }
 }

--- a/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
+++ b/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
@@ -1102,6 +1102,86 @@ public class CacheBootstrapBackgroundServiceTests {
             $"Only the bootstrap ListAllRecordsAsync call should have occurred; retry must not run after cancellation. Actual call count: {listCallCount[0]}" );
     }
 
+    /// <summary>
+    /// T6c: A persistently-failing statistics pass (via the manual-trigger path) terminates after
+    /// exactly two attempts — the initial attempt and one retry — then logs
+    /// <see cref="LogEventIds.RetryExhausted"/> (5579) and returns. It does NOT retry a third time
+    /// or loop indefinitely.
+    /// <para>
+    /// The manual-trigger entry path (<see cref="CacheBootstrapBackgroundService.RunStatisticsPassAsync"/>
+    /// → <see cref="CacheBootstrapBackgroundService.TriggerStatisticsRefreshAsync"/>) is used because
+    /// both the initial attempt and the retry enumerate the PDS via
+    /// <see cref="IATProtoStorageService.ListAllRecordsAsync"/>, making the call count a clean
+    /// observable proxy for "how many attempts ran". Expected: 2.
+    /// </para>
+    /// <para>
+    /// Failure-first evidence: before the Task 1 fix, <c>HandleStatisticsPassFailureAndRetryAsync</c>
+    /// re-entered <see cref="CacheBootstrapBackgroundService.RunStatisticsPassAsync"/> (not the core
+    /// body) on retry, which re-entered Handle with <c>isFirstAttempt:true</c> on the retry's failure
+    /// — restarting the retry cycle. The result was an unbounded loop:
+    /// <see cref="LogEventIds.RetryExhausted"/> was never logged and
+    /// <see cref="IATProtoStorageService.ListAllRecordsAsync"/> was called without bound. Under
+    /// the old code, the TCS below would never fire, the <see cref="TestContext"/> cancellation
+    /// would time out, and this test would fail.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task StatisticsPass_PersistentFailure_TerminatesAfterTwoAttemptsAndLogsRetryExhausted( ) {
+        // Arrange
+        _ = _loggerMock.Setup( l => l.IsEnabled( It.IsAny<LogLevel>( ) ) ).Returns( true );
+
+        // Make every ListAllRecordsAsync call throw so both the initial attempt and the retry fail.
+        int[] listCallCount = [0];
+        _ = _atProtoStorageMock
+            .Setup( x => x.ListAllRecordsAsync(
+                It.IsAny<Uri>( ), It.IsAny<string>( ),
+                It.IsAny<CancellationToken>( ), It.IsAny<bool>( ) ) )
+            .Returns<Uri, string, CancellationToken, bool>( ( _, _, _, _ ) => {
+                _ = Interlocked.Increment( ref listCallCount[0] );
+                throw new InvalidOperationException( "Persistent statistics failure" );
+            } );
+
+        // Signal when RetryExhausted (5579) is logged — the terminal event.
+        TaskCompletionSource retryExhaustedTcs = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _loggerMock
+            .Setup( l => l.Log(
+                LogLevel.Error,
+                It.Is<EventId>( e => e.Id == LogEventIds.RetryExhausted ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ) )
+            .Callback( ( ) => retryExhaustedTcs.TrySetResult( ) );
+
+        // Use a very short retry interval so the test does not spend 30 s in Task.Delay.
+        CacheBootstrapBackgroundService service = CreateService(
+            statisticsRetryInterval: TimeSpan.FromMilliseconds( 5 ) );
+
+        // Act: drive the manual-trigger path directly (TriggerStatisticsRefreshAsync →
+        // RunStatisticsPassAsync → RunStatisticsPassCoreAsync).
+        Task triggerTask = service.TriggerStatisticsRefreshAsync( CancellationToken.None );
+
+        // Wait for the RetryExhausted log — the termination signal.
+        await retryExhaustedTcs.Task.WaitAsync( TestContext.CancellationToken );
+
+        // Allow the trigger task to finish (it should return after RetryExhausted).
+        await triggerTask;
+
+        // Assert: exactly two ListAllRecordsAsync calls (initial attempt + one retry).
+        Assert.AreEqual( 2, listCallCount[0],
+            $"Expected exactly 2 ListAllRecordsAsync calls (initial + one retry); got {listCallCount[0]}" );
+
+        // Assert: RetryExhausted logged exactly once.
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.Is<EventId>( e => e.Id == LogEventIds.RetryExhausted ),
+                It.IsAny<It.IsAnyType>( ),
+                It.IsAny<Exception?>( ),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
+            Times.Once( ) );
+    }
+
     #endregion
 
     #region T7 — Coalescing: concurrent trigger during a running pass is dropped

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -44,7 +44,7 @@ rather than your main account password.
 
 ### Stale-cache refresh sweep
 
-The `StaleCacheRefreshBackgroundService` (in `BridgeBeats.Worker.CacheBootstrap`) runs on a
+The `StaleCacheRefreshBackgroundService` (in `BridgeBeats.Worker.Maintenance`) runs on a
 periodic timer, defaulting to every 24 hours (`RefreshIntervalHours`). Each run queries Redis for
 the oldest stale or expired media-link records and re-enqueues up to `MaxRecordsPerRun` of them at
 bulk priority. The provider workers process these lookups and write refreshed records back to the

--- a/src/BridgeBeats.Contracts/DTOs/CacheBootstrapStatus.cs
+++ b/src/BridgeBeats.Contracts/DTOs/CacheBootstrapStatus.cs
@@ -1,7 +1,7 @@
 namespace BridgeBeats.Contracts.DTOs;
 
 /// <summary>
-/// Point-in-time status of the CacheBootstrap worker, which warms the cache on a schedule.
+/// Point-in-time status of the Maintenance worker, which warms the cache on a schedule.
 /// Published to Redis under <see cref="RedisKey"/> and read back to surface bootstrap state
 /// alongside lookup statistics.
 /// </summary>

--- a/src/BridgeBeats.Contracts/Interfaces/IStatisticsService.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IStatisticsService.cs
@@ -5,7 +5,7 @@ namespace BridgeBeats.Contracts.Interfaces;
 /// <summary>
 /// Serves aggregate lookup statistics by reading the worker-published <c>status:statistics</c>
 /// Redis document, plus the live cache-bootstrap worker status that can be merged into the stats.
-/// Refresh requests are dispatched to the CacheBootstrap worker over Redis Pub/Sub.
+/// Refresh requests are dispatched to the Maintenance worker over Redis Pub/Sub.
 /// </summary>
 public interface IStatisticsService {
 
@@ -24,7 +24,7 @@ public interface IStatisticsService {
 
     /// <summary>
     /// Returns the most recently cached statistics snapshot without computing or waiting. The
-    /// value reflects the last snapshot written by the CacheBootstrap worker. Lets a caller
+    /// value reflects the last snapshot written by the Maintenance worker. Lets a caller
     /// distinguish "no data yet" from "data available". A projection over
     /// <see cref="GetStatus"/> (the snapshot field of the same status document).
     /// </summary>
@@ -35,14 +35,14 @@ public interface IStatisticsService {
     LookupStatistics? GetCachedStatistics( );
 
     /// <summary>
-    /// Whether the CacheBootstrap worker is currently running a statistics computation, as
+    /// Whether the Maintenance worker is currently running a statistics computation, as
     /// reported by the <c>IsRunning</c> field of the <c>status:statistics</c> Redis document. A
     /// projection over <see cref="GetStatus"/> (the running flag of the same status document).
     /// </summary>
     bool IsRefreshing { get; }
 
     /// <summary>
-    /// Publishes a manual-refresh request to the CacheBootstrap worker over Redis Pub/Sub.
+    /// Publishes a manual-refresh request to the Maintenance worker over Redis Pub/Sub.
     /// Returns immediately (fire-and-forget). Admin-gated and rate-limited by the caller.
     /// </summary>
     /// <returns>

--- a/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
+++ b/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
@@ -5,15 +5,18 @@ namespace BridgeBeats.Contracts.Records {
     /// <summary>Request to process an Apple Music playlist, identified by its id.</summary>
     /// <param name="PlaylistId">
     /// The Apple Music library playlist id to process. Must match the Apple library-playlist identifier
-    /// grammar: only alphanumeric characters, dots, underscores, and hyphens are permitted. The
-    /// expected form is <c>p.&lt;alphanumeric&gt;</c>, e.g. <c>p.ABCdef1234</c>. Maximum 100 characters.
+    /// grammar: alphanumeric segments separated by single dots, underscores, or hyphens. The value
+    /// must begin and end with an alphanumeric character; leading, trailing, or consecutive
+    /// separator characters are not permitted. Accepted forms include <c>p.&lt;alphanumeric&gt;</c>
+    /// (e.g. <c>p.ABCdef1234</c>), <c>i.&lt;alphanumeric&gt;</c> (e.g. <c>i.e5gmPS6rZ856</c>), and
+    /// <c>pl.u-&lt;alphanumeric&gt;</c> (e.g. <c>pl.u-abc123</c>). Maximum 100 characters.
     /// </param>
     public record ProcessPlaylistRequest(
         [Required]
         [StringLength( 100, MinimumLength = 1 )]
         [RegularExpression(
-            @"^[A-Za-z0-9._-]+$",
-            ErrorMessage = "PlaylistId contains invalid characters. Only alphanumeric characters, dots, underscores, and hyphens are allowed."
+            @"^[A-Za-z0-9]+([._-][A-Za-z0-9]+)*$",
+            ErrorMessage = "PlaylistId contains invalid characters. Only alphanumeric characters are allowed, with dots, underscores, or hyphens permitted as single separators between alphanumeric segments. Leading, trailing, and consecutive separator characters are not allowed."
         )]
         string PlaylistId
     );

--- a/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
+++ b/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
@@ -1,7 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace BridgeBeats.Contracts.Records {
 
     /// <summary>Request to process an Apple Music playlist, identified by its id.</summary>
-    /// <param name="PlaylistId">The Apple Music playlist id to process.</param>
-    public record ProcessPlaylistRequest( string PlaylistId );
+    /// <param name="PlaylistId">
+    /// The Apple Music library playlist id to process. Must match the Apple library-playlist identifier
+    /// grammar: only alphanumeric characters, dots, underscores, and hyphens are permitted. The
+    /// expected form is <c>p.&lt;alphanumeric&gt;</c>, e.g. <c>p.ABCdef1234</c>. Maximum 100 characters.
+    /// </param>
+    public record ProcessPlaylistRequest(
+        [Required]
+        [StringLength( 100, MinimumLength = 1 )]
+        [RegularExpression(
+            @"^[A-Za-z0-9._-]+$",
+            ErrorMessage = "PlaylistId contains invalid characters. Only alphanumeric characters, dots, underscores, and hyphens are allowed."
+        )]
+        string PlaylistId
+    );
 
 }

--- a/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
+++ b/src/BridgeBeats.Contracts/Records/ProcessPlaylistRequest.cs
@@ -15,7 +15,7 @@ namespace BridgeBeats.Contracts.Records {
         [Required]
         [StringLength( 100, MinimumLength = 1 )]
         [RegularExpression(
-            @"^[A-Za-z0-9]+([._-][A-Za-z0-9]+)*$",
+            @"\A[A-Za-z0-9]+([._-][A-Za-z0-9]+)*\z",
             ErrorMessage = "PlaylistId contains invalid characters. Only alphanumeric characters are allowed, with dots, underscores, or hyphens permitted as single separators between alphanumeric segments. Leading, trailing, and consecutive separator characters are not allowed."
         )]
         string PlaylistId

--- a/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
@@ -296,7 +296,8 @@ namespace BridgeBeats.Providers.AppleMusic {
         /// <summary>
         /// Validates that <paramref name="isrc"/> conforms to a conservative alphanumeric ISRC pattern.
         /// Apple Music strips ISRC hyphens, so the expected form is 4–18 uppercase letters and digits.
-        /// The Security Engineer should confirm whether tighter bounds are appropriate.
+        /// The canonical 12-character ISRC (hyphens stripped) fits well within this range; the upper
+        /// bound is intentionally permissive to avoid rejecting non-standard registrant codes.
         /// </summary>
         /// <param name="isrc">The ISRC value to validate.</param>
         /// <exception cref="ArgumentException">Thrown when the value does not match the expected pattern.</exception>
@@ -385,8 +386,9 @@ namespace BridgeBeats.Providers.AppleMusic {
 
         /// <summary>
         /// Compiled regex that accepts a conservative ISRC value: 4–18 uppercase or lowercase letters
-        /// and digits, with no hyphens (Apple Music strips ISRC hyphens). Security Engineer should
-        /// confirm whether stricter bounds are appropriate.
+        /// and digits, with no hyphens (Apple Music strips ISRC hyphens). The canonical 12-character
+        /// ISRC fits within this range; the upper bound is intentionally permissive to avoid rejecting
+        /// non-standard registrant codes.
         /// </summary>
         private static readonly Regex s_validIsrc = ValidIsrc();
 

--- a/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
@@ -54,14 +54,26 @@ namespace BridgeBeats.Providers.AppleMusic {
                 string? uri = s_appleLink.GetGroupValues(link, "URI").FirstOrDefault();
 
                 if (uri != null && (s_validAlbum.IsMatch( uri ) || s_validSong.IsMatch( uri ))) {
+                    string candidateStorefront = GetUriStoreFront( uri );
+                    if (!s_validStorefront.IsMatch( candidateStorefront )) {
+                        return false;
+                    }
+
                     string id = GetUriId(uri);
                     string albumSongId = GetSongId(uri);
 
-                    storefront = GetUriStoreFront( uri );
                     if (string.IsNullOrWhiteSpace( albumSongId )) {
+                        if (!s_validCatalogId.IsMatch( id )) {
+                            return false;
+                        }
+                        storefront = candidateStorefront;
                         requestUri = GetAlbumsURI( storefront, id );
                         isAlbum = true;
                     } else {
+                        if (!s_validCatalogId.IsMatch( albumSongId )) {
+                            return false;
+                        }
+                        storefront = candidateStorefront;
                         requestUri = GetSongsURI( storefront, albumSongId );
                     }
                     return true;
@@ -98,46 +110,79 @@ namespace BridgeBeats.Providers.AppleMusic {
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="artist">The artist name; URL-escaped into the query.</param>
         /// <returns>The relative search API path filtered to artist results.</returns>
-        public static string GetArtistSearchUri( string storefront, string artist )
-            => ArtistsSearchURI
-                .Replace( "{storefront}", storefront )
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code.
+        /// </exception>
+        public static string GetArtistSearchUri( string storefront, string artist ) {
+            ValidateStorefront( storefront );
+            return ArtistsSearchURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
                 .Replace( "{artist}", Uri.EscapeDataString( artist ) );
+        }
 
         /// <summary>Builds the Apple Music API path that finds songs by ISRC.</summary>
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="isrc">The International Standard Recording Code to filter on.</param>
         /// <returns>The relative API path filtered by ISRC.</returns>
-        public static string GetSongsIsrcURI( string storefront, string isrc )
-            => SongsIsrcURI
-                .Replace( "{storefront}", storefront )
-                .Replace( "{isrc}", isrc );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="isrc"/> contains characters outside the expected alphanumeric set.
+        /// </exception>
+        public static string GetSongsIsrcURI( string storefront, string isrc ) {
+            ValidateStorefront( storefront );
+            ValidateIsrc( isrc );
+            return SongsIsrcURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{isrc}", Uri.EscapeDataString( isrc ) );
+        }
 
         /// <summary>Builds the Apple Music API path that finds albums by UPC.</summary>
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="upc">The Universal Product Code to filter on.</param>
         /// <returns>The relative API path filtered by UPC.</returns>
-        public static string GetAlbumUpcURI( string storefront, string upc )
-            => AlbumsUpcURI
-                .Replace( "{storefront}", storefront )
-                .Replace( "{upc}", upc );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="upc"/> contains characters outside the expected numeric set.
+        /// </exception>
+        public static string GetAlbumUpcURI( string storefront, string upc ) {
+            ValidateStorefront( storefront );
+            ValidateUpc( upc );
+            return AlbumsUpcURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{upc}", Uri.EscapeDataString( upc ) );
+        }
 
         /// <summary>Builds the Apple Music API path that lists an artist's albums.</summary>
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="artistId">The Apple Music artist identifier.</param>
         /// <returns>The relative API path for the artist's albums.</returns>
-        public static string GetArtistAlbumsURI( string storefront, string artistId )
-            => ArtistAlbumsURI
-                .Replace( "{storefront}", storefront )
-                .Replace( "{artist}", artistId );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="artistId"/> is not a numeric catalog identifier.
+        /// </exception>
+        public static string GetArtistAlbumsURI( string storefront, string artistId ) {
+            ValidateStorefront( storefront );
+            ValidateCatalogId( artistId );
+            return ArtistAlbumsURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{artist}", Uri.EscapeDataString( artistId ) );
+        }
 
         /// <summary>Builds the Apple Music API path that lists an artist's songs.</summary>
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="artistId">The Apple Music artist identifier.</param>
         /// <returns>The relative API path for the artist's songs.</returns>
-        public static string GetArtistSongsURI( string storefront, string artistId )
-            => ArtistSongsURI
-                .Replace( "{storefront}", storefront )
-                .Replace( "{artist}", artistId );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="artistId"/> is not a numeric catalog identifier.
+        /// </exception>
+        public static string GetArtistSongsURI( string storefront, string artistId ) {
+            ValidateStorefront( storefront );
+            ValidateCatalogId( artistId );
+            return ArtistSongsURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{artist}", Uri.EscapeDataString( artistId ) );
+        }
 
         /// <summary>Template for the catalog album-by-id endpoint path.</summary>
         private const string AlbumsURI = "{storefront}/albums/{id}";
@@ -176,8 +221,17 @@ namespace BridgeBeats.Providers.AppleMusic {
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="id">The album identifier.</param>
         /// <returns>The relative API path for the album.</returns>
-        private static string GetAlbumsURI( string storefront, string id )
-            => AlbumsURI.Replace( "{storefront}", storefront ).Replace( "{id}", id );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="id"/> is not a numeric catalog identifier.
+        /// </exception>
+        private static string GetAlbumsURI( string storefront, string id ) {
+            ValidateStorefront( storefront );
+            ValidateCatalogId( id );
+            return AlbumsURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{id}", Uri.EscapeDataString( id ) );
+        }
 
         /// <summary>
         /// Extracts the song identifier from a parsed URI, preferring the <c>?i=</c> in-album selector and
@@ -196,8 +250,81 @@ namespace BridgeBeats.Providers.AppleMusic {
         /// <param name="storefront">The storefront (country) segment.</param>
         /// <param name="id">The song identifier.</param>
         /// <returns>The relative API path for the song.</returns>
-        private static string GetSongsURI( string storefront, string id )
-            => SongsURI.Replace( "{storefront}", storefront ).Replace( "{id}", id );
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="storefront"/> is not a 2–3-letter alphabetic code, or when
+        /// <paramref name="id"/> is not a numeric catalog identifier.
+        /// </exception>
+        private static string GetSongsURI( string storefront, string id ) {
+            ValidateStorefront( storefront );
+            ValidateCatalogId( id );
+            return SongsURI
+                .Replace( "{storefront}", Uri.EscapeDataString( storefront ) )
+                .Replace( "{id}", Uri.EscapeDataString( id ) );
+        }
+
+        #region Validation
+
+        /// <summary>
+        /// Validates that <paramref name="storefront"/> is a 2–3-letter alphabetic Apple Music storefront code
+        /// (ISO 3166-1 alpha-2, or the special-purpose "all" value).
+        /// </summary>
+        /// <param name="storefront">The storefront segment to validate.</param>
+        /// <exception cref="ArgumentException">Thrown when the value does not match the expected pattern.</exception>
+        private static void ValidateStorefront( string storefront ) {
+            if (!s_validStorefront.IsMatch( storefront )) {
+                throw new ArgumentException(
+                    $"Invalid storefront value '{storefront}': must be 2–3 alphabetic characters.",
+                    nameof( storefront )
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates that <paramref name="id"/> is a purely numeric Apple Music catalog identifier.
+        /// </summary>
+        /// <param name="id">The catalog identifier to validate.</param>
+        /// <exception cref="ArgumentException">Thrown when the value contains non-numeric characters.</exception>
+        private static void ValidateCatalogId( string id ) {
+            if (!s_validCatalogId.IsMatch( id )) {
+                throw new ArgumentException(
+                    $"Invalid catalog id '{id}': must contain only numeric digits.",
+                    nameof( id )
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates that <paramref name="isrc"/> conforms to a conservative alphanumeric ISRC pattern.
+        /// Apple Music strips ISRC hyphens, so the expected form is 4–18 uppercase letters and digits.
+        /// The Security Engineer should confirm whether tighter bounds are appropriate.
+        /// </summary>
+        /// <param name="isrc">The ISRC value to validate.</param>
+        /// <exception cref="ArgumentException">Thrown when the value does not match the expected pattern.</exception>
+        private static void ValidateIsrc( string isrc ) {
+            if (!s_validIsrc.IsMatch( isrc )) {
+                throw new ArgumentException(
+                    $"Invalid ISRC value '{isrc}': must be 4–18 alphanumeric characters.",
+                    nameof( isrc )
+                );
+            }
+        }
+
+        /// <summary>
+        /// Validates that <paramref name="upc"/> is a numeric barcode in the range of standard UPC/EAN lengths
+        /// (8–14 digits).
+        /// </summary>
+        /// <param name="upc">The UPC value to validate.</param>
+        /// <exception cref="ArgumentException">Thrown when the value does not match the expected pattern.</exception>
+        private static void ValidateUpc( string upc ) {
+            if (!s_validUpc.IsMatch( upc )) {
+                throw new ArgumentException(
+                    $"Invalid UPC value '{upc}': must be 8–14 numeric digits.",
+                    nameof( upc )
+                );
+            }
+        }
+
+        #endregion Validation
 
         #region Regex
 
@@ -232,6 +359,52 @@ namespace BridgeBeats.Providers.AppleMusic {
         /// <returns>The compiled song-URL regex.</returns>
         [GeneratedRegex( @"(?<StoreFront>\w+)/[Ss][Oo][Nn][Gg](?:/.*)?/(?<Identifier>[^?#]*)", RegexOptions.Compiled )]
         private static partial Regex ValidSongURI( );
+
+        /// <summary>
+        /// Compiled regex that accepts a valid Apple Music storefront: 2–3 alphabetic characters
+        /// (ISO 3166-1 alpha-2 country codes, or the special "all" value). Full-string match enforced
+        /// by anchors.
+        /// </summary>
+        private static readonly Regex s_validStorefront = ValidStorefront();
+
+        /// <summary>Source-generated factory for <see cref="s_validStorefront"/>.</summary>
+        /// <returns>The compiled storefront validation regex.</returns>
+        [GeneratedRegex( @"\A[a-zA-Z]{2,3}\z", RegexOptions.Compiled )]
+        private static partial Regex ValidStorefront( );
+
+        /// <summary>
+        /// Compiled regex that accepts a valid Apple Music numeric catalog identifier (one or more
+        /// decimal digits). Full-string match enforced by anchors.
+        /// </summary>
+        private static readonly Regex s_validCatalogId = ValidCatalogId();
+
+        /// <summary>Source-generated factory for <see cref="s_validCatalogId"/>.</summary>
+        /// <returns>The compiled catalog-id validation regex.</returns>
+        [GeneratedRegex( @"\A[0-9]+\z", RegexOptions.Compiled )]
+        private static partial Regex ValidCatalogId( );
+
+        /// <summary>
+        /// Compiled regex that accepts a conservative ISRC value: 4–18 uppercase or lowercase letters
+        /// and digits, with no hyphens (Apple Music strips ISRC hyphens). Security Engineer should
+        /// confirm whether stricter bounds are appropriate.
+        /// </summary>
+        private static readonly Regex s_validIsrc = ValidIsrc();
+
+        /// <summary>Source-generated factory for <see cref="s_validIsrc"/>.</summary>
+        /// <returns>The compiled ISRC validation regex.</returns>
+        [GeneratedRegex( @"\A[A-Za-z0-9]{4,18}\z", RegexOptions.Compiled )]
+        private static partial Regex ValidIsrc( );
+
+        /// <summary>
+        /// Compiled regex that accepts a numeric barcode in the range of standard UPC/EAN lengths
+        /// (EAN-8 through EAN-14, inclusive). Full-string match enforced by anchors.
+        /// </summary>
+        private static readonly Regex s_validUpc = ValidUpc();
+
+        /// <summary>Source-generated factory for <see cref="s_validUpc"/>.</summary>
+        /// <returns>The compiled UPC validation regex.</returns>
+        [GeneratedRegex( @"\A[0-9]{8,14}\z", RegexOptions.Compiled )]
+        private static partial Regex ValidUpc( );
 
         #endregion Regex
 

--- a/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/AppleMusic/AppleMusicLinkParser.cs
@@ -273,7 +273,7 @@ namespace BridgeBeats.Providers.AppleMusic {
         private static void ValidateStorefront( string storefront ) {
             if (!s_validStorefront.IsMatch( storefront )) {
                 throw new ArgumentException(
-                    $"Invalid storefront value '{storefront}': must be 2–3 alphabetic characters.",
+                    "Storefront must be 2–3 alphabetic characters.",
                     nameof( storefront )
                 );
             }
@@ -287,7 +287,7 @@ namespace BridgeBeats.Providers.AppleMusic {
         private static void ValidateCatalogId( string id ) {
             if (!s_validCatalogId.IsMatch( id )) {
                 throw new ArgumentException(
-                    $"Invalid catalog id '{id}': must contain only numeric digits.",
+                    "Catalog id must contain only numeric digits.",
                     nameof( id )
                 );
             }
@@ -303,7 +303,7 @@ namespace BridgeBeats.Providers.AppleMusic {
         private static void ValidateIsrc( string isrc ) {
             if (!s_validIsrc.IsMatch( isrc )) {
                 throw new ArgumentException(
-                    $"Invalid ISRC value '{isrc}': must be 4–18 alphanumeric characters.",
+                    "ISRC must be 4–18 alphanumeric characters.",
                     nameof( isrc )
                 );
             }
@@ -318,7 +318,7 @@ namespace BridgeBeats.Providers.AppleMusic {
         private static void ValidateUpc( string upc ) {
             if (!s_validUpc.IsMatch( upc )) {
                 throw new ArgumentException(
-                    $"Invalid UPC value '{upc}': must be 8–14 numeric digits.",
+                    "UPC must be 8–14 numeric digits.",
                     nameof( upc )
                 );
             }

--- a/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
@@ -278,7 +278,7 @@ public sealed partial class RedisMediaLinkCache : IMediaLinkCacheRepository {
     /// title/artist metadata pointers, and provider-id pointers. All written keys are recorded in
     /// <c>keys:{rkey}</c> so they can be refreshed or removed as a unit, and all share the configured
     /// cache-day TTL. When an entry for the same record already exists, only the TTLs are refreshed
-    /// rather than rewriting the pointers. This is the same method CacheBootstrap calls to rebuild
+    /// rather than rewriting the pointers. This is the same method the Maintenance worker calls to rebuild
     /// Redis from the PDS.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="result"/> is null.</exception>

--- a/src/BridgeBeats.Core/Infrastructure/Extensions/DataProtectionExtensions.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Extensions/DataProtectionExtensions.cs
@@ -4,7 +4,7 @@ namespace BridgeBeats.Core.Infrastructure.Extensions {
 
     /// <summary>
     /// Dependency-injection registration helper for the BridgeBeats shared Data Protection
-    /// foundation, used by all three host processes (Web, SagaCoordinator, CacheBootstrap) to
+    /// foundation, used by all three host processes (Web, SagaCoordinator, Maintenance) to
     /// ensure values encrypted in one process can be decrypted in another.
     /// </summary>
     public static class DataProtectionExtensions {
@@ -12,7 +12,7 @@ namespace BridgeBeats.Core.Infrastructure.Extensions {
         /// <summary>
         /// The default filesystem directory for the Data Protection key ring when no explicit path is
         /// configured. Defined once here so that the Web host (<c>AppSettings.DataProtectionKeyPath</c>),
-        /// the SagaCoordinator, and the CacheBootstrap worker all fall back to the same value and a
+        /// the SagaCoordinator, and the Maintenance worker all fall back to the same value and a
         /// future edit cannot desync the cross-process key path.
         /// </summary>
         public const string DefaultKeyPath = "./keys";

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -38,7 +38,7 @@ namespace BridgeBeats.Core.Infrastructure.Logging;
 ///   <item>2000-2999: Core/Providers (Spotify, Tidal, AppleMusic, Common)</item>
 ///   <item>3000-3999: Core/Services (Queue, LinkResolver, Cards, Other)</item>
 ///   <item>4000-4999: Web (Controllers, Middleware, Configuration)</item>
-///   <item>5000-6999: Workers (SagaCoordinator, Spotify, CacheBootstrap, JetStream, Discord, AppleMusic, Tidal)</item>
+///   <item>5000-6999: Workers (SagaCoordinator, Spotify, Maintenance, JetStream, Discord, AppleMusic, Tidal)</item>
 /// </list>
 /// </remarks>
 public static class LogEventIds {

--- a/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
+++ b/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
@@ -298,8 +298,11 @@ public partial class AppleMusicController(
             // Add user token for accessing user's library
             client.DefaultRequestHeaders.Add( "Music-User-Token", user.AppleMusicUserToken );
 
-            // Fetch all playlist tracks with pagination
-            string playlistId = request.PlaylistId.SanitizeForLogging( );
+            // Fetch all playlist tracks with pagination.
+            // Uri.EscapeDataString is defense-in-depth; the [RegularExpression] annotation on
+            // ProcessPlaylistRequest.PlaylistId has already enforced the safe character set via
+            // ModelState validation above.
+            string playlistId = Uri.EscapeDataString( request.PlaylistId );
 
             List<string> trackIds = [];
             string? nextUrl = $"https://api.music.apple.com/v1/me/library/playlists/{playlistId}/tracks";
@@ -350,7 +353,7 @@ public partial class AppleMusicController(
                 }
                 if (totalTracks >= 1000) {
                     overonekay = true;
-                    LogPlaylistTooLarge( playlistId );
+                    LogPlaylistTooLarge( request.PlaylistId.SanitizeForLogging( ) );
                     break;
                 }
             }

--- a/src/BridgeBeats.Web/Services/RedisStatisticsReader.cs
+++ b/src/BridgeBeats.Web/Services/RedisStatisticsReader.cs
@@ -83,7 +83,7 @@ public sealed partial class RedisStatisticsReader(
     }
 
     /// <summary>
-    /// <see langword="true"/> when the CacheBootstrap worker is currently running a statistics
+    /// <see langword="true"/> when the Maintenance worker is currently running a statistics
     /// computation, as reported by the <c>IsRunning</c> field of <c>status:statistics</c>.
     /// Served from the in-process memo. A projection over <see cref="GetStatus"/> (its running flag).
     /// </summary>
@@ -100,7 +100,7 @@ public sealed partial class RedisStatisticsReader(
     }
 
     /// <summary>
-    /// Publishes a manual refresh request to the CacheBootstrap worker via
+    /// Publishes a manual refresh request to the Maintenance worker via
     /// <see cref="RedisChannels.StatisticsRefreshRequested"/>. Returns immediately.
     /// </summary>
     /// <returns>

--- a/src/BridgeBeats.Worker.Maintenance/CacheBootstrapBackgroundService.cs
+++ b/src/BridgeBeats.Worker.Maintenance/CacheBootstrapBackgroundService.cs
@@ -411,8 +411,8 @@ public sealed partial class CacheBootstrapBackgroundService(
 
     /// <summary>
     /// Writes the statistics snapshot built from <paramref name="accumulator"/>. On failure,
-    /// writes an error status doc, waits the retry interval, then retries once via a fresh
-    /// <see cref="RunStatisticsPassAsync"/> call. A second failure writes the final error doc.
+    /// writes an error status doc, waits the retry interval, then retries once via
+    /// <see cref="RunStatisticsPassCoreAsync"/>. A second failure writes the final error doc.
     /// </summary>
     private async Task TryPublishStatisticsFromAccumulatorAsync(
         StatisticsAccumulator accumulator,
@@ -439,8 +439,9 @@ public sealed partial class CacheBootstrapBackgroundService(
     }
 
     /// <summary>
-    /// Writes an error status document, waits the retry interval, then retries via a fresh
-    /// <see cref="RunStatisticsPassAsync"/>. A second failure writes the final error document.
+    /// Writes an error status document, waits the retry interval, then retries via
+    /// <see cref="RunStatisticsPassCoreAsync"/>. A second failure writes the final error document
+    /// and returns, letting the periodic timer serve as the backstop.
     /// </summary>
     private async Task HandleStatisticsPassFailureAndRetryAsync(
         Exception firstEx,
@@ -466,9 +467,12 @@ public sealed partial class CacheBootstrapBackgroundService(
             throw;
         }
 
-        // Retry once: re-read records (cache-served within the 5-min TTL, no second download).
+        // Retry once via the core body (not RunStatisticsPassAsync, which would re-enter
+        // Handle with isFirstAttempt:true and restart the retry cycle unboundedly). Calling
+        // the core directly lets a second failure propagate to the catch below, which re-enters
+        // Handle with isFirstAttempt:false — the terminal path that logs RetryExhausted.
         try {
-            await RunStatisticsPassAsync( forceRefresh: false, cancellationToken );
+            await RunStatisticsPassCoreAsync( forceRefresh: false, cancellationToken );
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
         } catch (Exception retryEx) {
@@ -480,9 +484,42 @@ public sealed partial class CacheBootstrapBackgroundService(
     }
 
     /// <summary>
-    /// Runs a full statistics-only pass: enumerates all records (cache-served when within the
-    /// 5-minute TTL), folds them into a <see cref="StatisticsAccumulator"/>, and publishes the
-    /// snapshot. Called for the retry (no second download on the happy path) and for manual triggers.
+    /// Core statistics pass body: marks status running, enumerates all records (cache-served when
+    /// within the 5-minute TTL), folds them into a <see cref="StatisticsAccumulator"/>, and
+    /// publishes the snapshot. All exceptions propagate to the caller; no self-handling is
+    /// performed here. Callers are responsible for error-doc writes and retry orchestration.
+    /// </summary>
+    /// <param name="forceRefresh">
+    /// When <see langword="true"/>, bypasses the CAR cache TTL and forces a fresh download
+    /// (used by the manual admin trigger).
+    /// </param>
+    /// <param name="cancellationToken">Cancels the enumeration and the status write.</param>
+    private async Task RunStatisticsPassCoreAsync( bool forceRefresh, CancellationToken cancellationToken ) {
+        if (logger.IsEnabled( LogLevel.Information )) {
+            LogPassStarting( logger );
+        }
+
+        await WriteRunningStatusAsync( );
+
+        StatisticsAccumulator acc = new( );
+        await foreach ((string atUri, MediaLinkResult result) in
+            atProtoStorage.ListAllRecordsAsync(
+                settings.PdsUri, settings.UserDid, cancellationToken, forceRefresh: forceRefresh )) {
+            acc.Add( atUri, result );
+        }
+
+        LookupStatistics snapshot = acc.Build( );
+        await WriteHealthyStatusAsync( snapshot );
+        LogPassCompleted( logger, snapshot.TotalRecords );
+    }
+
+    /// <summary>
+    /// Runs a full statistics-only pass: wraps <see cref="RunStatisticsPassCoreAsync"/> with
+    /// error-doc-on-failure semantics so the manual-trigger path never leaves
+    /// <c>status:statistics</c> stuck at <c>IsRunning=true</c>. On failure,
+    /// <see cref="HandleStatisticsPassFailureAndRetryAsync"/> writes an error status document,
+    /// waits the retry interval, retries once via the core, and — on a second consecutive failure
+    /// — writes the final error document and returns.
     /// </summary>
     /// <param name="forceRefresh">
     /// When <see langword="true"/>, bypasses the CAR cache TTL and forces a fresh download
@@ -490,23 +527,8 @@ public sealed partial class CacheBootstrapBackgroundService(
     /// </param>
     /// <param name="cancellationToken">Cancels the enumeration and the status write.</param>
     internal async Task RunStatisticsPassAsync( bool forceRefresh, CancellationToken cancellationToken ) {
-        if (logger.IsEnabled( LogLevel.Information )) {
-            LogPassStarting( logger );
-        }
-
-        await WriteRunningStatusAsync( );
-
         try {
-            StatisticsAccumulator acc = new( );
-            await foreach ((string atUri, MediaLinkResult result) in
-                atProtoStorage.ListAllRecordsAsync(
-                    settings.PdsUri, settings.UserDid, cancellationToken, forceRefresh: forceRefresh )) {
-                acc.Add( atUri, result );
-            }
-
-            LookupStatistics snapshot = acc.Build( );
-            await WriteHealthyStatusAsync( snapshot );
-            LogPassCompleted( logger, snapshot.TotalRecords );
+            await RunStatisticsPassCoreAsync( forceRefresh, cancellationToken );
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
         } catch (Exception ex) {

--- a/src/BridgeBeats.Worker.Maintenance/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.Maintenance/Logging/LogEventIds.cs
@@ -1,7 +1,7 @@
 namespace BridgeBeats.Worker.Maintenance.Logging;
 
 /// <summary>
-/// Stable numeric event identifiers for the CacheBootstrap worker's structured log messages (5500-5749).
+/// Stable numeric event identifiers for the Maintenance worker's structured log messages (5500-5749).
 /// Extends <see cref="Core.Infrastructure.Logging.LogEventIds"/> with CacheBootstrap-specific EventIds.
 /// Each constant is the <c>EventId</c> assigned to a corresponding
 /// <see cref="Microsoft.Extensions.Logging.LoggerMessageAttribute"/> method. The

--- a/src/BridgeBeats.Worker.Maintenance/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Worker.Maintenance/Logging/LogEventIds.cs
@@ -2,7 +2,7 @@ namespace BridgeBeats.Worker.Maintenance.Logging;
 
 /// <summary>
 /// Stable numeric event identifiers for the Maintenance worker's structured log messages (5500-5749).
-/// Extends <see cref="Core.Infrastructure.Logging.LogEventIds"/> with CacheBootstrap-specific EventIds.
+/// Extends <see cref="Core.Infrastructure.Logging.LogEventIds"/> with Maintenance worker-specific EventIds.
 /// Each constant is the <c>EventId</c> assigned to a corresponding
 /// <see cref="Microsoft.Extensions.Logging.LoggerMessageAttribute"/> method. The
 /// <see cref="CacheBootstrapBackgroundService"/> messages occupy 5500–5519, the

--- a/src/BridgeBeats.Worker.Maintenance/Program.cs
+++ b/src/BridgeBeats.Worker.Maintenance/Program.cs
@@ -12,7 +12,7 @@ using StackExchange.Redis;
 namespace BridgeBeats.Worker.Maintenance;
 
 /// <summary>
-/// Entry point and composition root for the CacheBootstrap worker process. The worker is a headless
+/// Entry point and composition root for the Maintenance worker process. The worker is a headless
 /// background host (no HTTP endpoint): it builds a generic host, registers the Redis client, ATProto
 /// storage, the media-link cache, and the <see cref="CacheBootstrapBackgroundService"/> that rebuilds
 /// the Redis lookup index from the PDS.

--- a/src/BridgeBeats.Worker.Maintenance/Program.cs
+++ b/src/BridgeBeats.Worker.Maintenance/Program.cs
@@ -60,7 +60,7 @@ public static class Program {
         builder.AddRedisClient( "redis" );
 
         // Lane B: Data Protection — must use the same app name and key path as Web so
-        // values encrypted in one process (Web, SagaCoordinator, CacheBootstrap) can be
+        // values encrypted in one process (Web, SagaCoordinator, Maintenance) can be
         // decrypted by any other.
         string dataProtectionKeyPath = builder.Configuration["BridgeBeats:DataProtectionKeyPath"] ?? DataProtectionExtensions.DefaultKeyPath;
         _ = builder.Services.AddBridgeBeatsDataProtection( dataProtectionKeyPath );

--- a/src/BridgeBeats.Worker.Maintenance/ProgramLog.cs
+++ b/src/BridgeBeats.Worker.Maintenance/ProgramLog.cs
@@ -3,7 +3,7 @@ using BridgeBeats.Worker.Maintenance.Logging;
 namespace BridgeBeats.Worker.Maintenance;
 
 /// <summary>
-/// Source-generated structured-logging helpers for the CacheBootstrap startup path. These wrap the
+/// Source-generated structured-logging helpers for the Maintenance startup path. These wrap the
 /// Redis-connection verification messages emitted from <see cref="Program"/> before the worker runs.
 /// </summary>
 internal static partial class ProgramLog {

--- a/src/BridgeBeats.Worker.SagaCoordinator/Program.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/Program.cs
@@ -58,7 +58,7 @@ public static class Program {
         builder.AddRedisClient( "redis" );
 
         // Lane B: Data Protection — must use the same app name and key path as Web so
-        // values encrypted in one process (Web, SagaCoordinator, CacheBootstrap) can be
+        // values encrypted in one process (Web, SagaCoordinator, Maintenance) can be
         // decrypted by any other.
         string dataProtectionKeyPath = builder.Configuration["BridgeBeats:DataProtectionKeyPath"] ?? DataProtectionExtensions.DefaultKeyPath;
         _ = builder.Services.AddBridgeBeatsDataProtection( dataProtectionKeyPath );


### PR DESCRIPTION
- a correctness fix to the Maintenance worker's statistics retry loop, which could retry unbounded on persistent failure
- a security hardening of the Apple Music URL builders and the playlist endpoint, closing argument/path injection into outbound requests that carry the Apple developer JWT and the per-user Music-User-Token
- completion of the `CacheBootstrap` → `Maintenance` doc-comment rename.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] Tests added/updated for new functionality
- [x] Documentation updated (README, API docs, configuration docs)
- [x] No secrets or credentials committed
- [ ] Breaking changes documented in PR description

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**