### PR TITLE
fix(atproto): stop persisting internal isPartial flag onto PDS records

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,17 +37,17 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Docker Hub login
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build & push per-arch (by digest)
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: ./containers/Dockerfile
@@ -109,17 +109,17 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Docker Hub login
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/publish-caddy-cloudflare.yml
+++ b/.github/workflows/publish-caddy-cloudflare.yml
@@ -44,17 +44,17 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Docker Hub login
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build & push per-arch (by digest)
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: ./containers/Dockerfile.caddy
@@ -116,17 +116,17 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Docker Hub login
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: results.sarif

--- a/Tests/BridgeBeats.Tests.csproj
+++ b/Tests/BridgeBeats.Tests.csproj
@@ -14,22 +14,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.3" />
-    <!-- Pin: overrides the vulnerable MessagePack 2.5.192 pulled in via Aspire.Hosting.Testing → StreamJsonRpc. -->
-    <PackageReference Include="MessagePack" Version="2.5.301" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3">
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Testcontainers.Redis" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/EndToEnd/HomeControllerTests.cs
+++ b/Tests/EndToEnd/HomeControllerTests.cs
@@ -1,5 +1,13 @@
 using System.Net;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Core.Infrastructure.Utilities;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
 
 namespace BridgeBeats.Tests.EndToEnd;
 
@@ -307,4 +315,269 @@ public class HomeControllerTests {
     /// The MSTest-injected test context, used here to obtain the per-test cancellation token.
     /// </summary>
     public TestContext TestContext { get; set; }
+}
+
+/// <summary>
+/// Verifies that <c>MusicLookupResultItem.IsLookupInProgress</c> correctly reflects the injected
+/// <see cref="ILookupProgressProbe"/> at the three controller sites (<c>LookupResults</c>,
+/// <c>CreateViewModelFromResult</c>, <c>LookupResultsStream</c>). Each test exercises the
+/// <c>LookupResultsByIsrc</c> action with a stubbed media-link service (so a result item is always
+/// produced) and a controlled probe, then inspects the rendered HTML for the "Still looking up…"
+/// indicator that appears only when <c>IsLookupInProgress</c> is <see langword="true"/>.
+/// </summary>
+/// <remarks>
+/// Failure-first evidence for each new test is documented inline. A stub
+/// <see cref="ILookupProgressProbe"/> is injected via the per-test
+/// <see cref="ProbeOverrideFactory"/> so that the probe return value is the ONLY variable between
+/// the three cases; all other services are identical. This isolates the wiring path from the probe
+/// call through to the view-model property and rendered HTML.
+/// </remarks>
+[TestClass]
+[TestCategory( "EndToEnd" )]
+public class HomeControllerProbeWiringTests {
+
+    private const string TestUrl = "https://open.spotify.com/track/probetesttrack";
+
+    /// <summary>MSTest-injected context used to obtain the per-test cancellation token.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>
+    /// Verifies that when <see cref="ILookupProgressProbe.IsActiveAsync"/> returns
+    /// <see langword="true"/>, the rendered view contains the "Still looking up" in-progress indicator.
+    /// Failure-first: a probe stub wired to return <see langword="false"/> causes this assertion to
+    /// fail (indicator absent); the correct <see langword="true"/>-returning stub makes it pass.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResultsByIsrc_ProbeReturnsTrue_InProgressIndicatorIsRendered( ) {
+        Mock<ILookupProgressProbe> probeMock = new( );
+        _ = probeMock
+            .Setup( p => p.IsActiveAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( sp => BuildStubMediaService( ) );
+            _ = services.RemoveAll<ILookupProgressProbe>( );
+            _ = services.AddTransient<ILookupProgressProbe>( sp => probeMock.Object );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["isrc"] = "USRC12345678" } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResultsByIsrc", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( System.Net.HttpStatusCode.OK, response.StatusCode );
+        Assert.IsTrue(
+            content.Contains( "Still looking up", StringComparison.OrdinalIgnoreCase ),
+            "When the probe returns true, IsLookupInProgress must be true and the view must render the in-progress indicator." );
+    }
+
+    /// <summary>
+    /// Verifies that when <see cref="ILookupProgressProbe.IsActiveAsync"/> returns
+    /// <see langword="false"/>, the in-progress indicator is absent from the rendered view.
+    /// Failure-first: a probe stub returning <see langword="true"/> causes this assertion to fail
+    /// (indicator present); the correct <see langword="false"/>-returning stub makes it pass.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResultsByIsrc_ProbeReturnsFalse_InProgressIndicatorIsAbsent( ) {
+        Mock<ILookupProgressProbe> probeMock = new( );
+        _ = probeMock
+            .Setup( p => p.IsActiveAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( sp => BuildStubMediaService( ) );
+            _ = services.RemoveAll<ILookupProgressProbe>( );
+            _ = services.AddTransient<ILookupProgressProbe>( sp => probeMock.Object );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["isrc"] = "USRC12345678" } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResultsByIsrc", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( System.Net.HttpStatusCode.OK, response.StatusCode );
+        Assert.IsFalse(
+            content.Contains( "Still looking up", StringComparison.OrdinalIgnoreCase ),
+            "When the probe returns false, IsLookupInProgress must be false and the in-progress indicator must not appear." );
+    }
+
+    /// <summary>
+    /// Verifies that when no <see cref="ILookupProgressProbe"/> is registered (probe is
+    /// <see langword="null"/>), the optional-parameter guard in the controller short-circuits and
+    /// the in-progress indicator is absent from the rendered view.
+    /// Failure-first: removing the <c>probe is not null</c> guard from the controller would cause
+    /// a <see cref="NullReferenceException"/> during <c>IsActiveAsync</c>, turning this test into
+    /// an unexpected exception rather than a failing assertion.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResultsByIsrc_NullProbe_InProgressIndicatorIsAbsent( ) {
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( sp => BuildStubMediaService( ) );
+            // Explicitly remove every ILookupProgressProbe registration so the controller
+            // receives null for the optional probe parameter.
+            _ = services.RemoveAll<ILookupProgressProbe>( );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["isrc"] = "USRC12345678" } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResultsByIsrc", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( System.Net.HttpStatusCode.OK, response.StatusCode );
+        Assert.IsFalse(
+            content.Contains( "Still looking up", StringComparison.OrdinalIgnoreCase ),
+            "When no probe is registered (null), the optional-param guard must prevent the IsActiveAsync call " +
+            "and IsLookupInProgress must remain false." );
+    }
+
+    /// <summary>
+    /// Verifies the regular URL-result action derives and probes the URL saga key carried by the
+    /// result's restored input link.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResults_UrlProbeReturnsTrue_InProgressIndicatorIsRendered( ) {
+        string expectedKey = LookupKeyBuilder.UrlKey( TestUrl );
+        Mock<ILookupProgressProbe> probeMock = new( );
+        _ = probeMock
+            .Setup( p => p.IsActiveAsync( expectedKey, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( _ => BuildStubMediaService( ) );
+            _ = services.RemoveAll<ILookupProgressProbe>( );
+            _ = services.AddTransient<ILookupProgressProbe>( _ => probeMock.Object );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["uri"] = TestUrl } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResults", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.Contains( "Still looking up", content, StringComparison.OrdinalIgnoreCase );
+        probeMock.Verify(
+            p => p.IsActiveAsync( expectedKey, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Verifies the streaming URL-result action uses the restored input link to probe the same saga
+    /// key and renders the progress indicator in its streamed card.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResultsStream_UrlProbeReturnsTrue_InProgressIndicatorIsRendered( ) {
+        string expectedKey = LookupKeyBuilder.UrlKey( TestUrl );
+        Mock<ILookupProgressProbe> probeMock = new( );
+        _ = probeMock
+            .Setup( p => p.IsActiveAsync( expectedKey, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( _ => BuildStubMediaService( ) );
+            _ = services.RemoveAll<ILookupProgressProbe>( );
+            _ = services.AddTransient<ILookupProgressProbe>( _ => probeMock.Object );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["uri"] = TestUrl } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResultsStream", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.Contains( "Still looking up", content, StringComparison.OrdinalIgnoreCase );
+        probeMock.Verify(
+            p => p.IsActiveAsync( expectedKey, It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+    }
+
+    /// <summary>
+    /// Builds the minimal configuration overrides for the probe-wiring test host. Workers and
+    /// ATProto are disabled so the host can start without external infrastructure beyond the shared
+    /// Redis container.
+    /// </summary>
+    private static Dictionary<string, string?> BuildBaseConfig( ) => new( ) {
+        ["BridgeBeats:DiscordToken"] = string.Empty,
+        ["BridgeBeats:Workers:UseWorkerServices"] = "false",
+        ["BridgeBeats:ATProtoIdentifier"] = string.Empty,
+        ["BridgeBeats:ATProtoPassword"] = string.Empty,
+        ["BridgeBeats:ATProtoUserDID"] = string.Empty,
+    };
+
+    /// <summary>
+    /// Builds a stub <see cref="IMediaLinkService"/> that returns a single Spotify result for
+    /// any ISRC, so the controller's <c>CreateViewModelFromResult</c> always produces at least
+    /// one view-model item regardless of what ISRC is submitted. The stub is disposable: a new
+    /// instance is created per-test factory.
+    /// </summary>
+    private static IMediaLinkService BuildStubMediaService( ) {
+        Mock<IMediaLinkService> mock = new( );
+        MediaLinkResult stubResult = new( ) {
+            Results = new Dictionary<SupportedProviders, MusicLookupResult> {
+                [SupportedProviders.Spotify] = new MusicLookupResult {
+                    Artist = "Probe Test Artist",
+                    Title = "Probe Test Track",
+                    ExternalId = "USRC12345678",
+                    URL = "https://open.spotify.com/track/probetesttrack",
+                    ArtUrl = string.Empty,
+                    IsAlbum = false
+                }
+            }
+        };
+        stubResult.InputLinks.Add( TestUrl );
+        _ = mock
+            .Setup( s => s.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( stubResult );
+        _ = mock
+            .Setup( s => s.GetInfoAsync( It.IsAny<string>( ) ) )
+            .Returns( (string _) => YieldResult( stubResult ) );
+        return mock.Object;
+    }
+
+    private static async IAsyncEnumerable<MediaLinkResult> YieldResult( MediaLinkResult result ) {
+        await Task.CompletedTask;
+        yield return result;
+    }
+
+    /// <summary>
+    /// Extends <see cref="CustomWebApplicationFactory"/> with a per-test service-override callback
+    /// so probe-wiring tests can inject stub implementations without modifying the shared factory.
+    /// The override callback runs after the parent's <see cref="CustomWebApplicationFactory.ConfigureWebHost"/>
+    /// so <c>RemoveAll&lt;T&gt;</c> correctly replaces any service the parent registered.
+    /// </summary>
+    private sealed class ProbeOverrideFactory(
+        Dictionary<string, string?> config,
+        Action<IServiceCollection> serviceOverrides
+    ) : CustomWebApplicationFactory( config ) {
+        protected override void ConfigureWebHost( IWebHostBuilder builder ) {
+            base.ConfigureWebHost( builder );
+            _ = builder.ConfigureServices( serviceOverrides );
+        }
+    }
 }

--- a/Tests/EndToEnd/HomeControllerTests.cs
+++ b/Tests/EndToEnd/HomeControllerTests.cs
@@ -318,12 +318,8 @@ public class HomeControllerTests {
 }
 
 /// <summary>
-/// Verifies that <c>MusicLookupResultItem.IsLookupInProgress</c> correctly reflects the injected
-/// <see cref="ILookupProgressProbe"/> at the three controller sites (<c>LookupResults</c>,
-/// <c>CreateViewModelFromResult</c>, <c>LookupResultsStream</c>). Each test exercises the
-/// <c>LookupResultsByIsrc</c> action with a stubbed media-link service (so a result item is always
-/// produced) and a controlled probe, then inspects the rendered HTML for the "Still looking up…"
-/// indicator that appears only when <c>IsLookupInProgress</c> is <see langword="true"/>.
+/// Verifies result rendering behavior with stubbed media-link services, including live saga-progress
+/// indicators and preservation of guidance carried by result-less placeholders.
 /// </summary>
 /// <remarks>
 /// Failure-first evidence for each new test is documented inline. A stub
@@ -334,12 +330,65 @@ public class HomeControllerTests {
 /// </remarks>
 [TestClass]
 [TestCategory( "EndToEnd" )]
-public class HomeControllerProbeWiringTests {
+public class HomeControllerRenderingTests {
 
     private const string TestUrl = "https://open.spotify.com/track/probetesttrack";
+    private const string PlaceholderMessage = "Apple Music is temporarily unavailable. Please try again.";
 
     /// <summary>MSTest-injected context used to obtain the per-test cancellation token.</summary>
     public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>
+    /// Verifies URL lookup placeholders retain their provider guidance instead of becoming a generic
+    /// no-results response.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResults_ResultlessPlaceholder_RendersProviderMessage( ) {
+        MediaLinkResult placeholder = new( ) { Messages = [PlaceholderMessage] };
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( _ => BuildStubMediaService( placeholder ) );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["uri"] = TestUrl } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResults", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.Contains( PlaceholderMessage, content, StringComparison.Ordinal );
+        Assert.DoesNotContain( "No results found", content, StringComparison.OrdinalIgnoreCase );
+    }
+
+    /// <summary>
+    /// Verifies single-result actions retain guidance from a result-less placeholder rather than
+    /// replacing it with their generic no-results fallback.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 15000, CooperativeCancellation = true )]
+    public async Task LookupResultsByIsrc_ResultlessPlaceholder_RendersProviderMessage( ) {
+        MediaLinkResult placeholder = new( ) { Messages = [PlaceholderMessage] };
+        using ProbeOverrideFactory factory = new( BuildBaseConfig( ), services => {
+            _ = services.RemoveAll<IMediaLinkService>( );
+            _ = services.AddTransient<IMediaLinkService>( _ => BuildStubMediaService( placeholder ) );
+        } );
+        await factory.InitializeDatabasesAsync( );
+        using HttpClient client = factory.CreateClient( );
+
+        string token = await AntiforgeryTestHelper.GetAntiforgeryTokenAsync( client, TestContext.CancellationToken );
+        FormUrlEncodedContent formData = new( new Dictionary<string, string> { ["isrc"] = "USRC12345678" } );
+        HttpResponseMessage response = await AntiforgeryTestHelper.PostWithAntiforgeryAsync(
+            client, "/Home/LookupResultsByIsrc", formData, token, TestContext.CancellationToken );
+        string content = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.Contains( PlaceholderMessage, content, StringComparison.Ordinal );
+        Assert.DoesNotContain( "No results found", content, StringComparison.OrdinalIgnoreCase );
+    }
 
     /// <summary>
     /// Verifies that when <see cref="ILookupProgressProbe.IsActiveAsync"/> returns
@@ -536,9 +585,9 @@ public class HomeControllerProbeWiringTests {
     /// one view-model item regardless of what ISRC is submitted. The stub is disposable: a new
     /// instance is created per-test factory.
     /// </summary>
-    private static IMediaLinkService BuildStubMediaService( ) {
+    private static IMediaLinkService BuildStubMediaService( MediaLinkResult? result = null ) {
         Mock<IMediaLinkService> mock = new( );
-        MediaLinkResult stubResult = new( ) {
+        MediaLinkResult stubResult = result ?? new MediaLinkResult {
             Results = new Dictionary<SupportedProviders, MusicLookupResult> {
                 [SupportedProviders.Spotify] = new MusicLookupResult {
                     Artist = "Probe Test Artist",

--- a/Tests/Integration/RedisMediaLinkCacheTests.cs
+++ b/Tests/Integration/RedisMediaLinkCacheTests.cs
@@ -339,17 +339,15 @@ public class RedisMediaLinkCacheTests {
     }
 
     /// <summary>
-    /// Verifies a recent cached record that represents a provider subset (IsPartial = true on the
-    /// in-memory DTO) is reported as FRESH. Staleness is age-only; partiality is owned by the saga
-    /// and does not drive cache freshness. The sibling test above (aged record) remains the positive
-    /// control for the stale path.
+    /// Verifies a recent cached record that represents a provider subset is reported as FRESH.
+    /// Staleness is age-only; partiality is owned by the saga and does not drive cache freshness.
+    /// The sibling test above (aged record) remains the positive control for the stale path.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task CheckRecordFreshness_ReturnsFresh_WhenResultIsRecentButSubset( ) {
-        // Arrange — a freshly looked-up result where only Spotify responded (IsPartial = true on DTO)
+        // Arrange — a freshly looked-up result where only Spotify responded
         MediaLinkResult result = CreateTestResult( "PARTIALTEST123", false );
-        result.IsPartial = true;
 
         string recordUri = $"at://{UserDID}/link.bridgebeats.lookup/track:PARTIALTEST123";
 

--- a/Tests/Integration/RedisMediaLinkCacheTests.cs
+++ b/Tests/Integration/RedisMediaLinkCacheTests.cs
@@ -339,12 +339,15 @@ public class RedisMediaLinkCacheTests {
     }
 
     /// <summary>
-    /// Verifies a cached record flagged partial is reported as stale on retrieval even when recent.
+    /// Verifies a recent cached record that represents a provider subset (IsPartial = true on the
+    /// in-memory DTO) is reported as FRESH. Staleness is age-only; partiality is owned by the saga
+    /// and does not drive cache freshness. The sibling test above (aged record) remains the positive
+    /// control for the stale path.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task CheckRecordFreshness_ReturnsStale_WhenResultIsPartial( ) {
-        // Arrange - a freshly looked-up but PARTIAL result
+    public async Task CheckRecordFreshness_ReturnsFresh_WhenResultIsRecentButSubset( ) {
+        // Arrange — a freshly looked-up result where only Spotify responded (IsPartial = true on DTO)
         MediaLinkResult result = CreateTestResult( "PARTIALTEST123", false );
         result.IsPartial = true;
 
@@ -360,9 +363,12 @@ public class RedisMediaLinkCacheTests {
         (MediaLinkResult cachedResult, string cachedUri, bool isStale)? lookupResult =
             await _cache.TryGetCachedResultByISRCAsync( "PARTIALTEST123" );
 
-        // Assert
+        // Assert — age-only freshness: a recent subset record must be fresh
         Assert.IsNotNull( lookupResult );
-        Assert.IsTrue( lookupResult.Value.isStale, "Partial results should always be stale-eligible" );
+        Assert.IsFalse(
+            lookupResult.Value.isStale,
+            "A recent subset record must be fresh. Staleness is age-only; partiality does not drive freshness."
+        );
     }
 
     /// <summary>

--- a/Tests/Integration/StaleCacheRefreshSagaCompletionIntegrationTests.cs
+++ b/Tests/Integration/StaleCacheRefreshSagaCompletionIntegrationTests.cs
@@ -377,7 +377,7 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
 
         // ── Step 2: Simulate Apple lookup failure — write back record with Spotify only. ──────
         // The age-only rule: LookedUpAt must be past the cache window for re-selection.
-        MediaLinkResult partialRecord = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -61 ), IsPartial = true };
+        MediaLinkResult partialRecord = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -61 ) };
         partialRecord.Results[SupportedProviders.Spotify] = new MusicLookupResult {
             URL = SpotifyTrackUrl,
             ExternalId = Isrc,

--- a/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
+++ b/Tests/Unit/ATProtoStorageServiceListRecordsTests.cs
@@ -911,7 +911,7 @@ public class ATProtoStorageServiceListRecordsTests {
     }
 
     /// <summary>
-    /// Item 7b: mutating a yielded element's <c>IsPartial</c> within the TTL causes subsequent
+    /// Item 7b: mutating a yielded element's <c>Messages</c> within the TTL causes subsequent
     /// reads to observe the mutation — proving the shared-reference invariant. This documents the
     /// hazard: consumers must treat yielded elements as read-only.
     /// </summary>
@@ -929,15 +929,15 @@ public class ATProtoStorageServiceListRecordsTests {
         MediaLinkResult sharedElement = r1[0].Result;
 
         // Mutate the element (exercising the documented hazard)
-        bool originalIsPartial = sharedElement.IsPartial;
-        sharedElement.IsPartial = !originalIsPartial;
+        sharedElement.Messages = ["mutated-sentinel"];
 
         // Second read within TTL — same cached list, same element reference
         List<(string AtUri, MediaLinkResult Result)> r2 = await CollectAsync(
             service.ListAllRecordsAsync( s_testPdsUri, TestDid, TestContext.CancellationToken ) );
 
         Assert.AreSame( sharedElement, r2[0].Result );
-        Assert.AreEqual( !originalIsPartial, r2[0].Result.IsPartial,
+        Assert.IsNotNull( r2[0].Result.Messages );
+        Assert.AreEqual( "mutated-sentinel", r2[0].Result.Messages![0],
             "The mutation is visible across reads because both reads share the same MediaLinkResult instance." );
     }
 

--- a/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
+++ b/Tests/Unit/CacheBootstrapBackgroundServiceTests.cs
@@ -1257,7 +1257,6 @@ public class CacheBootstrapBackgroundServiceTests {
     public void StatisticsAccumulator_Add_DoesNotMutateInputRecord( ) {
         MediaLinkResult result = new( ) {
             LookedUpAt = new DateTime( 2024, 5, 1, 12, 0, 0, DateTimeKind.Utc ),
-            IsPartial = false,
         };
         result.Results.Add( SupportedProviders.Spotify, new MusicLookupResult {
             Artist = "A",
@@ -1268,7 +1267,6 @@ public class CacheBootstrapBackgroundServiceTests {
         } );
 
         DateTime lookedUpAtBefore = result.LookedUpAt;
-        bool isPartialBefore = result.IsPartial;
         int resultCountBefore = result.Results.Count;
 
         StatisticsAccumulator accumulator = new( );
@@ -1276,7 +1274,6 @@ public class CacheBootstrapBackgroundServiceTests {
         _ = accumulator.Build( );
 
         Assert.AreEqual( lookedUpAtBefore, result.LookedUpAt, "LookedUpAt must be unchanged after Add" );
-        Assert.AreEqual( isPartialBefore, result.IsPartial, "IsPartial must be unchanged after Add" );
         Assert.HasCount( resultCountBefore, result.Results, "Results count must be unchanged after Add" );
     }
 

--- a/Tests/Unit/CachingMediaLinkServiceTests.cs
+++ b/Tests/Unit/CachingMediaLinkServiceTests.cs
@@ -103,7 +103,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByMetadataAsync( TestTitle, TestArtist ) )
-            .ReturnsAsync( new LookupResult { Result = expectedResult, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = expectedResult } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoAsync( TestTitle, TestArtist );
@@ -122,7 +122,7 @@ public class CachingMediaLinkServiceTests {
         // Arrange
         _ = _orchestratorMock
             .Setup( o => o.LookupByMetadataAsync( It.IsAny<string>( ), It.IsAny<string>( ) ) )
-            .ReturnsAsync( new LookupResult { Result = null, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = null } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoAsync( TestTitle, TestArtist );
@@ -145,7 +145,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
-            .ReturnsAsync( new LookupResult { Result = expectedResult, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = expectedResult } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByISRCAsync( TestIsrc );
@@ -163,7 +163,7 @@ public class CachingMediaLinkServiceTests {
         // Arrange
         _ = _orchestratorMock
             .Setup( o => o.LookupByIsrcAsync( It.IsAny<string>( ) ) )
-            .ReturnsAsync( new LookupResult { Result = null, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = null } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByISRCAsync( TestIsrc );
@@ -186,7 +186,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByUpcAsync( TestUpc ) )
-            .ReturnsAsync( new LookupResult { Result = expectedResult, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = expectedResult } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByUPCAsync( TestUpc );
@@ -204,7 +204,7 @@ public class CachingMediaLinkServiceTests {
         // Arrange
         _ = _orchestratorMock
             .Setup( o => o.LookupByUpcAsync( It.IsAny<string>( ) ) )
-            .ReturnsAsync( new LookupResult { Result = null, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = null } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByUPCAsync( TestUpc );
@@ -228,7 +228,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByProviderIdAsync( TestProviderId, SupportedProviders.Spotify, false ) )
-            .ReturnsAsync( new LookupResult { Result = expectedResult, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = expectedResult } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByProviderIdAsync( TestProviderId, SupportedProviders.Spotify, false );
@@ -252,7 +252,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByProviderIdAsync( TestProviderId, SupportedProviders.AppleMusic, true ) )
-            .ReturnsAsync( new LookupResult { Result = expectedResult, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = expectedResult } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByProviderIdAsync( TestProviderId, SupportedProviders.AppleMusic, true );
@@ -273,7 +273,7 @@ public class CachingMediaLinkServiceTests {
         // Arrange
         _ = _orchestratorMock
             .Setup( o => o.LookupByProviderIdAsync( It.IsAny<string>( ), It.IsAny<SupportedProviders>( ), It.IsAny<bool>( ) ) )
-            .ReturnsAsync( new LookupResult { Result = null, IsPartial = false } );
+            .ReturnsAsync( new LookupResult { Result = null } );
 
         // Act
         MediaLinkResult? result = await _service.GetInfoByProviderIdAsync( TestProviderId, SupportedProviders.Spotify, false );
@@ -297,7 +297,7 @@ public class CachingMediaLinkServiceTests {
         MediaLinkResult expectedResult = CreateMediaLinkResult( );
         _ = _orchestratorMock
             .Setup( o => o.LookupByContentAsync( TestContent ) )
-            .Returns( CreateAsyncEnumerable( new LookupResult { Result = expectedResult, IsPartial = false } ) );
+            .Returns( CreateAsyncEnumerable( new LookupResult { Result = expectedResult } ) );
 
         // Act
         List<MediaLinkResult> results = [];
@@ -321,8 +321,8 @@ public class CachingMediaLinkServiceTests {
         _ = _orchestratorMock
             .Setup( o => o.LookupByContentAsync( TestContent ) )
             .Returns( CreateAsyncEnumerable(
-                new LookupResult { Result = null, IsPartial = false },
-                new LookupResult { Result = CreateMediaLinkResult( ), IsPartial = false }
+                new LookupResult { Result = null },
+                new LookupResult { Result = CreateMediaLinkResult( ) }
             ) );
 
         // Act
@@ -361,6 +361,31 @@ public class CachingMediaLinkServiceTests {
     #region Partial Result Message Tests
 
     /// <summary>
+    /// Verifies that a rate-limited saga with no provider payload still returns an API DTO marked
+    /// partial, rather than forcing clients to infer its state from the message text.
+    /// </summary>
+    [TestMethod]
+    public async Task GetInfoByISRCAsync_WhenRateLimitedWithoutPayload_ShouldReturnPartialPlaceholder( ) {
+        DateTimeOffset retryAfter = DateTimeOffset.UtcNow.AddMinutes( 5 );
+        _ = _orchestratorMock
+            .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
+            .ReturnsAsync( new LookupResult {
+                Result = null,
+                SagaId = "test-saga",
+                RateLimitedProviders = [
+                    new ProviderRateLimitInfo( SupportedProviders.AppleMusic, retryAfter, "/v1/catalog" )
+                ]
+            } );
+
+        MediaLinkResult? result = await _service.GetInfoByISRCAsync( TestIsrc );
+
+        Assert.IsNotNull( result );
+        Assert.IsTrue( result.IsPartial );
+        Assert.IsNotNull( result.RateLimitedProviders );
+        Assert.Contains( SupportedProviders.AppleMusic, result.RateLimitedProviders );
+    }
+
+    /// <summary>
     /// Verifies that a partial result with one rate-limited provider produces a single message naming
     /// that provider and describing it as temporarily unavailable.
     /// </summary>
@@ -374,7 +399,6 @@ public class CachingMediaLinkServiceTests {
             .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
             .ReturnsAsync( new LookupResult {
                 Result = expectedResult,
-                IsPartial = true,
                 SagaId = "test-saga",
                 RateLimitedProviders = [
                     new ProviderRateLimitInfo( SupportedProviders.AppleMusic, retryAfter, "/v1/catalog" )
@@ -386,6 +410,7 @@ public class CachingMediaLinkServiceTests {
 
         // Assert
         Assert.IsNotNull( result );
+        Assert.IsTrue( result.IsPartial, "A saga-backed partial result must expose isPartial on the API DTO." );
         Assert.IsNotNull( result.Messages );
         Assert.HasCount( 1, result.Messages );
         Assert.Contains( "AppleMusic", result.Messages[0] );
@@ -406,7 +431,6 @@ public class CachingMediaLinkServiceTests {
             .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
             .ReturnsAsync( new LookupResult {
                 Result = expectedResult,
-                IsPartial = true,
                 SagaId = "test-saga",
                 RateLimitedProviders = [
                     new ProviderRateLimitInfo( SupportedProviders.AppleMusic, retryAfter, "/v1/catalog" ),
@@ -419,6 +443,7 @@ public class CachingMediaLinkServiceTests {
 
         // Assert
         Assert.IsNotNull( result );
+        Assert.IsTrue( result.IsPartial, "A saga-backed partial result must expose isPartial on the API DTO." );
         Assert.IsNotNull( result.Messages );
         Assert.HasCount( 2, result.Messages );
         Assert.Contains( "AppleMusic", result.Messages[0] );
@@ -437,8 +462,7 @@ public class CachingMediaLinkServiceTests {
         _ = _orchestratorMock
             .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
             .ReturnsAsync( new LookupResult {
-                Result = expectedResult,
-                IsPartial = false
+                Result = expectedResult
             } );
 
         // Act
@@ -446,6 +470,7 @@ public class CachingMediaLinkServiceTests {
 
         // Assert
         Assert.IsNotNull( result );
+        Assert.IsFalse( result.IsPartial, "A finalized result must expose isPartial=false on the API DTO." );
         Assert.IsNull( result.Messages );
     }
 
@@ -462,7 +487,6 @@ public class CachingMediaLinkServiceTests {
             .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
             .ReturnsAsync( new LookupResult {
                 Result = expectedResult,
-                IsPartial = true,
                 SagaId = "test-saga",
                 RateLimitedProviders = []
             } );
@@ -472,37 +496,10 @@ public class CachingMediaLinkServiceTests {
 
         // Assert
         Assert.IsNotNull( result );
-        Assert.IsTrue( result.IsPartial, "The DTO should be flagged partial for downstream consumers" );
+        Assert.IsTrue( result.IsPartial, "Pending secondary lookups must be machine-readable without parsing Messages." );
         Assert.IsNotNull( result.Messages );
         Assert.HasCount( 1, result.Messages );
         Assert.Contains( "still being fetched", result.Messages[0] );
-    }
-
-    /// <summary>
-    /// Verifies that when the orchestrator reports a partial lookup, the translated
-    /// <see cref="MediaLinkResult"/> has its <see cref="MediaLinkResult.IsPartial"/> flag set even
-    /// though the source result started non-partial.
-    /// </summary>
-    [TestMethod]
-    public async Task GetInfoByISRCAsync_WhenPartial_ShouldFlagResultPartial( ) {
-        // Arrange
-        MediaLinkResult expectedResult = CreateMediaLinkResult( );
-        Assert.IsFalse( expectedResult.IsPartial );
-
-        _ = _orchestratorMock
-            .Setup( o => o.LookupByIsrcAsync( TestIsrc ) )
-            .ReturnsAsync( new LookupResult {
-                Result = expectedResult,
-                IsPartial = true,
-                SagaId = "test-saga"
-            } );
-
-        // Act
-        MediaLinkResult? result = await _service.GetInfoByISRCAsync( TestIsrc );
-
-        // Assert
-        Assert.IsNotNull( result );
-        Assert.IsTrue( result.IsPartial );
     }
 
     #endregion

--- a/Tests/Unit/Helpers/TestCarBuilder.cs
+++ b/Tests/Unit/Helpers/TestCarBuilder.cs
@@ -93,8 +93,7 @@ internal static class TestCarBuilder {
 
     /// <summary>
     /// Encodes a <see cref="MediaLinkResultRecord"/> as a DAG-CBOR record block (the value block an MST
-    /// entry points at), writing <c>results</c>, optional <c>isPartial</c>, and round-trip-formatted
-    /// <c>lookedUpAt</c>.
+    /// entry points at), writing <c>results</c> and round-trip-formatted <c>lookedUpAt</c>.
     /// </summary>
     /// <param name="record">The record to encode.</param>
     /// <returns>The CBOR-encoded record block bytes.</returns>
@@ -103,8 +102,8 @@ internal static class TestCarBuilder {
         writer.WriteStartMap( null );
 
         // DAG-CBOR canonical key order: length-first, then lexicographic.
-        // Key lengths: results(7) < isPartial(9) < lookedUpAt(10)
-        // Write results first, then isPartial (only when true), then lookedUpAt.
+        // Key lengths: results(7) < lookedUpAt(10)
+        // Write results first, then lookedUpAt.
 
         WriteCborTextString( writer, "results" );
         writer.WriteStartArray( null );
@@ -112,11 +111,6 @@ internal static class TestCarBuilder {
             BuildProviderResultBlock( writer, r );
         }
         writer.WriteEndArray( );
-
-        if (record.IsPartial) {
-            WriteCborTextString( writer, "isPartial" );
-            writer.WriteBoolean( true );
-        }
 
         WriteCborTextString( writer, "lookedUpAt" );
         WriteCborTextString( writer, record.LookedUpAt.ToString( "O" ) );

--- a/Tests/Unit/LookupKeyBuilderTests.cs
+++ b/Tests/Unit/LookupKeyBuilderTests.cs
@@ -1,0 +1,172 @@
+using BridgeBeats.Core.Infrastructure.Utilities;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Format-equality drift guards for the <see cref="LookupKeyBuilder"/> methods.
+/// Each test pins the exact key format against the legacy literal strings that were inlined in
+/// <c>LookupOrchestrator</c> before the extraction, ensuring the builder and the orchestrator
+/// produce byte-identical output for the same inputs.
+/// </summary>
+/// <remarks>
+/// Failure-first evidence: these tests were added after the builder methods were introduced.
+/// The assertions pin to exact string literals (<c>"IsrcLookup:USRC17600943"</c>,
+/// <c>"UpcLookup:abc123"</c>, <c>"SongLookup:BLINDING LIGHTS:THE WEEKND"</c>, etc.) so any
+/// change to the key format produces a red test at the format-pinning level before it can
+/// silently break saga-id derivation. For example, <c>UpcKey_DoesNotUpperCase</c> asserts
+/// exactly <c>"UpcLookup:abc123"</c>, which fails immediately if upper-casing is accidentally
+/// added.
+/// </remarks>
+[TestClass]
+public class LookupKeyBuilderTests {
+
+    #region IsrcKey format equality
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.IsrcKey"/> must produce the exact legacy format
+    /// <c>IsrcLookup:{ISRC}</c> where the ISRC is trimmed and upper-cased.
+    /// </summary>
+    [TestMethod]
+    public void IsrcKey_MatchesLegacyInlineFormat( ) {
+        const string Isrc = "usrc17600943";
+        string expected = $"IsrcLookup:{Isrc.Trim( ).ToUpperInvariant( )}";
+
+        string actual = LookupKeyBuilder.IsrcKey( Isrc );
+
+        Assert.AreEqual( expected, actual );
+    }
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.IsrcKey"/> trims surrounding whitespace before upper-casing,
+    /// matching the orchestrator's normalization sequence.
+    /// </summary>
+    [TestMethod]
+    public void IsrcKey_TrimsAndUpperCases( ) {
+        string actual = LookupKeyBuilder.IsrcKey( "  usRc17600943  " );
+
+        Assert.AreEqual( "IsrcLookup:USRC17600943", actual );
+    }
+
+    #endregion
+
+    #region UpcKey format equality
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.UpcKey"/> must produce the exact legacy format
+    /// <c>UpcLookup:{UPC}</c> where the UPC is trimmed ONLY (no upper-casing).
+    /// </summary>
+    [TestMethod]
+    public void UpcKey_MatchesLegacyInlineFormat( ) {
+        const string Upc = "00602547087683";
+        string expected = $"UpcLookup:{Upc.Trim( )}";
+
+        string actual = LookupKeyBuilder.UpcKey( Upc );
+
+        Assert.AreEqual( expected, actual );
+    }
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.UpcKey"/> does NOT upper-case — distinguishing it from
+    /// <see cref="LookupKeyBuilder.IsrcKey"/>. This guards against accidentally adding
+    /// upper-casing that would break the saga-id round-trip for UPC lookups.
+    /// </summary>
+    [TestMethod]
+    public void UpcKey_DoesNotUpperCase( ) {
+        string actual = LookupKeyBuilder.UpcKey( "  abc123  " );
+
+        Assert.AreEqual( "UpcLookup:abc123", actual );
+    }
+
+    #endregion
+
+    #region MetadataKey format equality
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.MetadataKey"/> must produce the exact legacy format
+    /// <c>SongLookup:{TITLE}:{ARTIST}</c> where both title and artist are trimmed and upper-cased.
+    /// </summary>
+    [TestMethod]
+    public void MetadataKey_MatchesLegacyInlineFormat( ) {
+        const string Title = "Blinding Lights";
+        const string Artist = "The Weeknd";
+        string expected =
+            $"SongLookup:{Title.Trim( ).ToUpperInvariant( )}:{Artist.Trim( ).ToUpperInvariant( )}";
+
+        string actual = LookupKeyBuilder.MetadataKey( Title, Artist );
+
+        Assert.AreEqual( expected, actual );
+    }
+
+    /// <summary>
+    /// <see cref="LookupKeyBuilder.MetadataKey"/> trims and upper-cases both title and artist
+    /// independently, confirming neither is omitted.
+    /// </summary>
+    [TestMethod]
+    public void MetadataKey_TrimsAndUpperCasesBothParts( ) {
+        string actual = LookupKeyBuilder.MetadataKey( "  blinding lights  ", "  the weeknd  " );
+
+        Assert.AreEqual( "SongLookup:BLINDING LIGHTS:THE WEEKND", actual );
+    }
+
+    #endregion
+
+    #region UrlKey round-trip
+
+    /// <summary>
+    /// Guards the round-trip between the orchestrator's URL saga key and the probe key derived from
+    /// <c>MediaLinkResult.InputLinks[0]</c> in <c>HomeController</c>. The two inputs here are
+    /// genuinely different strings: the orchestrator receives the raw submitted URL, which may include
+    /// a <c>www.</c> subdomain and a Spotify <c>?si=</c> tracking parameter; the probe builds its key
+    /// from a clean canonical form of the same track URL with neither of those variations.
+    /// <see cref="HashUtility.HashUrl"/> reconciles them via
+    /// <see cref="BridgeBeats.Core.Domain.Providers.Common.LinkNormalizer"/> (strips scheme, strips
+    /// <c>www.</c>, removes tracking parameters) so both forms hash to the same saga key.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: replacing <see cref="LookupKeyBuilder.UrlKey"/> on the orchestrator
+    /// side with <see cref="HashUtility.ComputeSha256Base32"/> (raw SHA-256 with no normalization)
+    /// produces a different hash from the probe side, because the raw strings differ in <c>www.</c>
+    /// prefix, scheme form, and query parameter content. The <c>Assert.AreEqual</c> assertion fails.
+    /// A constant-returning stub for <c>UrlKey</c> would pass this equality test but fail the
+    /// discriminator test below (<see cref="UrlKey_DifferentTracks_ProduceDifferentKeys"/>).
+    /// </remarks>
+    [TestMethod]
+    public void UrlKey_RoundTrip_NormalizationReconcilesWwwPrefixAndTrackingParam( ) {
+        // Orchestrator path: receives the URL as submitted, possibly with www. and a tracking param.
+        const string SubmittedUrl = "https://www.open.spotify.com/track/4cODK2wGLETKBW3PvgPWqT?si=tracking";
+        string orchestratorKey = LookupKeyBuilder.UrlKey( SubmittedUrl );
+
+        // Probe path: InputLinks[0] is built as $"https://{linkGroupCapture}" where linkGroupCapture
+        // is the "Link" regex-group value from MediaLinkServiceBase applied to the submitted URL.
+        // A submitter of the same track without www. or the tracking param produces a genuinely
+        // different string — the clean canonical form. Both must map to the same saga key so the
+        // probe can locate the active saga regardless of which URL form reached the orchestrator.
+        const string ProbeLinkFromInputLinks = "https://open.spotify.com/track/4cODK2wGLETKBW3PvgPWqT";
+        string probeKey = LookupKeyBuilder.UrlKey( ProbeLinkFromInputLinks );
+
+        Assert.AreEqual( orchestratorKey, probeKey,
+            "UrlKey must produce the same key for URLs that differ only in www. prefix and " +
+            "tracking parameters; HashUrl normalization (via LinkNormalizer) must absorb them." );
+    }
+
+    /// <summary>
+    /// Discriminator guard: two URLs pointing at genuinely different Spotify tracks must produce
+    /// different <see cref="LookupKeyBuilder.UrlKey"/> values. Without this check a
+    /// constant-returning stub for <c>UrlKey</c> would pass
+    /// <see cref="UrlKey_RoundTrip_NormalizationReconcilesWwwPrefixAndTrackingParam"/> for the
+    /// wrong reason.
+    /// </summary>
+    /// <remarks>
+    /// Failure-first evidence: a stub <c>UrlKey</c> that returns a constant string passes the
+    /// round-trip equality test but fails here immediately on the inequality assertion.
+    /// </remarks>
+    [TestMethod]
+    public void UrlKey_DifferentTracks_ProduceDifferentKeys( ) {
+        string keyA = LookupKeyBuilder.UrlKey( "https://open.spotify.com/track/4cODK2wGLETKBW3PvgPWqT" );
+        string keyB = LookupKeyBuilder.UrlKey( "https://open.spotify.com/track/DIFFERENTTRACKID0000000" );
+
+        Assert.AreNotEqual( keyA, keyB, "Different track IDs must produce different URL lookup keys." );
+    }
+
+    #endregion
+}

--- a/Tests/Unit/LookupOrchestratorTests.cs
+++ b/Tests/Unit/LookupOrchestratorTests.cs
@@ -298,18 +298,19 @@ public class LookupOrchestratorTests {
 
     /// <summary>
     /// Verifies that a fresh cache hit (isStale = false) on a subset record — one where only some
-    /// providers contributed results — yields a non-partial envelope with no saga ID. Partiality of
-    /// the stored record is not re-surfaced once the record is cold-served; the caller sees a final
-    /// result. The saga-driven partial test below (~line 940) is the negative control proving the
-    /// hot/saga early-release path still returns <c>IsPartial = true</c>.
+    /// providers contributed results — yields a non-partial envelope with no saga ID. Under the
+    /// computed-property model, <c>LookupResult.IsPartial</c> derives from <c>!string.IsNullOrEmpty(SagaId)</c>.
+    /// The cache-hit path sets no <c>SagaId</c>, so the envelope is always non-partial for a
+    /// fresh cache hit regardless of how many providers contributed to the stored result.
+    /// A regression that incorrectly sets <c>SagaId</c> on a cache-hit result would fail
+    /// the <c>Assert.IsNull(result.SagaId)</c> assertion below.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task LookupByIsrcAsync_WithFreshCacheHitOnSubsetRecord_ShouldReturnNonPartialWithNoSagaId( ) {
-        // Arrange — a subset result (only Spotify responded); IsPartial is false because
-        // ConvertFromRecord no longer reads isPartial from the PDS record
+        // Arrange — a subset result (only Spotify responded); the cache-hit path must not
+        // propagate any partial state to the envelope via SagaId.
         MediaLinkResult subsetResult = new( ) {
-            IsPartial = false,
             Results = new Dictionary<SupportedProviders, MusicLookupResult> {
                 [SupportedProviders.Spotify] = new MusicLookupResult {
                     Artist = TestArtist,
@@ -749,6 +750,13 @@ public class LookupOrchestratorTests {
         // Assert
         Assert.HasCount( 1, results );
         Assert.IsNotNull( results[0].Result );
+        MediaLinkResult actualResult = results[0].Result!;
+        Assert.HasCount( 1, actualResult.InputLinks );
+        Assert.AreEqual(
+            "https://open.spotify.com/track/abc123",
+            actualResult.InputLinks[0],
+            "The caching orchestrator must restore the submitted URL because PDS records do not persist InputLinks."
+        );
     }
 
     /// <summary>

--- a/Tests/Unit/LookupOrchestratorTests.cs
+++ b/Tests/Unit/LookupOrchestratorTests.cs
@@ -297,6 +297,51 @@ public class LookupOrchestratorTests {
     }
 
     /// <summary>
+    /// Verifies that a fresh cache hit (isStale = false) on a subset record — one where only some
+    /// providers contributed results — yields a non-partial envelope with no saga ID. Partiality of
+    /// the stored record is not re-surfaced once the record is cold-served; the caller sees a final
+    /// result. The saga-driven partial test below (~line 940) is the negative control proving the
+    /// hot/saga early-release path still returns <c>IsPartial = true</c>.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WithFreshCacheHitOnSubsetRecord_ShouldReturnNonPartialWithNoSagaId( ) {
+        // Arrange — a subset result (only Spotify responded); IsPartial is false because
+        // ConvertFromRecord no longer reads isPartial from the PDS record
+        MediaLinkResult subsetResult = new( ) {
+            IsPartial = false,
+            Results = new Dictionary<SupportedProviders, MusicLookupResult> {
+                [SupportedProviders.Spotify] = new MusicLookupResult {
+                    Artist = TestArtist,
+                    Title = TestTitle,
+                    ExternalId = TestIsrc,
+                    URL = "https://open.spotify.com/track/123",
+                    ArtUrl = "https://example.com/art.jpg",
+                    IsAlbum = false
+                }
+            }
+        };
+
+        _ = _cacheMock
+            .Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( (subsetResult, TestRecordUri, false) ); // isStale = false → served as fresh
+
+        // Act
+        LookupResult result = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        // Assert — cold-served subset record is non-partial with no saga
+        Assert.IsNotNull( result.Result );
+        Assert.IsFalse( result.IsPartial, "Cold-served subset record must not be partial in the envelope." );
+        Assert.IsNull( result.SagaId, "Cold-served subset record must carry no saga ID." );
+
+        // Deduplicator must not be touched — cache hit short-circuits before dedup
+        _deduplicatorMock.Verify(
+            d => d.TryAcquireAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
     /// Verifies a cache miss with the dedup lock acquired creates an ISRC saga and enqueues the first provider request
     /// at <see cref="QueuePriority.Interactive"/>.
     /// </summary>

--- a/Tests/Unit/LookupProgressProbeTests.cs
+++ b/Tests/Unit/LookupProgressProbeTests.cs
@@ -1,0 +1,233 @@
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Domain.Services.LinkResolver;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Tests <see cref="LookupProgressProbe"/> and <see cref="NullLookupProgressProbe"/>.
+/// The probe predicate has three ANDed conditions — saga not null, not complete, no FinalResultUri —
+/// and each is tested independently so no single condition is silently masked by another.
+/// </summary>
+/// <remarks>
+/// Failure-first evidence for each new test is documented inline. Case (b) is the canonical
+/// failure-first case: a naive <c>saga != null</c> predicate returns <see langword="true"/> for a
+/// complete saga whose PDS write is still in flight, but the correct predicate returns
+/// <see langword="false"/>. The five probe tests were written against a naive
+/// <c>return saga is not null;</c> stub, which fails cases (b) and (c). Case (c2) isolates the
+/// <c>FinalResultUri</c> clause: case (c) already has <c>IsComplete = true</c>, which causes the
+/// <c>!saga.IsComplete</c> arm to short-circuit before reaching <c>string.IsNullOrEmpty</c>; case
+/// (c2) reverses that so the <c>FinalResultUri</c> clause is the only failing condition and thus has
+/// its own independent negative control. Case (d) does not distinguish the naive from the correct
+/// predicate (both return <see langword="false"/> for a null saga); it is included as a completeness
+/// guard.
+/// </remarks>
+[TestClass]
+public class LookupProgressProbeTests {
+
+    private const string TestLookupKey = "IsrcLookup:USRC12345678";
+
+    private Mock<ISagaStateManager> _sagaManagerMock = null!;
+    private LookupProgressProbe _probe = null!;
+
+    /// <summary>Provides <see cref="TestContext.CancellationToken"/> for cooperative cancellation.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Initializes mocks and the probe under test before each test method.</summary>
+    [TestInitialize]
+    public void Setup( ) {
+        _sagaManagerMock = new Mock<ISagaStateManager>( );
+        _probe = new LookupProgressProbe( _sagaManagerMock.Object, NullLogger<LookupProgressProbe>.Instance );
+    }
+
+    #region Constructor guard
+
+    /// <summary>Passing <see langword="null"/> for the saga manager throws <see cref="ArgumentNullException"/>.</summary>
+    [TestMethod]
+    public void Constructor_NullSagaManager_Throws( ) {
+        _ = Assert.ThrowsExactly<ArgumentNullException>( ( ) => new LookupProgressProbe( null!, NullLogger<LookupProgressProbe>.Instance ) );
+    }
+
+    #endregion
+
+    #region Probe predicate cases
+
+    /// <summary>
+    /// Case (a): active saga (not complete, no FinalResultUri) → <see langword="true"/>.
+    /// Failure-first: against naive <c>saga != null</c> this would also return true — the test
+    /// passes for the wrong reason. The correct predicate passes for the right reason (all three
+    /// conditions hold). Both predicates agree on this case; see case (b) for the divergence.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaIsActiveAndNonComplete_ReturnsTrue( ) {
+        LookupSagaState saga = BuildSaga( isComplete: false, finalResultUri: null );
+        SetupGetAsync( TestLookupKey, saga );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsTrue( result );
+    }
+
+    /// <summary>
+    /// Case (b): all providers have reported in (<see cref="LookupSagaState.IsComplete"/> is
+    /// <see langword="true"/>) but the PDS write is still in flight so
+    /// <see cref="LookupSagaState.FinalResultUri"/> is <see langword="null"/> — the finalize race.
+    /// Correct predicate → <see langword="false"/>. Failure-first evidence: a naive
+    /// <c>saga != null</c> predicate returns <see langword="true"/> here (false-positive).
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaIsCompleteFinalizeRace_ReturnsFalse( ) {
+        LookupSagaState saga = BuildSaga( isComplete: true, finalResultUri: null );
+        SetupGetAsync( TestLookupKey, saga );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result,
+            "A saga that is IsComplete must not trigger the in-progress indicator, " +
+            "even when FinalResultUri has not yet been set (finalize race)." );
+    }
+
+    /// <summary>
+    /// Case (c): saga has a <see cref="LookupSagaState.FinalResultUri"/> set → lookup is done,
+    /// indicator must not show. Correct predicate → <see langword="false"/>.
+    /// Failure-first: a naive <c>saga != null</c> returns <see langword="true"/> here.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaIsFinalizedWithUri_ReturnsFalse( ) {
+        LookupSagaState saga = BuildSaga( isComplete: true, finalResultUri: "at://did/collection/rkey" );
+        SetupGetAsync( TestLookupKey, saga );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result,
+            "A saga that has a FinalResultUri must not trigger the in-progress indicator." );
+    }
+
+    /// <summary>
+    /// Case (c2): saga is not yet complete but already has a
+    /// <see cref="LookupSagaState.FinalResultUri"/> — an atypical race where the finalize step
+    /// wrote the URI without setting <see cref="LookupSagaState.IsComplete"/>. The
+    /// <c>string.IsNullOrEmpty(saga.FinalResultUri)</c> clause must independently reject this saga.
+    /// Correct predicate → <see langword="false"/>.
+    /// Failure-first: removing <c>&amp;&amp; string.IsNullOrEmpty(saga.FinalResultUri)</c> from the
+    /// predicate causes this test to return <see langword="true"/> (<see cref="LookupSagaState.IsComplete"/>
+    /// is <see langword="false"/>, so only the null-check fires); all other cases remain green because
+    /// every other false-returning case is already handled by a different clause.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaIncompleteButHasFinalResultUri_ReturnsFalse( ) {
+        LookupSagaState saga = BuildSaga( isComplete: false, finalResultUri: "at://did/collection/rkey" );
+        SetupGetAsync( TestLookupKey, saga );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result,
+            "A saga that has a FinalResultUri must not trigger the in-progress indicator, " +
+            "even when IsComplete is false." );
+    }
+
+    /// <summary>
+    /// Case (d): <see cref="ISagaStateManager.GetAsync"/> returns <see langword="null"/> (saga
+    /// does not exist or has expired) → <see langword="false"/>.
+    /// Failure-first: a naive <c>saga != null</c> returns <see langword="false"/> here, so this
+    /// case does not distinguish the two predicates. Included as a completeness guard.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaDoesNotExist_ReturnsFalse( ) {
+        SetupGetAsync( TestLookupKey, null );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result );
+    }
+
+    /// <summary>
+    /// Case (e): <see cref="ISagaStateManager.GetAsync"/> throws (transient saga-store fault).
+    /// The probe must return <see langword="false"/> — "cannot determine → not in progress" —
+    /// matching the graceful-degradation intent. A render-path fault must not convert a successful
+    /// lookup into an error response.
+    /// Failure-first: before the try/catch was added, the exception propagated out of
+    /// <see cref="LookupProgressProbe.IsActiveAsync"/> and this test threw instead of asserting
+    /// <see langword="false"/>; passes after the fault-tolerance fix.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaStoreThrows_ReturnsFalse( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( TestLookupKey );
+        _ = _sagaManagerMock
+            .Setup( m => m.GetAsync( sagaId, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "Redis connection failed" ) );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result, "A saga-store fault must produce false (not in progress), not an exception." );
+    }
+
+    #endregion
+
+    #region NullLookupProgressProbe
+
+    /// <summary>
+    /// <see cref="NullLookupProgressProbe.IsActiveAsync"/> always returns <see langword="false"/>
+    /// regardless of the key and without calling any underlying service.
+    /// </summary>
+    [TestMethod]
+    public async Task NullLookupProgressProbe_AlwaysReturnsFalse( ) {
+        NullLookupProgressProbe nullProbe = new( );
+
+        bool result = await nullProbe.IsActiveAsync( TestLookupKey, TestContext.CancellationToken );
+
+        Assert.IsFalse( result );
+    }
+
+    /// <summary>
+    /// <see cref="NullLookupProgressProbe"/> returns <see langword="false"/> even for an
+    /// arbitrary key value, confirming the no-op contract is not key-dependent.
+    /// </summary>
+    [TestMethod]
+    public async Task NullLookupProgressProbe_ArbitraryKey_ReturnsFalse( ) {
+        NullLookupProgressProbe nullProbe = new( );
+
+        bool result = await nullProbe.IsActiveAsync( "UpcLookup:000000000000", TestContext.CancellationToken );
+
+        Assert.IsFalse( result );
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void SetupGetAsync( string lookupKey, LookupSagaState? returnValue ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+        _ = _sagaManagerMock
+            .Setup( m => m.GetAsync( sagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( returnValue );
+    }
+
+    private static LookupSagaState BuildSaga( bool isComplete, string? finalResultUri ) {
+        Dictionary<SupportedProviders, ProviderLookupState> providerStates = new( ) {
+            [SupportedProviders.Spotify] = new ProviderLookupState(
+                Provider: SupportedProviders.Spotify,
+                IsComplete: isComplete,
+                IsSuccess: isComplete,
+                ResultJson: null,
+                CompletedAt: null,
+                ErrorMessage: null
+            )
+        };
+
+        return new LookupSagaState {
+            SagaId = ISagaStateManager.GenerateSagaId( TestLookupKey ),
+            LookupKey = TestLookupKey,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678",
+            ProviderStates = providerStates,
+            FinalResultUri = finalResultUri
+        };
+    }
+
+    #endregion
+}

--- a/Tests/Unit/LookupProgressProbeTests.cs
+++ b/Tests/Unit/LookupProgressProbeTests.cs
@@ -166,6 +166,24 @@ public class LookupProgressProbeTests {
         Assert.IsFalse( result, "A saga-store fault must produce false (not in progress), not an exception." );
     }
 
+    /// <summary>
+    /// A cancelled saga-store read belongs to the request lifecycle and must degrade quietly to
+    /// <see langword="false"/> rather than turning request or host shutdown into a failure.
+    /// </summary>
+    [TestMethod]
+    public async Task IsActiveAsync_WhenSagaStoreReadIsCancelled_ReturnsFalse( ) {
+        using CancellationTokenSource cts = new( );
+        cts.Cancel( );
+        string sagaId = ISagaStateManager.GenerateSagaId( TestLookupKey );
+        _ = _sagaManagerMock
+            .Setup( m => m.GetAsync( sagaId, cts.Token ) )
+            .ThrowsAsync( new OperationCanceledException( cts.Token ) );
+
+        bool result = await _probe.IsActiveAsync( TestLookupKey, cts.Token );
+
+        Assert.IsFalse( result );
+    }
+
     #endregion
 
     #region NullLookupProgressProbe

--- a/Tests/Unit/LookupResultTests.cs
+++ b/Tests/Unit/LookupResultTests.cs
@@ -1,0 +1,56 @@
+using BridgeBeats.Contracts.Records;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Pins the computed <see cref="LookupResult.IsPartial"/> invariant directly. Covers the three
+/// canonical cases: a non-empty <see cref="LookupResult.SagaId"/> (partial), no
+/// <see cref="LookupResult.SagaId"/> (not partial), and an empty-string
+/// <see cref="LookupResult.SagaId"/> (not partial). The empty-string case is the critical
+/// regression guard: it distinguishes the hardened <c>!string.IsNullOrEmpty(SagaId)</c>
+/// predicate from the prior <c>SagaId is not null</c> form.
+/// </summary>
+[TestClass]
+public class LookupResultTests {
+
+    /// <summary>
+    /// <see cref="LookupResult.IsPartial"/> is <c>true</c> when <see cref="LookupResult.SagaId"/>
+    /// is a non-empty string, indicating an in-progress saga is coordinating the lookup.
+    /// </summary>
+    [TestMethod]
+    public void IsPartial_ReturnsTrueForNonEmptySagaId( ) {
+        // Arrange
+        LookupResult result = new( ) { SagaId = "saga-123" };
+
+        // Assert
+        Assert.IsTrue( result.IsPartial );
+    }
+
+    /// <summary>
+    /// <see cref="LookupResult.IsPartial"/> is <c>false</c> when <see cref="LookupResult.SagaId"/>
+    /// is <see langword="null"/> (default), indicating a final result with no saga in play.
+    /// </summary>
+    [TestMethod]
+    public void IsPartial_ReturnsFalseWhenSagaIdIsNull( ) {
+        // Arrange
+        LookupResult result = new( );
+
+        // Assert
+        Assert.IsFalse( result.IsPartial );
+    }
+
+    /// <summary>
+    /// <see cref="LookupResult.IsPartial"/> is <c>false</c> when <see cref="LookupResult.SagaId"/>
+    /// is an empty string. This is the regression guard for the <c>!string.IsNullOrEmpty(SagaId)</c>
+    /// predicate: the prior <c>SagaId is not null</c> form would have returned <c>true</c> for this
+    /// input, treating an empty string as a valid saga identifier.
+    /// </summary>
+    [TestMethod]
+    public void IsPartial_ReturnsFalseForEmptySagaId( ) {
+        // Arrange
+        LookupResult result = new( ) { SagaId = "" };
+
+        // Assert
+        Assert.IsFalse( result.IsPartial );
+    }
+}

--- a/Tests/Unit/MediaLinkResultRecordTests.cs
+++ b/Tests/Unit/MediaLinkResultRecordTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Storage;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Regression guard verifying that the <c>link.bridgebeats.lookup</c> PDS record shape never
+/// serializes an <c>isPartial</c> key, regardless of the in-memory <see cref="MediaLinkResult"/>
+/// partiality flag. Partiality is owned by the saga and must not persist to the PDS.
+/// </summary>
+[TestClass]
+public class MediaLinkResultRecordTests {
+
+    /// <summary>
+    /// The private static <c>ConvertToRecord</c> method on <see cref="ATProtoStorageService"/>,
+    /// resolved via reflection once for the class.
+    /// </summary>
+    private static readonly MethodInfo s_convertToRecord =
+        typeof( ATProtoStorageService ).GetMethod(
+            "ConvertToRecord",
+            BindingFlags.NonPublic | BindingFlags.Static
+        ) ?? throw new InvalidOperationException( "ATProtoStorageService.ConvertToRecord not found via reflection." );
+
+    /// <summary>
+    /// Verifies that a <see cref="MediaLinkResult"/> with <c>IsPartial = true</c> and a provider
+    /// subset produces a <see cref="MediaLinkResultRecord"/> whose JSON serialization contains no
+    /// <c>isPartial</c> key. Also asserts that <c>results</c> and <c>lookedUpAt</c> are present
+    /// (positive control: an empty serializer cannot pass for the wrong reason).
+    /// </summary>
+    /// <remarks>
+    /// The GOTCHA the QA plan calls out: <c>[JsonIgnore(WhenWritingDefault)]</c> would suppress a
+    /// <c>false</c> value anyway, so the test must drive <c>IsPartial = true</c> all the way through
+    /// the pipeline to prove the property is absent for the right reason — it was removed — not merely
+    /// suppressed by its default.
+    /// </remarks>
+    [TestMethod]
+    public void ConvertToRecord_WithPartialResult_DoesNotSerializeIsPartialKey( ) {
+        // Arrange — a DTO that is explicitly partial with one provider result
+        MediaLinkResult dto = new( ) {
+            IsPartial = true,
+            Results = new Dictionary<SupportedProviders, MusicLookupResult> {
+                [SupportedProviders.Spotify] = new MusicLookupResult {
+                    Artist = "Test Artist",
+                    Title = "Test Track",
+                    ExternalId = "USRC12345678",
+                    URL = "https://open.spotify.com/track/test",
+                    ArtUrl = string.Empty,
+                    IsAlbum = false
+                }
+            }
+        };
+
+        // Failure-first evidence: before the IsPartial property was removed from MediaLinkResultRecord,
+        // invoking ConvertToRecord with IsPartial=true and serializing would have produced a JSON object
+        // containing "isPartial":true. Now it must not.
+
+        // Act — run through the private pipeline under test
+        MediaLinkResultRecord record = (MediaLinkResultRecord)(
+            s_convertToRecord.Invoke( null, [dto] )
+                ?? throw new InvalidOperationException( "ConvertToRecord returned null." )
+        );
+
+        string json = JsonSerializer.Serialize( record );
+
+        // Assert — primary: no isPartial key in the serialized output
+        JsonNode? node = JsonNode.Parse( json );
+        Assert.IsNotNull( node, "Serialized record must parse as valid JSON." );
+        JsonObject? obj = node.AsObject( );
+        Assert.IsNotNull( obj, "Serialized record must be a JSON object." );
+
+        Assert.IsFalse(
+            obj.ContainsKey( "isPartial" ),
+            "The serialized PDS record must not contain an 'isPartial' key. " +
+            "Partiality is owned by the saga, not the persisted record."
+        );
+
+        // Assert — positive control: required fields must be present so an empty serializer cannot pass
+        Assert.IsTrue( obj.ContainsKey( "results" ), "Serialized record must contain 'results'." );
+        Assert.IsTrue( obj.ContainsKey( "lookedUpAt" ), "Serialized record must contain 'lookedUpAt'." );
+    }
+}

--- a/Tests/Unit/MediaLinkResultRecordTests.cs
+++ b/Tests/Unit/MediaLinkResultRecordTests.cs
@@ -16,6 +16,8 @@ namespace BridgeBeats.Tests.Unit;
 [TestClass]
 public class MediaLinkResultRecordTests {
 
+    private static readonly JsonSerializerOptions s_webJsonOptions = new( JsonSerializerDefaults.Web );
+
     /// <summary>
     /// The private static <c>ConvertToRecord</c> method on <see cref="ATProtoStorageService"/>,
     /// resolved via reflection once for the class.
@@ -39,8 +41,8 @@ public class MediaLinkResultRecordTests {
     /// suppressed by its default.
     /// </remarks>
     [TestMethod]
-    public void ConvertToRecord_WithPartialResult_DoesNotSerializeIsPartialKey( ) {
-        // Arrange — a DTO that is explicitly partial with one provider result
+    public void ConvertToRecord_DoesNotSerializeIsPartialKey( ) {
+        // Arrange — an explicitly partial API DTO with one provider result
         MediaLinkResult dto = new( ) {
             IsPartial = true,
             Results = new Dictionary<SupportedProviders, MusicLookupResult> {
@@ -82,5 +84,20 @@ public class MediaLinkResultRecordTests {
         // Assert — positive control: required fields must be present so an empty serializer cannot pass
         Assert.IsTrue( obj.ContainsKey( "results" ), "Serialized record must contain 'results'." );
         Assert.IsTrue( obj.ContainsKey( "lookedUpAt" ), "Serialized record must contain 'lookedUpAt'." );
+    }
+
+    /// <summary>
+    /// Verifies the public API representation retains <c>isPartial</c> even though the persisted
+    /// PDS record deliberately omits it. This pins the boundary between transient saga-derived
+    /// response metadata and durable record content.
+    /// </summary>
+    [TestMethod]
+    public void ApiSerialization_IncludesIsPartialKey( ) {
+        MediaLinkResult dto = new( ) { IsPartial = true };
+
+        JsonObject obj = JsonNode.Parse( JsonSerializer.Serialize( dto, s_webJsonOptions ) )!.AsObject( );
+
+        Assert.IsTrue( obj.ContainsKey( "isPartial" ), "API JSON must retain the isPartial contract." );
+        Assert.IsTrue( obj["isPartial"]!.GetValue<bool>( ) );
     }
 }

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -682,9 +682,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Exactly( 2 )
         );
 
-        // Assert - Partial result written with the IsPartial flag set on the stored record
+        // Assert - Partial result written (non-terminal write path: SetPartialResultUriAsync, not SetFinalResultUriAsync)
         _atProtoStorageMock.Verify(
-            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -785,10 +789,10 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - No secondary lookups queued (everything came from cache)
         _queueResolverMock.Verify( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ), Times.Never );
 
-        // Assert - Final result stored with ALL three providers' results, not marked partial
+        // Assert - Final result stored with ALL three providers' results (terminal write path: SetFinalResultUriAsync below)
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync(
-                It.Is<MediaLinkResult>( r => r.Results.Count == 3 && !r.IsPartial ),
+                It.Is<MediaLinkResult>( r => r.Results.Count == 3 ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -892,12 +896,16 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
 
-        // Assert - Partial result includes the cached provider's data (Spotify + AppleMusic)
+        // Assert - Partial result includes the cached provider's data (Spotify + AppleMusic), non-terminal write
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync(
-                It.Is<MediaLinkResult>( r => r.Results.Count == 2 && r.IsPartial ),
+                It.Is<MediaLinkResult>( r => r.Results.Count == 2 ),
                 It.IsAny<CancellationToken>( )
             ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -1074,9 +1082,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Never
         );
 
-        // Assert - The partial result is still written for waiting callers
+        // Assert - The partial result is still written for waiting callers (non-terminal write path)
         _atProtoStorageMock.Verify(
-            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }
@@ -1241,9 +1253,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Never
         );
 
-        // Assert - The partial result is written for waiting callers instead
+        // Assert - The partial result is written for waiting callers instead (non-terminal write path)
         _atProtoStorageMock.Verify(
-            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
@@ -1338,9 +1354,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Never
         );
 
-        // Assert - The partial result is written so waiting callers receive a response
+        // Assert - The partial result is written so waiting callers receive a response (non-terminal write path)
         _atProtoStorageMock.Verify(
-            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -1404,9 +1424,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Exactly( 2 )
         );
 
-        // Assert - Partial result written instead of a premature final
+        // Assert - Partial result written instead of a premature final (non-terminal write path)
         _atProtoStorageMock.Verify(
-            a => a.StoreMediaLinkResultAsync( It.Is<MediaLinkResult>( r => r.IsPartial ), It.IsAny<CancellationToken>( ) ),
+            a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _sagaManagerMock.Verify(
+            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
@@ -2099,9 +2123,9 @@ public class SagaCoordinatorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// Verifies the non-terminal write path: <c>terminal=false</c> sets <c>IsPartial=true</c> on
-    /// the combined result, calls <c>SetPartialResultUriAsync</c> (not <c>SetFinalResultUriAsync</c>),
-    /// and never calls <c>SetIsPartialAsync(false)</c> or <c>TryClaimFinalizeAsync</c>.
+    /// Verifies the non-terminal write path: <c>terminal=false</c> calls <c>SetPartialResultUriAsync</c>
+    /// (not <c>SetFinalResultUriAsync</c>), and never calls <c>SetIsPartialAsync(false)</c> or
+    /// <c>TryClaimFinalizeAsync</c>.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -2143,14 +2167,14 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Act - non-terminal write
         await service.InvokeWriteForTestAsync( partialSaga, terminal: false, cts.Token );
 
-        // Assert - the combined result written to PDS carries IsPartial=true
+        // Assert - the combined result is stored once (non-terminal path confirmed by SetPartialResultUriAsync below)
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync(
-                It.Is<MediaLinkResult>( r => r.IsPartial ),
+                It.IsAny<MediaLinkResult>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once,
-            "Non-terminal write must produce a result with IsPartial=true"
+            "Non-terminal write must store the result exactly once"
         );
 
         // Assert - partial URI stored, not final URI

--- a/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
+++ b/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
@@ -537,7 +537,7 @@ public class StaleCacheRefreshBackgroundServiceTests {
         DateTime justStale = DateTime.UtcNow.AddDays( -cacheDays ).AddSeconds( -1 );
         DateTime justFresh = DateTime.UtcNow.AddDays( -cacheDays ).AddDays( 1 );
 
-        (string, MediaLinkResult) staleRec = MakeStaleRecord( "at://stale", justStale, isrc: "STALE_ISRC", forceIsPartial: false );
+        (string, MediaLinkResult) staleRec = MakeStaleRecord( "at://stale", justStale, isrc: "STALE_ISRC" );
         (string, MediaLinkResult) freshRec = MakeFreshRecord( "at://fresh", justFresh, isrc: "FRESH_ISRC" );
 
         SetupRecordList( [staleRec, freshRec] );
@@ -565,20 +565,21 @@ public class StaleCacheRefreshBackgroundServiceTests {
     }
 
     /// <summary>
-    /// A record with <c>IsPartial = true</c> and a FRESH timestamp is NOT selected. This is the
-    /// age-only behavior change: partial-ness alone is no longer a staleness trigger.
+    /// A record with a FRESH timestamp is NOT selected regardless of its provider coverage.
+    /// Freshness is age-only: the only criterion is whether the record has exceeded the cache
+    /// window; provider coverage has no bearing on selection.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task RunRefreshPass_PartialButFreshRecord_IsNotSelected( ) {
+    public async Task RunRefreshPass_FreshRecord_IsNotSelected( ) {
         DateTime fresh = DateTime.UtcNow.AddDays( -1 ); // well inside cache window
 
-        // IsPartial=true, fresh timestamp — under age-only rule this must NOT be selected.
-        (string, MediaLinkResult) partialFreshRec = MakeStaleRecord( "at://partial-fresh", fresh, isrc: "PARTIAL_ISRC", forceIsPartial: true );
-        // IsPartial=false, fresh timestamp — also NOT selected.
+        // Fresh timestamp — under age-only rule this must NOT be selected.
+        (string, MediaLinkResult) ageFreshRec = MakeStaleRecord( "at://age-fresh", fresh, isrc: "AGE_FRESH_ISRC" );
+        // Also fresh timestamp — also NOT selected.
         (string, MediaLinkResult) freshRec = MakeFreshRecord( "at://fresh", fresh, isrc: "FRESH_ISRC" );
 
-        SetupRecordList( [partialFreshRec, freshRec] );
+        SetupRecordList( [ageFreshRec, freshRec] );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
         await service.RunRefreshPassAsync( TestContext.CancellationToken );
@@ -600,7 +601,7 @@ public class StaleCacheRefreshBackgroundServiceTests {
         DateTime expired = DateTime.UtcNow.AddDays( -31 ); // outside 30-day window
 
         (string, MediaLinkResult) partialExpiredRec = MakeStaleRecord(
-            "at://partial-expired", expired, isrc: "PARTIAL_EXPIRED_ISRC", forceIsPartial: true );
+            "at://partial-expired", expired, isrc: "PARTIAL_EXPIRED_ISRC" );
 
         SetupRecordList( [partialExpiredRec] );
 
@@ -636,15 +637,15 @@ public class StaleCacheRefreshBackgroundServiceTests {
         _settings = MakeSettings( cacheDays: cacheDays );
         DateTime utcNow = DateTime.UtcNow;
 
-        // Records: one expired non-partial, one fresh non-partial, one fresh partial.
+        // Records: one expired, one fresh, one fresh with limited provider coverage.
         (string, MediaLinkResult) expiredRec = MakeStaleRecord(
-            "at://expired", utcNow.AddDays( -60 ), isrc: "EXPIRED_ISRC", forceIsPartial: false );
+            "at://expired", utcNow.AddDays( -60 ), isrc: "EXPIRED_ISRC" );
         (string, MediaLinkResult) freshRec = MakeFreshRecord(
             "at://fresh", utcNow.AddDays( -1 ), isrc: "FRESH_ISRC" );
-        (string, MediaLinkResult) partialFreshRec = MakeStaleRecord(
-            "at://partial-fresh", utcNow.AddDays( -1 ), isrc: "PARTIAL_ISRC", forceIsPartial: true );
+        (string, MediaLinkResult) ageFreshRec = MakeStaleRecord(
+            "at://age-fresh", utcNow.AddDays( -1 ), isrc: "AGE_FRESH_ISRC" );
 
-        SetupRecordList( [expiredRec, freshRec, partialFreshRec] );
+        SetupRecordList( [expiredRec, freshRec, ageFreshRec] );
 
         List<QueuedLookupRequest> enqueuedRequests = [];
         _ = _queueMock
@@ -889,7 +890,7 @@ public class StaleCacheRefreshBackgroundServiceTests {
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task RunRefreshPass_RecordWithNoIdentifier_IsSkippedAndNotAnError( ) {
-        MediaLinkResult result = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -60 ), IsPartial = false };
+        MediaLinkResult result = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -60 ) };
         result.Results[SupportedProviders.Spotify] = new MusicLookupResult {
             URL = string.Empty,
             ExternalId = string.Empty,
@@ -1863,10 +1864,9 @@ public class StaleCacheRefreshBackgroundServiceTests {
     private static (string AtUri, MediaLinkResult Result) MakeStaleRecord(
         string atUri,
         DateTime lookedUpAt,
-        string isrc = "ISRC_DEFAULT",
-        bool forceIsPartial = false
+        string isrc = "ISRC_DEFAULT"
     ) {
-        MediaLinkResult result = new( ) { LookedUpAt = lookedUpAt, IsPartial = forceIsPartial };
+        MediaLinkResult result = new( ) { LookedUpAt = lookedUpAt };
         result.Results[SupportedProviders.Spotify] = new MusicLookupResult {
             URL = "https://open.spotify.com/track/3SPOTID12345",
             ExternalId = isrc,
@@ -1882,7 +1882,7 @@ public class StaleCacheRefreshBackgroundServiceTests {
         DateTime lookedUpAt,
         string isrc = "FRESH_ISRC_DEFAULT"
     ) {
-        MediaLinkResult result = new( ) { LookedUpAt = lookedUpAt, IsPartial = false };
+        MediaLinkResult result = new( ) { LookedUpAt = lookedUpAt };
         result.Results[SupportedProviders.Spotify] = new MusicLookupResult {
             URL = "https://open.spotify.com/track/3SPOTFRESH1",
             ExternalId = isrc,

--- a/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
+++ b/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
@@ -592,18 +592,18 @@ public class StaleCacheRefreshBackgroundServiceTests {
     }
 
     /// <summary>
-    /// A record with <c>IsPartial = true</c> and an EXPIRED timestamp IS selected (via the age arm).
-    /// Confirms partial records do eventually get refreshed — just once per freshness window.
+    /// A record whose timestamp is outside the freshness window is selected based on age alone.
+    /// Provider coverage is not part of the selection predicate.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task RunRefreshPass_PartialAndExpired_IsSelected( ) {
+    public async Task RunRefreshPass_ExpiredRecord_IsSelected( ) {
         DateTime expired = DateTime.UtcNow.AddDays( -31 ); // outside 30-day window
 
-        (string, MediaLinkResult) partialExpiredRec = MakeStaleRecord(
-            "at://partial-expired", expired, isrc: "PARTIAL_EXPIRED_ISRC" );
+        (string, MediaLinkResult) expiredRec = MakeStaleRecord(
+            "at://expired", expired, isrc: "EXPIRED_ISRC" );
 
-        SetupRecordList( [partialExpiredRec] );
+        SetupRecordList( [expiredRec] );
 
         List<QueuedLookupRequest> enqueuedRequests = [];
         _ = _queueMock
@@ -620,19 +620,19 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         Assert.HasCount( 1, enqueuedRequests );
         Assert.AreEqual( LookupRequestType.SongIdLookup, enqueuedRequests[0].LookupType,
-            "Partial-expired record with parseable URL yields a native SongIdLookup leg." );
+            "Expired record with a parseable URL yields a native SongIdLookup leg." );
         Assert.AreEqual( "3SPOTID12345", enqueuedRequests[0].LookupValue,
             "Native leg LookupValue is the extracted track ID, not the ISRC." );
     }
 
     /// <summary>
     /// Equivalence pin: the age-only selection produces the same result set as the inline age check
-    /// without the old <c>IsPartial</c> arm. A corpus with a partial+fresh record confirms it is
-    /// excluded.
+    /// without the old <c>IsPartial</c> arm. A corpus with fresh records of differing provider
+    /// coverage confirms both are excluded.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task RunRefreshPass_SelectionEquivalentToAgeOnlyCheck_ExcludesPartialFresh( ) {
+    public async Task RunRefreshPass_SelectionEquivalentToAgeOnlyCheck_ExcludesFreshRecords( ) {
         int cacheDays = 30;
         _settings = MakeSettings( cacheDays: cacheDays );
         DateTime utcNow = DateTime.UtcNow;

--- a/Tests/Unit/ViewSecurityHelpersTests.cs
+++ b/Tests/Unit/ViewSecurityHelpersTests.cs
@@ -185,9 +185,10 @@ public class ViewSecurityHelpersTests {
     /// </summary>
     [TestMethod]
     public void HtmlSafeJsonOptions_IsSingletonInstance( ) {
-        Assert.AreSame(
-            ViewSecurityHelpers.HtmlSafeJsonOptions,
-            ViewSecurityHelpers.HtmlSafeJsonOptions );
+        JsonSerializerOptions firstAccess = ViewSecurityHelpers.HtmlSafeJsonOptions;
+        JsonSerializerOptions secondAccess = ViewSecurityHelpers.HtmlSafeJsonOptions;
+
+        Assert.AreSame( firstAccess, secondAccess );
     }
 
     // -----------------------------------------------------------------------

--- a/Tests/packages.lock.json
+++ b/Tests/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Aspire.Hosting.Testing": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "En6XNWJvYOHY6h3czTFSvYN4fKDA7d+Aqd9OKHpBzha8OxGyksLHA2Z+JgDHk9XC8S7zCS7IDmgzuPwKxFTiTQ==",
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "ETvzLx362Ntj4vHhnlgFK1h3coW7Cs37O8rkIv/ma12MZQEwNvNqpEd2AKMGEdcxDn8FTGQMHHXPTyKvIRdlFA==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.4.3",
-          "Aspire.Hosting.AppHost": "13.4.3",
+          "Aspire.Hosting": "13.4.6",
+          "Aspire.Hosting.AppHost": "13.4.6",
           "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore": "2.80.0",
           "Grpc.Net.ClientFactory": "2.80.0",
@@ -39,7 +39,7 @@
           "Polly.Core": "8.6.6",
           "Polly.Extensions": "8.6.6",
           "Semver": "3.0.0",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
@@ -51,39 +51,40 @@
       },
       "MessagePack": {
         "type": "Direct",
-        "requested": "[2.5.301, )",
-        "resolved": "2.5.301",
-        "contentHash": "WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+        "requested": "[3.1.8, )",
+        "resolved": "3.1.8",
+        "contentHash": "Qk2q+9FVxnMSp+NQ9y3SLz3HqWe7Rg3KRMHhBX28FkKUoOeP9YIU86mA4pFOxDDjUIRA9e7Ssbxs/LwWUcAzPw==",
         "dependencies": {
-          "MessagePack.Annotations": "2.5.301",
-          "Microsoft.NET.StringTools": "17.6.3"
+          "MessagePack.Annotations": "3.1.8",
+          "MessagePackAnalyzer": "3.1.8",
+          "Microsoft.NET.StringTools": "17.11.4"
         }
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "Mt+5CtYz+xmog1S1TJt2owVKU8YquZtNy9bmO+kfrrtjEDZPzCw1qZ7o97PLpIEpt3yy4F5YdAUh9nKPm0CX5Q==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "pTWE4RtRbb9sl/U9QjZA5oapEZ01ZEMfRilZvvh55ZW97caTQ2XuAF6sgc+7ojKWBbR2qrcWVo5P80gMPuW/tQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
-          "Microsoft.Extensions.Hosting": "10.0.9"
+          "Microsoft.AspNetCore.TestHost": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Hosting": "10.0.10"
         }
       },
       "Microsoft.Extensions.TimeProvider.Testing": {
         "type": "Direct",
-        "requested": "[10.7.0, )",
-        "resolved": "10.7.0",
-        "contentHash": "THd3CJ9e/ftm/3+Z69E51MQy4n46so4Zs/vUevMCYR5tjZsP+INqD4npXARVQwB2nnG+eQ8SI6ERLe/tn6gwSA=="
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "xXcxGfXSO/8o7IfYK36r3eZTl9RMKAl5K6x3x6o/QQBolI0t8vsLIGmhc3HJBTd11u1uPLHz61VnOTSTmY7ZVA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.8.1, )",
+        "resolved": "18.8.1",
+        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
+          "Microsoft.CodeCoverage": "18.8.1",
+          "Microsoft.TestPlatform.TestHost": "18.8.1"
         }
       },
       "Moq": {
@@ -97,42 +98,42 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
         "dependencies": {
-          "MSTest.TestFramework": "4.2.3",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
-          "Microsoft.Testing.Platform.MSBuild": "2.2.3"
+          "MSTest.TestFramework": "4.3.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
         "dependencies": {
-          "MSTest.Analyzers": "4.2.3"
+          "MSTest.Analyzers": "4.3.2"
         }
       },
       "Testcontainers.Redis": {
         "type": "Direct",
-        "requested": "[4.12.0, )",
-        "resolved": "4.12.0",
-        "contentHash": "7tiLEDCZx6mWNxHJpTyvI48O4Y4ih+pLf7JS4IdPlnl2ww1XRaCe/paGwYUOtySKstwwD2x7jgDhucjaoeBb3g==",
+        "requested": "[4.13.0, )",
+        "resolved": "4.13.0",
+        "contentHash": "OPnG9q83LYvgwGTAnCCsPEemRiJoxL+Mv3C6/lJnlpw+qCfAuiCWD4Hmtb/tUO0xbndzc7FecrhpEho0aldZBA==",
         "dependencies": {
-          "Testcontainers": "4.12.0"
+          "Testcontainers": "4.13.0"
         }
       },
       "Aspire.Dashboard.Sdk.osx-arm64": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "ycXVw1G1/rbswZxfh9beYe3KqK6B+4J0TLX99alrtH4pM+r8cuTS6D6JNEBj1tvT7jyoAcogfaCDe1jIbVgeCQ=="
+        "resolved": "13.4.6",
+        "contentHash": "ImzN7Egx/jWH0FfzIwjuZ1V4WpRsjMI6aO0VJE63fYV+PO32B0kpAbHxAcwQ4c742or4VnXOllmQPtVR1IY/gw=="
       },
       "Aspire.Hosting": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "X6UgBZNWU/zOp65qkNElsa5BMPbxv0P59E+6D0NcRFi1n5iMY2UN2xnEnghfKBDBKUSwqnEGvUg/cLL9N797zw==",
+        "resolved": "13.4.6",
+        "contentHash": "YJEvsrgcVLPQ88aJ3aFMIEJue0ZFmyH8RfyQu0PnHdZzjBAiK0c8BaYUAycWu35QpTe4hHxEYaY0wW4gpy/kwg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
           "Google.Protobuf": "3.34.1",
@@ -159,17 +160,17 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
       "Aspire.Hosting.AppHost": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "/xbwGWapQ1j+nlL+hGrPF1pTG2qLyg0bRQcXI2o4lJ1Pg22n7lXaoaOnBBlheUm12+psdph2M95Mp8D17yYR0A==",
+        "resolved": "13.4.6",
+        "contentHash": "+4BxGpb2JQDk3+uOmk5eDpK0Brg2d3hwqrK/7d/aDBAUoHYbjfwbItIfdYJjKjbxUkBiaotokcWdVbLNsMo9Nw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.4.3",
+          "Aspire.Hosting": "13.4.6",
           "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore": "2.80.0",
           "Grpc.Net.ClientFactory": "2.80.0",
@@ -195,23 +196,23 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
       "Aspire.Hosting.Orchestration.osx-arm64": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "OGxSbcaEzP+a4rm4FHo6v5pKywB0uvRZtHefTN6pT1CtKyq3sb1XIBKq6xB30P/KKoiPxMiiK7az9PajiOp8Lw=="
+        "resolved": "13.4.6",
+        "contentHash": "8im4H5IZVIjLIR4uNAEzx8HDwsD/Brq8UsjZNfCs4jVbwwq+B7iA1EvieFy3OjhNP6CQXCHosvCJ0DjVOMofYg=="
       },
       "Aspire.Hosting.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "l1ZirqHUg0PtgA5y8uNFTGIo3eSZsWjocNVOd5Lnifhu54bb/wBaCvUi3VxUHW5hRu8fgFR5RH41mL9AOGapeQ==",
+        "resolved": "13.4.6",
+        "contentHash": "UW4XTP72beiHhyth+2IHxilEN6HOnc+u88m9C9qoc35ysoTsZrxDDdTQjc6mteS8yENitQrE8VJlg2bLoU2AoQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.4.3",
+          "Aspire.Hosting": "13.4.6",
           "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore": "2.80.0",
           "Grpc.Net.ClientFactory": "2.80.0",
@@ -238,14 +239,14 @@
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
           "StackExchange.Redis": "2.13.1",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
@@ -306,63 +307,63 @@
       },
       "Docker.DotNet.Enhanced": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "resolved": "4.3.3",
+        "contentHash": "nGicLwvd42FhRk+khY5uS6cx49ErNdwYKnYBg0F4m4BDKLp/R77AVmmN9xAiqI3W/wN5ZCHkdUhgxf5ORkZuFQ==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
-          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
-          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
-          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
-          "Docker.DotNet.Enhanced.Unix": "4.2.0",
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.3.3",
+          "Docker.DotNet.Enhanced.NPipe": "4.3.3",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.3.3",
+          "Docker.DotNet.Enhanced.Unix": "4.3.3",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         }
       },
       "Docker.DotNet.Enhanced.Handler.Abstractions": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw==",
+        "resolved": "4.3.3",
+        "contentHash": "9Cp8hOgtynixcDoAs9lnEaQosluojSYmiW3fsLsLIVfZjlq/fznSIZNUhnmyT4Xo1Iyuok/y49WL/25O47u0Pw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         }
       },
       "Docker.DotNet.Enhanced.LegacyHttp": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "resolved": "4.3.3",
+        "contentHash": "7j3M16emv9PAQN7VwFn23xLYNj8GJmwPOcogveHkaWnOCqiC+anRaNKQwqIBNApM1AuwZKivehTKTPmmrjUUnw==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
         }
       },
       "Docker.DotNet.Enhanced.NativeHttp": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "resolved": "4.3.3",
+        "contentHash": "iNzK+jRFeEMobSA7l/h4ARwCKOOefOWtVN5/RB0ft6/6H6IQXvVUuOgGyZAjYLBT7TsyClRYno2B904f3dtBuQ==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
         }
       },
       "Docker.DotNet.Enhanced.NPipe": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "resolved": "4.3.3",
+        "contentHash": "ZTLYufuEfY0e6qLOgeH9QgXx2KYuoABRVaY5A8rsggyLgYqbDj9rCRfVAhHPCUv83S7pVxDHy+Tvm/BnxjWVpg==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
         }
       },
       "Docker.DotNet.Enhanced.Unix": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "resolved": "4.3.3",
+        "contentHash": "ypo8qNbmvHw1t9VfpRTMogCw2vht6VjkXzlGYUUeP2H2bf83USURdla1maW1njn2oq2rfLUFOGMfmt+A37QU2w==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
         }
       },
       "Docker.DotNet.Enhanced.X509": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
+        "resolved": "4.3.3",
+        "contentHash": "oBDibWezEv4hgj3RIQxI3DVcxkNV1MdrD0d/jhjUu+h3DL+qc0wlkQva15kkwMatXmC/hWp1VP0DMoFXe+BmEw==",
         "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
         }
       },
       "Duende.IdentityModel": {
@@ -469,8 +470,8 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
@@ -480,39 +481,39 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Http": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Json.More.Net": {
@@ -548,8 +549,13 @@
       },
       "MessagePack.Annotations": {
         "type": "Transitive",
-        "resolved": "2.5.301",
-        "contentHash": "3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A=="
+        "resolved": "3.1.8",
+        "contentHash": "SitOtZ4tOlAZZPF7p52M7143F+Cuz7o/aU0MrtAXX0+ZkPXzDNroOFhzzE2ogMFThsoEW/E6akXVVcBFM9ZKaw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "Vm4g0cR4YRKRchEOmMJ0uVFU6yxdg7cJa2KHv3SUAHEsdYKvMpHMF5A1hZfsix89ymD5cmuzRnw9a6dKMcvq+Q=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -558,30 +564,30 @@
       },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "urOeZY19KqnhNpVJkL/BiFApqaEmWoIq0kD56VD/aaiC0RkIK81tBnN65Z6zed+QgYMbv8VbNYFXiRI1/ReKPA=="
+        "resolved": "10.0.10",
+        "contentHash": "T/kOT3kAVZU1B0QlpRxASpdbAJ/o5DLFW7bWS6vyE44uMqPmojEcaFENt6ww1xaLH++ZNwsEJ1YUOwPK050lNQ=="
       },
       "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "D6cU2Cwwq0R49mrc6Z6BcKmobffUZvvSbQ7kIe+TfqqN2yv54YNQem3iN1nnmbAdIMMejl9y0PCb/5oSth7NLA==",
+        "resolved": "10.0.10",
+        "contentHash": "w6P461MvhJrttEcyGfN00tf8rdwQJFK+s0pebR44jiTzAa+PUZ804xzbGZQpR6klSFd212M4DIIROSaW0Acifg==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.9"
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.Identity.Stores": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Identity.Stores": "10.0.10"
         }
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "mR4y30XFsVbn7EwV3Ic5/KMBO5QGwukTJE2ztGmpAST5ACX+Z+9r+Y6D1eibJojsOIW5KHpM4myo9/aRALJOyg=="
+        "resolved": "10.0.10",
+        "contentHash": "Kks+OpQlP/eWQhnTjkiv0H9kc9Uqa7ieAzNV62yJpZ8Ips/WwpfpwrwZUKzV83CBJaBl5OI7J2XxVVTC8vah/Q=="
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Transitive",
@@ -591,76 +597,81 @@
           "Microsoft.Net.Http.Headers": "10.0.0"
         }
       },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.8.1",
+        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
@@ -671,12 +682,12 @@
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q==",
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
         }
       },
       "Microsoft.Extensions.ApiDescription.Server": {
@@ -686,162 +697,162 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A==",
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.ObjectPool": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "8D4HaqxWdm5M/nuhQffjPoR1ekhlpyKTXjFMAT5KlP0dvxkJe5JLAP6MAsuUEUxKWG09Bi5aAUaYMFKrMqWHqA==",
+        "resolved": "10.0.10",
+        "contentHash": "33cBeR2HRbzHUTtmcmLdNOApneNGcymwwL4arHuotgVK9Frba8kcDTrvVTj7cSCmF1R9OiSbZH0KxNOwab3HUg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "JhKySWIL8+N4yFt4HPm1rGKCHooze+MBdTdpXc0bd/PGm31TrSUi2m0Nek1y441Wlv/RE6VH0W/DCv2xnmy8FA==",
+        "resolved": "10.0.10",
+        "contentHash": "KRfFSSCV58vEdU7mPED/YMzeovIWF5P0g8s9K8n9HEfy0/WzMq37SrPdXdFN5/dFT/rPMHpF7AvpoXHckbcBFg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "NgLB9cYnIb0/djSDcnqo4GIGGWooxGmr/gCUe3/CRXcKqLizOFui8MyW4EVkTB/KNJL+oXdMXnD6ZRm3Y+qkrQ==",
+        "resolved": "10.0.10",
+        "contentHash": "ZOhZYwvbXGTgGVRwswIirofEMVHuWdxjdh0JeUZXwaF9cgcjXdz/t0ELtgaevw7ezTyv47yPNCgGreWtLkn3IQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "LiFKJgc9jZEW+7RhcSfsvCwoikt1lDdOqOn+whZC5zVHyg/gExftHl2QPtmfiHsEdDNg+Y+BDr6835tOfj8Y7A==",
+        "resolved": "10.0.10",
+        "contentHash": "uvJ6sHwjgrkMEJOgiC76G0mcZGXerwyyWkwX34EOjCbxKG6TCtfAoqDKAMsCvEBf9HxjlGQEgqsSMOGCmGBf+A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "ockJRreRW/HbGwoyHzYOxMucFBimvAZ8lKNwQLMHrS6mwkDUaCJMWzzeE+Rm9vgFlv2o/xqk8fm+FpqrDCnkTA==",
+        "resolved": "10.0.10",
+        "contentHash": "1s1sKFTk/Foam64JY6+m/diH8drL3Wx6V3gtSd5v1IEZtszZYyc1pW8uRnMblzpNiR0l0t8gGk7tXj3xHzFgdg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Json": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Json": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA==",
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ==",
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
@@ -862,332 +873,333 @@
       },
       "Microsoft.Extensions.Features": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "ohU5761fyZq7eSg0nLQMzHvCrGGGmyzgRzAGebHZlQ4D7/9v9uzPYJ/AUYcD5kNSiOWR34Ma4qGgKs0PUPrYZw=="
+        "resolved": "10.0.10",
+        "contentHash": "4Zdm7n1vxXAXpHOhGQVpGd5KCdcI1EWk66ilgdrDt2I+928ND+u/F+EVrzYi9pmRR+XeAE47kjuVEmkP0b0mBw=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "zm8WVod4swgprGrkxkuSILlbXqdDRqF+3y6U0I7jlmj4PMyKN6d8pzXZHUn5lr/gZVULzk/+FeTYlTupt6akpg==",
+        "resolved": "10.0.10",
+        "contentHash": "jhJAyo38kSrH3ARvWUk0h8itogVnQu2DCZuPo+s0Z+tXes0ugTxMPaHYzap85785eHQmPFqD9TYERqBbtGxn/w==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "mvRf9qOH/LslWIee/h+lsElnoUyKotEwoPL31soqScmO/eoxObaTCLCdx2DdqPdRi9LnB+7qKZ49jfyrLZuc+w=="
+        "resolved": "10.0.10",
+        "contentHash": "jSOCVxEwCd4Aq925kJVz1kSO1EpX2OHYKL04qVREXkDU7Ce3pVDdHPYm+fEy8y/th2kJf/DAstRHpJAqoNWP8w=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HTgnvmK0ubesUFO16pLC+i9+RS8lEGd6TmDouuy75FsAgIFrSwUVhYCqG2IENzBJwgxGc/6Rsulfsvd9ZG/XkA==",
+        "resolved": "10.0.10",
+        "contentHash": "tL9FkfV64GPUDSPvwrgyw42LVzsnVAnyrqJEuZVJbODgrQ3eL63zmzEcVWoCHzfgqUhWggzbgAyUCnz/zfI3Pg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.9",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.9",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Json": "10.0.9",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Diagnostics": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
-          "Microsoft.Extensions.Logging.Console": "10.0.9",
-          "Microsoft.Extensions.Logging.Debug": "10.0.9",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.9",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.10",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.10",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Json": "10.0.10",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.Logging.Console": "10.0.10",
+          "Microsoft.Extensions.Logging.Debug": "10.0.10",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.10",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Http": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5jdmuLRg1HO7x/v8McOf6ndhkMQWImkRBtJpXM8+xIocXNdLqCItyyFLKusdILc62TDzHuLlqaWoxtOA5FFOPg==",
+        "resolved": "10.0.10",
+        "contentHash": "DuEBLw2y7ZBfilnaJtlge8f2M49932v43t7j1InceXVjcZzxNrSEkobYXdgZkXuPFnFbKcbWpAS+fZgYEW1BhA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Diagnostics": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.9",
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Http": "10.0.10",
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.9",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Identity.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "LkVkMn8gNFxS756O6+Dd+nUFXrgm9wQ4sPFXc7EUGTUEZa1MLcamE6I0BZ3F8SbclxcHqPRBnFCg6PDt4HKotQ==",
+        "resolved": "10.0.10",
+        "contentHash": "ZA+9MX1D7+jm/1RF3iOOBThCps55MT1jAwLne1dryMj9cuAeOVtGS3pBegqk1Mwza+0tuVAklob+Q/EA9bHnQw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.9",
-          "Microsoft.Extensions.Diagnostics": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Identity.Stores": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "BhIDzh6apQFKcsbiA3OAPLR0eorngp6Ftl096k8TaeE34stXqt6zlkHbvzSNAhKwKUlVH5Nld6e69N/exhbTXA==",
+        "resolved": "10.0.10",
+        "contentHash": "WMG/9wPJPnwU2w1R/WPLO/RL2UpGpBhw9z6odAAUkFdZypzzXl620FJWEoPpuBUq6Q4GYgMg0FQVRCO6gO4MQQ==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Identity.Core": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Identity.Core": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
+        "resolved": "10.0.10",
+        "contentHash": "cLrqxkuEfcilZ8SjK+9KAnpLk9lOoMPaOokF+wRUYie+iUEcdX4/p/+gJkt0BYgWLthjpBUCkVTBI6Kxg0nsOw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
+        "resolved": "10.0.10",
+        "contentHash": "VIlNzPwPS0GeQVSmCqqo36ugryX3LpE9ul6gEkks5VLET3weH/XMLeWmclwfoGn4Nxi2mwVibB+OZBVJ9tDqvg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "r/A0ahpXmZH/8ltPjrFFWp12BIizK9cCVJXPcHyOad8e4eIX7P/geW+uBYdczkeCAaMebT4jEU7snOm4GnmKfA==",
+        "resolved": "10.0.10",
+        "contentHash": "8+TZBnV5fgBXoVNJ5ROSErUwYogk4hOgV7c2HWK1u5cqKGmiUTUn7+KqZ35iQu8e/B7Ykccyz5OTjdXcidNZ9g==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "goAl30/WwmdnWDPRwATaDPIK0iuDBnQSMTH2XYGVB1SwReg7hglhvDNjjpNhT25US3GF4I5q6BhTNs6nFYzEfg==",
+        "resolved": "10.0.10",
+        "contentHash": "0RE4951AzQ+YD4gVrvbq0BhdsiBgSDo44yM7+QBZ2mrmMJeNjY+teCIYfUjqDPVYnKs0HR6SkkhgrX1YgXZq3Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "System.Diagnostics.EventLog": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "System.Diagnostics.EventLog": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.EventSource": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
+        "resolved": "10.0.10",
+        "contentHash": "85SAPwXhJtdBInzN2k7SChiFiBGh3KOWay5AfoY+GREF6P7oZA98+ST2p7Z9384iLKYjkZSKIZ/FqIO5aojtNw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "KZENCkfqO7Ciax6goUWQHDSxKH+x763hkBWMz9KpE87EyKW+EKEas9EFe9i1KgtQShG8KwKxaeJ5gd9sj6TuTQ=="
+        "resolved": "10.0.10",
+        "contentHash": "Tx0R6PY9MNSh0mDKSxbpHLuuec93IxF1cel+1ithQnMNr/vbfLSSHOQHGHIppAJCGfPcEo/wO1Ylj+QpXtzo3A=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options.DataAnnotations": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "HhxwIGECGGJ8ox2kvm6/hkN/w1ZyKrO5uu/rLAL51V0ypPdahoNf+dHS6Er/DJs2aeUmH38ZTTzACfLy1O6w3Q==",
+        "resolved": "10.0.9",
+        "contentHash": "+GfvpicDQRYgQ5P3kjfzkiH+w4FlABL6xwmQ+EDE0Oc7E9haPV4oyqbstPlWPdwamF7u1ts6hzaVKqNptDEwGA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics": "10.0.9",
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.9",
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Http": "10.0.10",
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A==",
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Features": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Features": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
-          "Microsoft.Extensions.ObjectPool": "10.0.9",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.ObjectPool": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Net.Http.Headers": {
@@ -1200,81 +1212,80 @@
       },
       "Microsoft.NET.StringTools": {
         "type": "Transitive",
-        "resolved": "17.6.3",
-        "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
+        "resolved": "18.4.0",
+        "contentHash": "iQWOKi3L5QStmWqDjDubcr1KlTDy88qBTe88I0etlUUo1l0zSNebGJXl1Xetyl+ACA+ujP3YUtxo3Nz54JPriw=="
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "3.7.0",
-        "contentHash": "7Ld/wUsxSEKBjAk8nPZ13qkju5kNoh20gf0JHPeHrK41tMZRpIq9amXFAOHncicjg0U5M035I+6/z3cBsYBHfg=="
+        "resolved": "3.8.0",
+        "contentHash": "bF+KnfJSd9KLUOZxl07IdhmQcvz/adqU+GVub7+SVOydHpJGOGIWqwngZ3JxgtDpKYRA6vlk+0tv82G0KXRuhw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "resolved": "2.3.2",
+        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "resolved": "2.3.2",
+        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
+        "resolved": "18.8.1",
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
+        "resolved": "18.8.1",
+        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
         }
       },
       "Microsoft.VisualStudio.Threading.Only": {
         "type": "Transitive",
-        "resolved": "17.13.61",
-        "contentHash": "vl5a2URJYCO5m+aZZtNlAXAMz28e2pUotRuoHD7RnCWOCeoyd8hWp5ZBaLNYq4iEj2oeJx5ZxiSboAjVmB20Qg==",
+        "resolved": "17.14.15",
+        "contentHash": "NqONyw1RXyj9P3k5e1uU2k9kc1ptwuU5NJQzG+MPq7vQVHUzBY8HLuJf/N2Rw5H/myD96CVxziDxmjawPuzntw==",
         "dependencies": {
           "Microsoft.VisualStudio.Validation": "17.8.8"
         }
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
-        "resolved": "17.8.8",
-        "contentHash": "rWXThIpyQd4YIXghNkiv2+VLvzS+MCMKVRDR0GAMlflsdo+YcAN2g2r5U1Ah98OFjQMRexTFtXQQ2LkajxZi3g=="
+        "resolved": "17.13.22",
+        "contentHash": "fC20ITOxlUpGQ0ltAxITQbeFxwuB6OjLT3lByC4+/Gm46o/Mwv9hlIVrBhiUhnqdQzUUvr4EHkdiYe7WOSMLmw=="
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
@@ -1302,13 +1313,23 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.2.3",
-        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+        "resolved": "4.3.2",
+        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
+      },
+      "Nerdbank.MessagePack": {
+        "type": "Transitive",
+        "resolved": "1.2.4",
+        "contentHash": "9NKlDsKkOV5zQFkZZnQmssdV6npFNs0Of1Nz5mvAJA4uANxCge2TfXQ9nCYUet58bEWQ00a/aNHdjmcXEI7iuQ==",
+        "dependencies": {
+          "Microsoft.NET.StringTools": "18.4.0",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "PolyType": "1.3.1"
+        }
       },
       "Nerdbank.Streams": {
         "type": "Transitive",
-        "resolved": "2.12.87",
-        "contentHash": "oDKOeKZ865I5X8qmU3IXMyrAnssYEiYWTobPGdrqubN3RtTzEHIv+D6fwhdcfrdhPJzHjCkK/ORztR/IsnmA6g==",
+        "resolved": "2.13.16",
+        "contentHash": "GjifQ5M4IpQWjGNNbIrsj8M/M7ESb2328OeoGeqxk5rOJiuaAJ5zFc6CyqB+5UWKr1KEGK23hKoxA+z1gooAKA==",
         "dependencies": {
           "Microsoft.VisualStudio.Threading.Only": "17.13.61",
           "Microsoft.VisualStudio.Validation": "17.8.8"
@@ -1316,19 +1337,19 @@
       },
       "NetCord": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "XHThYWQU2rzutsJt7Ga8qTPZ0i3ckP9JQzhZonJHOir+QmNoL7hXLGKxu22C4DxMQ20N4loWkC/fr4JE7i+Fag=="
+        "resolved": "1.0.0-beta.11",
+        "contentHash": "1mzToSQ3J6wtHt1NirCJ4O9Dt1Ou/G9sSiLrFpub3KwWFpUWZqi/bncjAeCCMymosBYTasbqI+M5r6m/3DoLHg=="
       },
       "NetCord.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "wRyycx2LP3yob3ck6O57mxqeKgKRj39j0mnQLfWJOoynIggNuLxIJNw4nGXCbYDCYQSfYK2GMS91IFJ5Vbhpbw==",
+        "resolved": "1.0.0-beta.11",
+        "contentHash": "81v1p+ns7Z/ky822idTHKEGy4tt8trC6MY+hB2i0k0rKqguCsSxo8syXMNlvksYBk+TLiQzJgHkfQ+aA+VmXJA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8",
-          "Microsoft.Extensions.Options.DataAnnotations": "10.0.8",
-          "NetCord": "1.0.0-beta.2"
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.9",
+          "NetCord": "1.0.0-beta.11"
         }
       },
       "Newtonsoft.Json": {
@@ -1379,28 +1400,28 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -1450,6 +1471,11 @@
           "Polly.Core": "8.4.2",
           "System.Threading.RateLimiting": "8.0.0"
         }
+      },
+      "PolyType": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "GFdJvsN/VczpP0GfdPIi0jDudGH2Emk3rcIJHdqwU2SL2zQm1xSl6OTYvQSUxvzHu3ClWo096ICdWXVkpifQUA=="
       },
       "QRCoder": {
         "type": "Transitive",
@@ -1556,8 +1582,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -1615,52 +1641,53 @@
       },
       "StreamJsonRpc": {
         "type": "Transitive",
-        "resolved": "2.22.23",
-        "contentHash": "Ahq6uUFPnU9alny5h4agyX74th3PRq3NQCRNaDOqWcx20WT06mH/wENSk5IbHDc8BmfreQVEIBx5IXLBbsLFIA==",
+        "resolved": "2.25.29",
+        "contentHash": "ebP0ScWRtbd1EWayLRJ6bjM7aPwYZoJIIU1DApmn/cYl2dydR9f4p6Mj3eY77qzAywy6IbZWB9sJPSWeO5hmrg==",
         "dependencies": {
-          "MessagePack": "2.5.192",
-          "Microsoft.VisualStudio.Threading.Only": "17.13.61",
-          "Microsoft.VisualStudio.Validation": "17.8.8",
-          "Nerdbank.Streams": "2.12.87",
+          "MessagePack": "2.5.302",
+          "Microsoft.VisualStudio.Threading.Only": "17.14.15",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "Nerdbank.MessagePack": "1.2.4",
+          "Nerdbank.Streams": "2.13.16",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Swashbuckle.AspNetCore": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "SDU6akgCV/H4jFMRfyJ0mgO5jWOuuAqekvEThXg8c/LjnfNz5Nkaz+RUpeTVJKWIRX4wDKC/6R3ogJ4AsRE32A==",
+        "resolved": "10.2.3",
+        "contentHash": "8KNh1RWvofdU6DVLyBs4Z/OpUMnmf8oNvJQc0QxpwySRbi42bwLfdVMMrXZWANg5U5KQGQq1xW6r/hlcqw99tQ==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "10.0.0",
-          "Swashbuckle.AspNetCore.Swagger": "10.2.1",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1",
-          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.1"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.3",
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.3",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.3"
         }
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "ej4inPhiWCq+0utG8yaKhIhE8M3k3R/qRaGhpgDZB+O/s+o62/zRMO1Cn2CtQccsrqPE9PYnzCp6hQGYGpJOyQ==",
+        "resolved": "10.2.3",
+        "contentHash": "1jUUs3WQnrS0FUtaZPLSy1yYMEwS1zlvDmvQ2/eldPHUANX0LJSLVZecCMgSMdeGiRqeaRrIXLtSz++TCiTMww==",
         "dependencies": {
           "Microsoft.OpenApi": "2.7.5"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "JYX6i/y0xEtQWH/hZyfcage1/ldwww83ueD/gBc34uSnMwyvRLUsOpYcxlliFFxFbZMrY6t+R9ENqolE7zTEOg==",
+        "resolved": "10.2.3",
+        "contentHash": "y7t4coDRAeFYChmvlMRiH2OjbiRrm9AVIDgt17fQfs3x9PVAI5PiwWYOhg+4F13R4Q36WDc9lqfoOnNa3tNbGg==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "10.2.1"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.3"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
+        "resolved": "10.0.10",
+        "contentHash": "OvGz3PrzuAI/Sj7LTcXcCe3FClRI1IyRMZjNONcZtFh+Ww7nAtSh4kh08r8KVe/xxkXJPjR0Y1jF7H+N42d4xQ=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -1691,11 +1718,11 @@
       },
       "Testcontainers": {
         "type": "Transitive",
-        "resolved": "4.12.0",
-        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
+        "resolved": "4.13.0",
+        "contentHash": "j8vi9jPBNSwaraGGx8w+2gtZyWrlbKxdhiGMS3nektg+KiwjFWx9ghCjs57EoQfvI+IAbzti0oQJupQChwgMog==",
         "dependencies": {
-          "Docker.DotNet.Enhanced": "4.2.0",
-          "Docker.DotNet.Enhanced.X509": "4.2.0",
+          "Docker.DotNet.Enhanced": "4.3.3",
+          "Docker.DotNet.Enhanced.X509": "4.3.3",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "SSH.NET": "2025.1.0",
           "SharpZipLib": "1.4.2"
@@ -1714,64 +1741,64 @@
       "bridgebeats.apphost": {
         "type": "Project",
         "dependencies": {
-          "Aspire.Dashboard.Sdk.osx-arm64": "[13.4.3, )",
-          "Aspire.Hosting.AppHost": "[13.4.3, )",
-          "Aspire.Hosting.Orchestration.osx-arm64": "[13.4.3, )",
-          "Aspire.Hosting.Redis": "[13.4.3, )",
-          "MessagePack": "[2.5.301, )"
+          "Aspire.Dashboard.Sdk.osx-arm64": "[13.4.6, )",
+          "Aspire.Hosting.AppHost": "[13.4.6, )",
+          "Aspire.Hosting.Orchestration.osx-arm64": "[13.4.6, )",
+          "Aspire.Hosting.Redis": "[13.4.6, )",
+          "MessagePack": "[3.1.8, )"
         }
       },
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
         }
       },
       "bridgebeats.web": {
         "type": "Project",
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )",
-          "Microsoft.OpenApi": "[3.7.0, )",
-          "Swashbuckle.AspNetCore": "[10.2.1, )"
+          "Microsoft.OpenApi": "[3.8.0, )",
+          "Swashbuckle.AspNetCore": "[10.2.3, )"
         }
       },
       "bridgebeats.worker.discord": {
         "type": "Project",
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "NetCord.Hosting": "[1.0.0-beta.2, )"
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "NetCord.Hosting": "[1.0.0-beta.11, )"
         }
       },
       "bridgebeats.worker.jetstreamwatcher": {
         "type": "Project",
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )",
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.worker.maintenance": {
@@ -1790,6 +1817,31 @@
         "type": "Project",
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "OvGz3PrzuAI/Sj7LTcXcCe3FClRI1IyRMZjNONcZtFh+Ww7nAtSh4kh08r8KVe/xxkXJPjR0Y1jF7H+N42d4xQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -236,8 +236,8 @@ them; `url` streams them.
 | `results` | object (map) keyed by provider name | Each key is a `SupportedProviders` member name (`AppleMusic`, `Spotify`, `Tidal`); each value is the provider's result. Populated as each provider responds. |
 | `messages` | array of strings or `null` | Informational messages; `null` when there are none. |
 | `lookedUpAt` | string (ISO 8601, UTC) | When the aggregate was looked up. |
-| `isPartial` | boolean | `true` when some providers were rate-limited and have not yet resolved. |
-| `rateLimitedProviders` | array of provider names or `null` | The providers still rate-limited; `null` unless `isPartial` is `true`. |
+| `isPartial` | boolean | `true` when this response was returned before its lookup saga finalized and a more complete provider set may follow. This is transient API metadata and is not persisted in PDS records. |
+| `rateLimitedProviders` | array of provider names or `null` | The providers still rate-limited when the result is incomplete; `null` when no providers are rate-limited. |
 
 The `results` keys are the `SupportedProviders` enum member names in PascalCase — `AppleMusic`,
 `Spotify`, `Tidal` — not numeric values. System.Text.Json serializes enum dictionary keys as the
@@ -451,8 +451,10 @@ curl -X POST https://bridgebeats.example.com/music/lookup/urlList \
    providers.
 2. Honor the `Retry-After` header on 429 responses.
 3. Cache results on your side to avoid redundant calls.
-4. Check `isPartial` on the response: when `true`, some providers were rate-limited and the result
-   may be updated once they resolve.
+4. Check `isPartial` on the response. When `true`, the coordinating saga had not finalized when
+   the response was produced and a more complete provider set may follow. When
+   `rateLimitedProviders` is non-null, it identifies providers delayed by rate limiting; `messages`
+   contains user-facing explanations and retry timing.
 
 ## Swagger
 

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -90,13 +90,20 @@ record present on the PDS but missing from Redis can still be served.
 
 ### Staleness
 
-`CheckRecordFreshness` marks a record stale when either condition holds:
+`CheckRecordFreshness` marks a record stale on age alone: the record is stale when its `lookedUpAt`
+timestamp is older than `CacheDays`. Nothing else drives the freshness check.
 
-- The record's `lookedUpAt` is older than `CacheDays`, or
-- The record is partial (`isPartial` is `true`).
+Partiality does not affect cache freshness. API partiality is transient metadata derived from the
+active saga and is not persisted to PDS records. A record read through the PDS/cache path is assumed
+complete; when it ages past the window it remains a complete-but-stale response and is eligible for
+refresh. This is the same age-based rule the bulk sweep applies, so interactive lookups and the sweep
+agree on what counts as stale.
 
-Partial results are always treated as stale-eligible so callers re-enter the lookup path and wait for
-the complete result rather than serving a partial result as final.
+A partial saga generation can briefly occupy the deterministic PDS record before the final
+generation replaces it. A concurrent cache reader may treat that body as complete because fresh
+cache hits deliberately avoid an additional saga read. This bounded consistency window is accepted
+for the current single-service topology; a subsequent read after saga completion receives the final
+replacement.
 
 ### Storage flow
 

--- a/src/BridgeBeats.AppHost/BridgeBeats.AppHost.csproj
+++ b/src/BridgeBeats.AppHost/BridgeBeats.AppHost.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -14,14 +14,13 @@
     <Deterministic>true</Deterministic>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>  
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.3" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.3" />
-    <!-- Pin: overrides the vulnerable MessagePack 2.5.192 pulled in via Aspire.Hosting → StreamJsonRpc. -->
-    <PackageReference Include="MessagePack" Version="2.5.301" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
 
     <ProjectReference Include="..\BridgeBeats.Web\BridgeBeats.Web.csproj" />
     <ProjectReference Include="..\BridgeBeats.Worker.Discord\BridgeBeats.Worker.Discord.csproj" />

--- a/src/BridgeBeats.AppHost/packages.lock.json
+++ b/src/BridgeBeats.AppHost/packages.lock.json
@@ -4,18 +4,18 @@
     "net10.0": {
       "Aspire.Dashboard.Sdk.osx-arm64": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "ycXVw1G1/rbswZxfh9beYe3KqK6B+4J0TLX99alrtH4pM+r8cuTS6D6JNEBj1tvT7jyoAcogfaCDe1jIbVgeCQ=="
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "ImzN7Egx/jWH0FfzIwjuZ1V4WpRsjMI6aO0VJE63fYV+PO32B0kpAbHxAcwQ4c742or4VnXOllmQPtVR1IY/gw=="
       },
       "Aspire.Hosting.AppHost": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "/xbwGWapQ1j+nlL+hGrPF1pTG2qLyg0bRQcXI2o4lJ1Pg22n7lXaoaOnBBlheUm12+psdph2M95Mp8D17yYR0A==",
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "+4BxGpb2JQDk3+uOmk5eDpK0Brg2d3hwqrK/7d/aDBAUoHYbjfwbItIfdYJjKjbxUkBiaotokcWdVbLNsMo9Nw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.4.3",
+          "Aspire.Hosting": "13.4.6",
           "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore": "2.80.0",
           "Grpc.Net.ClientFactory": "2.80.0",
@@ -41,25 +41,25 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
       "Aspire.Hosting.Orchestration.osx-arm64": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "OGxSbcaEzP+a4rm4FHo6v5pKywB0uvRZtHefTN6pT1CtKyq3sb1XIBKq6xB30P/KKoiPxMiiK7az9PajiOp8Lw=="
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "8im4H5IZVIjLIR4uNAEzx8HDwsD/Brq8UsjZNfCs4jVbwwq+B7iA1EvieFy3OjhNP6CQXCHosvCJ0DjVOMofYg=="
       },
       "Aspire.Hosting.Redis": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "l1ZirqHUg0PtgA5y8uNFTGIo3eSZsWjocNVOd5Lnifhu54bb/wBaCvUi3VxUHW5hRu8fgFR5RH41mL9AOGapeQ==",
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "UW4XTP72beiHhyth+2IHxilEN6HOnc+u88m9C9qoc35ysoTsZrxDDdTQjc6mteS8yENitQrE8VJlg2bLoU2AoQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.4.3",
+          "Aspire.Hosting": "13.4.6",
           "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore": "2.80.0",
           "Grpc.Net.ClientFactory": "2.80.0",
@@ -86,18 +86,19 @@
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
           "StackExchange.Redis": "2.13.1",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
       "MessagePack": {
         "type": "Direct",
-        "requested": "[2.5.301, )",
-        "resolved": "2.5.301",
-        "contentHash": "WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+        "requested": "[3.1.8, )",
+        "resolved": "3.1.8",
+        "contentHash": "Qk2q+9FVxnMSp+NQ9y3SLz3HqWe7Rg3KRMHhBX28FkKUoOeP9YIU86mA4pFOxDDjUIRA9e7Ssbxs/LwWUcAzPw==",
         "dependencies": {
-          "MessagePack.Annotations": "2.5.301",
-          "Microsoft.NET.StringTools": "17.6.3"
+          "MessagePack.Annotations": "3.1.8",
+          "MessagePackAnalyzer": "3.1.8",
+          "Microsoft.NET.StringTools": "17.11.4"
         }
       },
       "Microsoft.NET.ILLink.Tasks": {
@@ -108,8 +109,8 @@
       },
       "Aspire.Hosting": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "X6UgBZNWU/zOp65qkNElsa5BMPbxv0P59E+6D0NcRFi1n5iMY2UN2xnEnghfKBDBKUSwqnEGvUg/cLL9N797zw==",
+        "resolved": "13.4.6",
+        "contentHash": "YJEvsrgcVLPQ88aJ3aFMIEJue0ZFmyH8RfyQu0PnHdZzjBAiK0c8BaYUAycWu35QpTe4hHxEYaY0wW4gpy/kwg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
           "Google.Protobuf": "3.34.1",
@@ -136,7 +137,7 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "Polly.Core": "8.6.6",
           "Semver": "3.0.0",
-          "StreamJsonRpc": "2.22.23",
+          "StreamJsonRpc": "2.25.29",
           "System.IO.Hashing": "10.0.8"
         }
       },
@@ -269,8 +270,13 @@
       },
       "MessagePack.Annotations": {
         "type": "Transitive",
-        "resolved": "2.5.301",
-        "contentHash": "3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A=="
+        "resolved": "3.1.8",
+        "contentHash": "SitOtZ4tOlAZZPF7p52M7143F+Cuz7o/aU0MrtAXX0+ZkPXzDNroOFhzzE2ogMFThsoEW/E6akXVVcBFM9ZKaw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "Vm4g0cR4YRKRchEOmMJ0uVFU6yxdg7cJa2KHv3SUAHEsdYKvMpHMF5A1hZfsix89ymD5cmuzRnw9a6dKMcvq+Q=="
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
@@ -595,21 +601,21 @@
       },
       "Microsoft.NET.StringTools": {
         "type": "Transitive",
-        "resolved": "17.6.3",
-        "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
+        "resolved": "18.4.0",
+        "contentHash": "iQWOKi3L5QStmWqDjDubcr1KlTDy88qBTe88I0etlUUo1l0zSNebGJXl1Xetyl+ACA+ujP3YUtxo3Nz54JPriw=="
       },
       "Microsoft.VisualStudio.Threading.Only": {
         "type": "Transitive",
-        "resolved": "17.13.61",
-        "contentHash": "vl5a2URJYCO5m+aZZtNlAXAMz28e2pUotRuoHD7RnCWOCeoyd8hWp5ZBaLNYq4iEj2oeJx5ZxiSboAjVmB20Qg==",
+        "resolved": "17.14.15",
+        "contentHash": "NqONyw1RXyj9P3k5e1uU2k9kc1ptwuU5NJQzG+MPq7vQVHUzBY8HLuJf/N2Rw5H/myD96CVxziDxmjawPuzntw==",
         "dependencies": {
           "Microsoft.VisualStudio.Validation": "17.8.8"
         }
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
-        "resolved": "17.8.8",
-        "contentHash": "rWXThIpyQd4YIXghNkiv2+VLvzS+MCMKVRDR0GAMlflsdo+YcAN2g2r5U1Ah98OFjQMRexTFtXQQ2LkajxZi3g=="
+        "resolved": "17.13.22",
+        "contentHash": "fC20ITOxlUpGQ0ltAxITQbeFxwuB6OjLT3lByC4+/Gm46o/Mwv9hlIVrBhiUhnqdQzUUvr4EHkdiYe7WOSMLmw=="
       },
       "ModelContextProtocol": {
         "type": "Transitive",
@@ -630,10 +636,20 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Nerdbank.MessagePack": {
+        "type": "Transitive",
+        "resolved": "1.2.4",
+        "contentHash": "9NKlDsKkOV5zQFkZZnQmssdV6npFNs0Of1Nz5mvAJA4uANxCge2TfXQ9nCYUet58bEWQ00a/aNHdjmcXEI7iuQ==",
+        "dependencies": {
+          "Microsoft.NET.StringTools": "18.4.0",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "PolyType": "1.3.1"
+        }
+      },
       "Nerdbank.Streams": {
         "type": "Transitive",
-        "resolved": "2.12.87",
-        "contentHash": "oDKOeKZ865I5X8qmU3IXMyrAnssYEiYWTobPGdrqubN3RtTzEHIv+D6fwhdcfrdhPJzHjCkK/ORztR/IsnmA6g==",
+        "resolved": "2.13.16",
+        "contentHash": "GjifQ5M4IpQWjGNNbIrsj8M/M7ESb2328OeoGeqxk5rOJiuaAJ5zFc6CyqB+5UWKr1KEGK23hKoxA+z1gooAKA==",
         "dependencies": {
           "Microsoft.VisualStudio.Threading.Only": "17.13.61",
           "Microsoft.VisualStudio.Validation": "17.8.8"
@@ -695,6 +711,11 @@
         "resolved": "8.6.6",
         "contentHash": "lCBL9mmhF9TZxHG3beVRkyjlLohkIC464xIAq7J7Y59C+z42hmsdUaeCKl2SIAYertOUU5TeBXyQDLDQGIKePQ=="
       },
+      "PolyType": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "GFdJvsN/VczpP0GfdPIi0jDudGH2Emk3rcIJHdqwU2SL2zQm1xSl6OTYvQSUxvzHu3ClWo096ICdWXVkpifQUA=="
+      },
       "Semver": {
         "type": "Transitive",
         "resolved": "3.0.0",
@@ -715,13 +736,14 @@
       },
       "StreamJsonRpc": {
         "type": "Transitive",
-        "resolved": "2.22.23",
-        "contentHash": "Ahq6uUFPnU9alny5h4agyX74th3PRq3NQCRNaDOqWcx20WT06mH/wENSk5IbHDc8BmfreQVEIBx5IXLBbsLFIA==",
+        "resolved": "2.25.29",
+        "contentHash": "ebP0ScWRtbd1EWayLRJ6bjM7aPwYZoJIIU1DApmn/cYl2dydR9f4p6Mj3eY77qzAywy6IbZWB9sJPSWeO5hmrg==",
         "dependencies": {
-          "MessagePack": "2.5.192",
-          "Microsoft.VisualStudio.Threading.Only": "17.13.61",
-          "Microsoft.VisualStudio.Validation": "17.8.8",
-          "Nerdbank.Streams": "2.12.87",
+          "MessagePack": "2.5.302",
+          "Microsoft.VisualStudio.Threading.Only": "17.14.15",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "Nerdbank.MessagePack": "1.2.4",
+          "Nerdbank.Streams": "2.13.16",
           "Newtonsoft.Json": "13.0.3"
         }
       },

--- a/src/BridgeBeats.Contracts/BridgeBeats.Contracts.csproj
+++ b/src/BridgeBeats.Contracts/BridgeBeats.Contracts.csproj
@@ -14,8 +14,8 @@
 
   <!-- Shared package dependency for ATProto records - provides AtProtoRecord base class -->
   <ItemGroup>
-    <PackageReference Include="idunno.AtProto" Version="2.0.0" />
-    <PackageReference Include="idunno.Bluesky" Version="2.0.0" />
+    <PackageReference Include="idunno.AtProto" Version="3.0.0" />
+    <PackageReference Include="idunno.Bluesky" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Contracts/DTOs/MediaLinkResult.cs
+++ b/src/BridgeBeats.Contracts/DTOs/MediaLinkResult.cs
@@ -37,20 +37,15 @@ public sealed class MediaLinkResult {
     public DateTime LookedUpAt { get; init; }
 
     /// <summary>
-    /// <see langword="true"/> when the aggregate is incomplete — some providers were rate-limited
-    /// and have not yet resolved, so <see cref="Results"/> does not cover every expected provider.
+    /// <see langword="true"/> when this API result was returned before its coordinating saga
+    /// finalized and a more complete provider set may follow. This is transient response metadata:
+    /// it is derived from saga state and is never persisted to the PDS record.
     /// </summary>
-    /// <remarks>
-    /// When <see langword="true"/>, <see cref="RateLimitedProviders"/> lists the providers that were
-    /// rate-limited and will be retried later; the result may be updated when those providers
-    /// complete.
-    /// </remarks>
     public bool IsPartial { get; set; }
 
     /// <summary>
     /// Providers currently rate-limited and therefore not yet resolved, or <see langword="null"/>
-    /// when none are rate-limited. Only populated when <see cref="IsPartial"/> is
-    /// <see langword="true"/>.
+    /// when none are rate-limited.
     /// </summary>
     public List<SupportedProviders>? RateLimitedProviders { get; set; }
 

--- a/src/BridgeBeats.Contracts/Interfaces/ILookupProgressProbe.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/ILookupProgressProbe.cs
@@ -1,0 +1,20 @@
+namespace BridgeBeats.Contracts.Interfaces;
+
+/// <summary>
+/// Reports whether a non-finalized saga exists for a given lookup key. Used at render time to
+/// decide whether to show a "lookup in progress" indicator on a result card.
+/// </summary>
+public interface ILookupProgressProbe {
+
+    /// <summary>
+    /// Returns <see langword="true"/> when a non-finalized saga exists for the key, indicating
+    /// the lookup is still in progress.
+    /// </summary>
+    /// <param name="lookupKey">The normalized lookup key to probe (for example <c>IsrcLookup:USRC12345678</c>).</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>
+    /// <see langword="true"/> when a saga for the key is active and not yet finalized;
+    /// <see langword="false"/> otherwise.
+    /// </returns>
+    Task<bool> IsActiveAsync( string lookupKey, CancellationToken ct = default );
+}

--- a/src/BridgeBeats.Contracts/Records/LookupResult.cs
+++ b/src/BridgeBeats.Contracts/Records/LookupResult.cs
@@ -22,10 +22,11 @@ public sealed record LookupResult {
 
     /// <summary>
     /// <see langword="true"/> when this result is partial, meaning not every provider has
-    /// responded yet and a more complete result may follow.
+    /// responded yet and a more complete result may follow. Derived from <see cref="SagaId"/>:
+    /// a result is partial if and only if it has a non-empty saga identifier.
     /// </summary>
     [JsonPropertyName( "isPartial" )]
-    public bool IsPartial { get; init; }
+    public bool IsPartial => !string.IsNullOrEmpty( SagaId );
 
     /// <summary>The identifier of the saga coordinating this lookup, when one is in play.</summary>
     [JsonPropertyName( "sagaId" )]

--- a/src/BridgeBeats.Contracts/Records/MediaLinkResultRecord.cs
+++ b/src/BridgeBeats.Contracts/Records/MediaLinkResultRecord.cs
@@ -23,17 +23,14 @@ public sealed record MediaLinkResultRecord : AtProtoRecord {
     /// </summary>
     /// <param name="results">The per-provider result rows that make up this lookup.</param>
     /// <param name="lookedUpAt">The absolute instant the lookup was performed.</param>
-    /// <param name="isPartial"><see langword="true"/> when not every provider contributed a result; defaults to <see langword="false"/>.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="results"/> is <see langword="null"/>.</exception>
     [JsonConstructor]
     public MediaLinkResultRecord(
         ICollection<ProviderResultRecord> results,
-        DateTimeOffset lookedUpAt,
-        bool isPartial = false
+        DateTimeOffset lookedUpAt
     ) : base( ) {
         Results = results ?? throw new ArgumentNullException( nameof( results ) );
         LookedUpAt = lookedUpAt;
-        IsPartial = isPartial;
     }
 
     /// <summary>The per-provider result rows captured for this lookup; see <see cref="ProviderResultRecord"/>.</summary>
@@ -45,12 +42,4 @@ public sealed record MediaLinkResultRecord : AtProtoRecord {
     [JsonPropertyName( "lookedUpAt" )]
     [JsonRequired]
     public DateTimeOffset LookedUpAt { get; init; }
-
-    /// <summary>
-    /// <see langword="true"/> when the persisted result is partial (not every provider responded).
-    /// Omitted from JSON when <see langword="false"/> so existing records remain unchanged.
-    /// </summary>
-    [JsonPropertyName( "isPartial" )]
-    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingDefault )]
-    public bool IsPartial { get; init; }
 }

--- a/src/BridgeBeats.Contracts/packages.lock.json
+++ b/src/BridgeBeats.Contracts/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "idunno.AtProto": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
@@ -16,22 +16,22 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Http": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.Bluesky": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "DnsClient": {
@@ -65,10 +65,10 @@
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Security.Ssrf": {
@@ -88,6 +88,11 @@
         "dependencies": {
           "Microsoft.Net.Http.Headers": "10.0.0"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -261,32 +266,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Net.Http.Headers": {
@@ -299,35 +305,35 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.15.3",
-        "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
+        "resolved": "1.16.0",
+        "contentHash": "nE/Px3MUvQC8c0UG0DOP5OJE7vMtiMaPYi/6TkSS/o/O0s/oPq+8WaPYTVEPzb7lwu/QyLgknc+sFm2FjPXe2A==",
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.16.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.15.3",
-        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+        "resolved": "1.16.0",
+        "contentHash": "WZP8Eb6vZTeNqeV+fjBitc7iefBoTHIhaWorqg/h/YiQBlcQJu0bICuTqKV0XRyjiE0eWs80yLlnUtHAFSkFWA=="
       },
       "OpenTelemetry.Api.ProviderBuilderExtensions": {
         "type": "Transitive",
-        "resolved": "1.15.3",
-        "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
+        "resolved": "1.16.0",
+        "contentHash": "hZwaHAkXvUNn9+cS+vEvYBgIrIQOQRz2cIRUODZ5gxHsDsLeNCueLgZFkybopjE0jUhLut6lm5eL3LTqbW0hMg==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "OpenTelemetry.Api": "1.15.3"
+          "OpenTelemetry.Api": "1.16.0"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.15.3",
-        "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
+        "resolved": "1.16.0",
+        "contentHash": "/YfrO5MRaA156vhNanYGPX2JjOwKUrA0+Jf7ltT2eD3VkfHqXcEJY5Oxt/nWH8lqBOTc1nJpn2soBtD5Cml8Dg==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "OpenTelemetry": "1.15.3"
+          "OpenTelemetry": "1.16.0"
         }
       },
       "PeterO.Cbor": {
@@ -351,8 +357,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -368,6 +374,7 @@
         "resolved": "0.8.8",
         "contentHash": "UIDFkA5DC3en3tOJ3Mof11yBx9kUQLsaeo/oFdvN6Bbkr9E9+VCqfIadHci8cu+I51K2Sl7XYWVl2R/mA75NBQ=="
       }
-    }
+    },
+    "net10.0/osx-arm64": {}
   }
 }

--- a/src/BridgeBeats.Core/BridgeBeats.Core.csproj
+++ b/src/BridgeBeats.Core/BridgeBeats.Core.csproj
@@ -15,25 +15,25 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="idunno.Security.Ssrf" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="idunno.Security.Ssrf" Version="5.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.3" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
     <PackageReference Include="QRCoder" Version="1.8.0" />
   </ItemGroup>
 

--- a/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
@@ -304,6 +304,14 @@ public static class ServiceExtensions {
                     s.GetRequiredService<ILogger<CachingMediaLinkService>>( )
                 )
             );
+
+            // Register the saga-backed progress probe
+            _ = services.AddTransient<ILookupProgressProbe>( s =>
+                new LookupProgressProbe(
+                    s.GetRequiredService<ISagaStateManager>( ),
+                    s.GetRequiredService<ILogger<LookupProgressProbe>>( )
+                )
+            );
         } else {
             // Use default (non-caching) service
             _ = services.AddTransient<IMediaLinkService>( s => {
@@ -315,6 +323,9 @@ public static class ServiceExtensions {
                     s.GetRequiredService<JsonSerializerOptions>( )
                 );
             } );
+
+            // Register the no-op probe for the non-caching path (no sagas)
+            _ = services.AddTransient<ILookupProgressProbe>( _ => new NullLookupProgressProbe( ) );
         }
 
         return services;

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/CachingMediaLinkService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/CachingMediaLinkService.cs
@@ -94,8 +94,8 @@ public sealed partial class CachingMediaLinkService(
     /// <see cref="MediaLinkResult"/>, attaching messages that explain a partial outcome. When the
     /// result has no payload but providers are rate-limited, a results-less placeholder carrying
     /// rate-limit messages is returned; when there is no payload and no rate limits, returns
-    /// <see langword="null"/>. When a payload exists and the lookup is partial, it is flagged partial
-    /// and annotated with either per-provider rate-limit messages or a generic "still fetching" note.
+    /// <see langword="null"/>. When a payload exists and the lookup is partial, it is annotated with
+    /// either per-provider rate-limit messages or a generic "still fetching" note.
     /// </summary>
     /// <param name="lookupResult">The orchestrator outcome to translate.</param>
     /// <returns>The annotated result, or <see langword="null"/> when there is nothing to return.</returns>
@@ -123,7 +123,8 @@ public sealed partial class CachingMediaLinkService(
         }
 
         if (lookupResult.IsPartial) {
-            // Keep the DTO honest for downstream consumers (web UI, bot, cache)
+            // IsPartial is API-only response metadata. ATProtoStorageService deliberately omits
+            // it when mapping MediaLinkResult to the persisted PDS record.
             lookupResult.Result.IsPartial = true;
             lookupResult.Result.Messages ??= [];
 

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
@@ -162,10 +162,10 @@ public sealed partial class LookupOrchestrator(
     /// <returns>The lookup outcome, possibly partial.</returns>
     public async Task<LookupResult> LookupByMetadataAsync( string title, string artist ) {
         if (string.IsNullOrWhiteSpace( title ) || string.IsNullOrWhiteSpace( artist )) {
-            return new LookupResult { Result = null, IsPartial = false };
+            return new LookupResult { Result = null };
         }
 
-        string lookupKey = $"{LookupRequestType.SongLookup}:{title.Trim().ToUpperInvariant()}:{artist.Trim().ToUpperInvariant()}";
+        string lookupKey = LookupKeyBuilder.MetadataKey( title, artist );
 
         return await PerformLookupAsync(
             lookupKey: lookupKey,
@@ -186,11 +186,11 @@ public sealed partial class LookupOrchestrator(
     /// <returns>The lookup outcome, possibly partial.</returns>
     public async Task<LookupResult> LookupByIsrcAsync( string isrc ) {
         if (string.IsNullOrWhiteSpace( isrc )) {
-            return new LookupResult { Result = null, IsPartial = false };
+            return new LookupResult { Result = null };
         }
 
         string normalizedIsrc = isrc.Trim( ).ToUpperInvariant( );
-        string lookupKey = $"{LookupRequestType.IsrcLookup}:{normalizedIsrc}";
+        string lookupKey = LookupKeyBuilder.IsrcKey( isrc );
 
         return await PerformLookupAsync(
             lookupKey: lookupKey,
@@ -209,11 +209,11 @@ public sealed partial class LookupOrchestrator(
     /// <returns>The lookup outcome, possibly partial.</returns>
     public async Task<LookupResult> LookupByUpcAsync( string upc ) {
         if (string.IsNullOrWhiteSpace( upc )) {
-            return new LookupResult { Result = null, IsPartial = false };
+            return new LookupResult { Result = null };
         }
 
         string normalizedUpc = upc.Trim( );
-        string lookupKey = $"{LookupRequestType.UpcLookup}:{normalizedUpc}";
+        string lookupKey = LookupKeyBuilder.UpcKey( upc );
 
         return await PerformLookupAsync(
             lookupKey: lookupKey,
@@ -236,7 +236,7 @@ public sealed partial class LookupOrchestrator(
     /// <returns>The lookup outcome, possibly partial.</returns>
     public async Task<LookupResult> LookupByProviderIdAsync( string providerId, SupportedProviders provider, bool isAlbum ) {
         if (string.IsNullOrWhiteSpace( providerId )) {
-            return new LookupResult { Result = null, IsPartial = false };
+            return new LookupResult { Result = null };
         }
 
         string normalizedId = providerId.Trim( );
@@ -265,7 +265,7 @@ public sealed partial class LookupOrchestrator(
     private async Task<LookupResult> LookupByUrlAsync( string url, SupportedProviders provider, TimeSpan? waitBudget = null ) {
         string lookupKey = LookupKeyBuilder.UrlKey( url );
 
-        return await PerformLookupAsync(
+        LookupResult lookupResult = await PerformLookupAsync(
             lookupKey: lookupKey,
             lookupType: LookupRequestType.UriLookup,
             lookupValue: url,
@@ -274,6 +274,20 @@ public sealed partial class LookupOrchestrator(
             initialProvider: provider,
             waitBudget: waitBudget
         );
+
+        // Input links are intentionally absent from PDS records. Restore the submitted URL on
+        // the response so Web can reconstruct the same saga key for its render-time progress
+        // probe, and so caching-path results preserve the same input-link contract as the direct
+        // resolver path.
+        if (lookupResult.Result is not null) {
+            // The controller probes InputLinks[0], so make the URL for this specific lookup the
+            // leading entry even if a reused in-memory result already carries another alias.
+            _ = lookupResult.Result.InputLinks.RemoveAll(
+                input => input.Equals( url, StringComparison.OrdinalIgnoreCase ) );
+            lookupResult.Result.InputLinks.Insert( 0, url );
+        }
+
+        return lookupResult;
     }
 
     /// <summary>
@@ -307,15 +321,17 @@ public sealed partial class LookupOrchestrator(
     ) {
         TimeSpan waitTimeout = waitBudget ?? _interactiveWaitTimeout;
 
-        // Check cache. Freshness is age-only (RedisMediaLinkCache.CheckRecordFreshness
-        // checks LookedUpAt against the configured window; IsPartial is not consulted).
+        // Check cache. Freshness is age-only (RedisMediaLinkCache.CheckRecordFreshness checks
+        // LookedUpAt against the configured window). PDS/cache reads carry no persisted partial
+        // flag and are assumed final. A partial saga generation can be visible briefly before its
+        // deterministic record is replaced by the final generation; that bounded consistency
+        // window is an accepted tradeoff for avoiding a saga read on every fresh cache hit.
         (MediaLinkResult result, string recordUri, bool isStale)? cached = await cacheCheck( );
 
         if (cached.HasValue && !cached.Value.isStale) {
             LogCacheHit( _logger, lookupKey );
             return new LookupResult {
-                Result = cached.Value.result,
-                IsPartial = cached.Value.result.IsPartial
+                Result = cached.Value.result
             };
         }
 
@@ -353,18 +369,17 @@ public sealed partial class LookupOrchestrator(
                 return await WaitForFinalResultAsync( lookupKey, inFlightSagaId, resultUri, deadline );
             }
 
-            // Timeout or failure - check cache again, might have been populated
+            // Timeout or failure - check cache again, might have been populated.
+            // A cache-served result is always final; no live saga reference is attached.
             cached = await cacheCheck( );
             if (cached.HasValue) {
                 return new LookupResult {
-                    Result = cached.Value.result,
-                    IsPartial = cached.Value.result.IsPartial,
-                    SagaId = cached.Value.result.IsPartial ? inFlightSagaId : null
+                    Result = cached.Value.result
                 };
             }
 
             // Still nothing, return null
-            return new LookupResult { Result = null, IsPartial = false };
+            return new LookupResult { Result = null };
         }
 
         try {
@@ -420,7 +435,7 @@ public sealed partial class LookupOrchestrator(
         // Generate deterministic saga ID from lookup key
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
 
-        // Create saga (or resume an in-progress one, e.g. when a cached partial sent us back here)
+        // Create a saga, or resume one already started for this deterministic lookup key.
         LookupSagaState saga = await _sagaManager.GetOrCreateAsync( sagaId, lookupKey, lookupType, lookupValue );
 
         DateTimeOffset deadline = DateTimeOffset.UtcNow + waitTimeout;
@@ -503,14 +518,13 @@ public sealed partial class LookupOrchestrator(
         if (storedResultUri is not null) {
             MediaLinkResult? storedResult = await _atProtoStorage.GetMediaLinkResultAsync( storedResultUri );
             return !string.IsNullOrEmpty( saga2!.FinalResultUri )
-                ? new LookupResult { Result = storedResult, IsPartial = false }
+                ? new LookupResult { Result = storedResult }
                 : CreatePartialResult( storedResult, sagaId, saga2 );
         }
 
         // No result yet
         return new LookupResult {
             Result = null,
-            IsPartial = true,
             SagaId = sagaId,
             RateLimitedProviders = GetActiveRateLimits( saga2 )
         };
@@ -548,9 +562,7 @@ public sealed partial class LookupOrchestrator(
             // Saga state missing (expired/deleted) - no saga means no in-progress partial; result is served as final
             if (saga is null) {
                 return new LookupResult {
-                    Result = result,
-                    IsPartial = result?.IsPartial ?? false,
-                    SagaId = result?.IsPartial == true ? sagaId : null
+                    Result = result
                 };
             }
 
@@ -559,8 +571,7 @@ public sealed partial class LookupOrchestrator(
 
             if (isFinal) {
                 return new LookupResult {
-                    Result = result,
-                    IsPartial = false
+                    Result = result
                 };
             }
 
@@ -653,7 +664,6 @@ public sealed partial class LookupOrchestrator(
     private static LookupResult CreatePartialResult( MediaLinkResult? result, string sagaId, LookupSagaState? saga )
         => new( ) {
             Result = result,
-            IsPartial = true,
             SagaId = sagaId,
             RateLimitedProviders = GetActiveRateLimits( saga )
         };

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
@@ -307,8 +307,8 @@ public sealed partial class LookupOrchestrator(
     ) {
         TimeSpan waitTimeout = waitBudget ?? _interactiveWaitTimeout;
 
-        // Check cache. Partial results are reported stale by the cache so they
-        // fall through to the dedup/wait logic below instead of masquerading as final.
+        // Check cache. Freshness is age-only (RedisMediaLinkCache.CheckRecordFreshness
+        // checks LookedUpAt against the configured window; IsPartial is not consulted).
         (MediaLinkResult result, string recordUri, bool isStale)? cached = await cacheCheck( );
 
         if (cached.HasValue && !cached.Value.isStale) {
@@ -545,7 +545,7 @@ public sealed partial class LookupOrchestrator(
 
             MediaLinkResult? result = await _atProtoStorage.GetMediaLinkResultAsync( resultUri );
 
-            // Saga state missing (expired/deleted) - trust the stored result's own flag
+            // Saga state missing (expired/deleted) - no saga means no in-progress partial; result is served as final
             if (saga is null) {
                 return new LookupResult {
                     Result = result,

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupProgressProbe.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupProgressProbe.cs
@@ -1,0 +1,70 @@
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using Microsoft.Extensions.Logging;
+
+namespace BridgeBeats.Core.Domain.Services.LinkResolver;
+
+/// <summary>
+/// Caching-path implementation of <see cref="ILookupProgressProbe"/>. Reads the saga state for
+/// the given lookup key and returns <see langword="true"/> only when a saga is present, not yet
+/// complete, and has no finalized result URI — the three conditions that together identify an
+/// actively running lookup rather than a finalizing or finalized one.
+/// </summary>
+/// <remarks>
+/// The predicate guards against two false-positive cases a naive null-check would miss:
+/// <list type="bullet">
+///   <item><description>
+///     A saga that is complete (all providers have reported in) but whose PDS write is still
+///     in flight. <see cref="LookupSagaState.IsComplete"/> is already true at that point, so
+///     the predicate returns <see langword="false"/>.
+///   </description></item>
+///   <item><description>
+///     A saga that has a finalized result URI set. The check on
+///     <see cref="LookupSagaState.FinalResultUri"/> ensures lingering saga rows after cleanup
+///     races do not trigger the indicator.
+///   </description></item>
+/// </list>
+/// On a transient saga-store fault the probe returns <see langword="false"/> (cannot determine
+/// → not in progress), matching the design's graceful-degradation intent. The fault is logged
+/// at <see cref="LogLevel.Warning"/> so it surfaces in monitoring without disrupting the render.
+/// </remarks>
+/// <param name="sagaManager">Used to read saga state by id.</param>
+/// <param name="logger">Used to log saga-store read faults at warning level.</param>
+public sealed class LookupProgressProbe( ISagaStateManager sagaManager, ILogger<LookupProgressProbe> logger ) : ILookupProgressProbe {
+
+    /// <summary>Saga state manager used to read per-lookup progress.</summary>
+    private readonly ISagaStateManager _sagaManager = sagaManager
+                                                    ?? throw new ArgumentNullException( nameof( sagaManager ) );
+
+    /// <summary>Logger used to record transient saga-store read faults.</summary>
+    private readonly ILogger<LookupProgressProbe> _logger = logger
+                                                          ?? throw new ArgumentNullException( nameof( logger ) );
+
+    /// <inheritdoc/>
+    public async Task<bool> IsActiveAsync( string lookupKey, CancellationToken ct = default ) {
+        try {
+            LookupSagaState? saga = await _sagaManager.GetAsync(
+                ISagaStateManager.GenerateSagaId( lookupKey ), ct );
+
+            return saga is not null
+                && !saga.IsComplete
+                && string.IsNullOrEmpty( saga.FinalResultUri );
+        } catch (Exception ex) {
+            _logger.LogWarning( ex,
+                "Saga store read failed for lookup key {LookupKey}; reporting not in progress",
+                lookupKey );
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// No-op implementation of <see cref="ILookupProgressProbe"/> for the non-caching path where
+/// sagas do not exist. Always returns <see langword="false"/>.
+/// </summary>
+public sealed class NullLookupProgressProbe : ILookupProgressProbe {
+
+    /// <inheritdoc/>
+    public Task<bool> IsActiveAsync( string lookupKey, CancellationToken ct = default )
+        => Task.FromResult( false );
+}

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupProgressProbe.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupProgressProbe.cs
@@ -1,5 +1,6 @@
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace BridgeBeats.Core.Domain.Services.LinkResolver;
@@ -27,6 +28,7 @@ namespace BridgeBeats.Core.Domain.Services.LinkResolver;
 /// On a transient saga-store fault the probe returns <see langword="false"/> (cannot determine
 /// → not in progress), matching the design's graceful-degradation intent. The fault is logged
 /// at <see cref="LogLevel.Warning"/> so it surfaces in monitoring without disrupting the render.
+/// Cancellation also returns <see langword="false"/>, but is not logged as a store fault.
 /// </remarks>
 /// <param name="sagaManager">Used to read saga state by id.</param>
 /// <param name="logger">Used to log saga-store read faults at warning level.</param>
@@ -42,17 +44,23 @@ public sealed class LookupProgressProbe( ISagaStateManager sagaManager, ILogger<
 
     /// <inheritdoc/>
     public async Task<bool> IsActiveAsync( string lookupKey, CancellationToken ct = default ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+
         try {
-            LookupSagaState? saga = await _sagaManager.GetAsync(
-                ISagaStateManager.GenerateSagaId( lookupKey ), ct );
+            LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
             return saga is not null
                 && !saga.IsComplete
                 && string.IsNullOrEmpty( saga.FinalResultUri );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Request and host cancellation are expected lifecycle events. Stop the store read and
+            // degrade quietly rather than converting shutdown into a render failure.
+            return false;
         } catch (Exception ex) {
+            string sanitizedSagaId = sagaId.SanitizeForLogging( );
             _logger.LogWarning( ex,
-                "Saga store read failed for lookup key {LookupKey}; reporting not in progress",
-                lookupKey );
+                "Saga store read failed for saga {SagaId}; reporting not in progress",
+                sanitizedSagaId );
             return false;
         }
     }

--- a/src/BridgeBeats.Core/Domain/Utilities/CacheFreshness.cs
+++ b/src/BridgeBeats.Core/Domain/Utilities/CacheFreshness.cs
@@ -1,11 +1,10 @@
 namespace BridgeBeats.Core.Domain.Utilities;
 
 /// <summary>
-/// The staleness predicate for the bulk refresh sweep (and any future interactive force-refresh
-/// that opts in). This is not repo-wide: the interactive read cache (<c>RedisMediaLinkCache</c>)
-/// keeps its own separate IsPartial-as-stale rule; this predicate governs only the refresh sweep's
-/// age-only selection. Staleness is AGE-ONLY: a record's partial-ness is deliberately NOT a
-/// staleness trigger, so a record can never be re-attempted more than once per freshness window
+/// The staleness predicate used across the codebase. Staleness is AGE-ONLY throughout: both the
+/// bulk refresh sweep and the interactive read cache (<c>RedisMediaLinkCache.CheckRecordFreshness</c>)
+/// apply the same age-only rule. A record's partial-ness is deliberately NOT a staleness trigger
+/// in either path, so a record can never be re-attempted more than once per freshness window
 /// (see remarks).
 /// </summary>
 /// <remarks>

--- a/src/BridgeBeats.Core/Domain/Utilities/CacheFreshness.cs
+++ b/src/BridgeBeats.Core/Domain/Utilities/CacheFreshness.cs
@@ -1,11 +1,11 @@
 namespace BridgeBeats.Core.Domain.Utilities;
 
 /// <summary>
-/// The staleness predicate used across the codebase. Staleness is AGE-ONLY throughout: both the
-/// bulk refresh sweep and the interactive read cache (<c>RedisMediaLinkCache.CheckRecordFreshness</c>)
-/// apply the same age-only rule. A record's partial-ness is deliberately NOT a staleness trigger
-/// in either path, so a record can never be re-attempted more than once per freshness window
-/// (see remarks).
+/// Defines the age-only staleness rule used by the bulk refresh sweep. The interactive read cache
+/// applies the equivalent age comparison in <c>RedisMediaLinkCache.CheckRecordFreshness</c> rather
+/// than calling this helper directly. A record's partial-ness is deliberately NOT a staleness
+/// trigger in either path, so a record can never be re-attempted more than once per freshness
+/// window (see remarks).
 /// </summary>
 /// <remarks>
 /// Partial-ness was previously an <c>||</c> term here. It was removed because a record a provider can

--- a/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Cache/RedisMediaLinkCache.cs
@@ -530,19 +530,17 @@ public sealed partial class RedisMediaLinkCache : IMediaLinkCacheRepository {
 
     /// <summary>
     /// Checks if a result is stale based on the cache days configuration.
-    /// Partial results are always stale-eligible so callers re-enter the lookup path
-    /// and wait for the complete result instead of serving the partial as final.
     /// </summary>
     /// <param name="result">The fetched result.</param>
     /// <param name="recordUri">The record URI it came from.</param>
     /// <returns>The result, its URI, and a staleness flag.</returns>
-    /// <remarks>A record is stale when it is partial or its last-looked-up time is older than the configured cache window.</remarks>
+    /// <remarks>A record is stale when its last-looked-up time is older than the configured cache window.</remarks>
     private (MediaLinkResult result, string recordUri, bool isStale) CheckRecordFreshness(
         MediaLinkResult result,
         string recordUri
     ) {
         DateTime expirationDate = DateTime.UtcNow.AddDays( -_cacheDays );
-        bool isStale = result.IsPartial || result.LookedUpAt < expirationDate;
+        bool isStale = result.LookedUpAt < expirationDate;
         return (result, recordUri, isStale);
     }
 

--- a/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Storage/ATProtoStorageService.cs
@@ -203,8 +203,7 @@ public partial class ATProtoStorageService(
 
         return new MediaLinkResultRecord(
             results: providerResults,
-            lookedUpAt: DateTimeOffset.UtcNow,
-            isPartial: result.IsPartial
+            lookedUpAt: DateTimeOffset.UtcNow
         );
     }
 
@@ -217,8 +216,7 @@ public partial class ATProtoStorageService(
     /// <remarks>Input links are not stored in PDS records, only provider results.</remarks>
     private static MediaLinkResult? ConvertFromRecord( MediaLinkResultRecord record ) {
         MediaLinkResult result = new( ) {
-            LookedUpAt = record.LookedUpAt.UtcDateTime,
-            IsPartial = record.IsPartial
+            LookedUpAt = record.LookedUpAt.UtcDateTime
         };
 
         foreach (ProviderResultRecord providerResult in record.Results) {

--- a/src/BridgeBeats.Core/Infrastructure/Utilities/LookupKeyBuilder.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Utilities/LookupKeyBuilder.cs
@@ -44,4 +44,36 @@ public static class LookupKeyBuilder {
     public static string UrlKey( string url ) {
         return $"{LookupRequestType.UriLookup}:{HashUtility.HashUrl( url )}";
     }
+
+    /// <summary>
+    /// Builds the cache and saga lookup key for an ISRC lookup. The ISRC is trimmed and
+    /// upper-cased — byte-identical to the orchestrator's inline normalization.
+    /// </summary>
+    /// <param name="isrc">The raw ISRC value.</param>
+    /// <returns>A key of the form <c>IsrcLookup:{ISRC}</c>.</returns>
+    public static string IsrcKey( string isrc ) {
+        return $"{LookupRequestType.IsrcLookup}:{isrc.Trim( ).ToUpperInvariant( )}";
+    }
+
+    /// <summary>
+    /// Builds the cache and saga lookup key for a UPC lookup. The UPC is trimmed only (no
+    /// upper-casing) — byte-identical to the orchestrator's inline normalization.
+    /// </summary>
+    /// <param name="upc">The raw UPC value.</param>
+    /// <returns>A key of the form <c>UpcLookup:{UPC}</c>.</returns>
+    public static string UpcKey( string upc ) {
+        return $"{LookupRequestType.UpcLookup}:{upc.Trim( )}";
+    }
+
+    /// <summary>
+    /// Builds the cache and saga lookup key for a metadata (title/artist) lookup. Both title
+    /// and artist are trimmed and upper-cased — byte-identical to the orchestrator's inline
+    /// normalization.
+    /// </summary>
+    /// <param name="title">The raw track or album title.</param>
+    /// <param name="artist">The raw artist name.</param>
+    /// <returns>A key of the form <c>SongLookup:{TITLE}:{ARTIST}</c>.</returns>
+    public static string MetadataKey( string title, string artist ) {
+        return $"{LookupRequestType.SongLookup}:{title.Trim( ).ToUpperInvariant( )}:{artist.Trim( ).ToUpperInvariant( )}";
+    }
 }

--- a/src/BridgeBeats.Core/packages.lock.json
+++ b/src/BridgeBeats.Core/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Direct",
-        "requested": "[13.4.3, )",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -23,68 +23,68 @@
       },
       "idunno.Security.Ssrf": {
         "type": "Direct",
-        "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "requested": "[5.4.0, )",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "NxgqhpB89S6BViMku9B476KopBumtk0IQ4/iVn2GeeUBW9SyzLvWwOR0zPgcooAtRlR0UVzXkaUs71gYHSAbHg==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "BsvxiKcy8k4/ijAPitmwKG1mlVsdC2lQtFLP28K2N8PlsGYbqPFOyfJ7p2kWil3gM6xXgQGf8Hz/pJB8ej+Dug==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Microsoft.Build.Framework": "18.0.2",
           "Microsoft.CodeAnalysis.CSharp": "5.0.0",
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
           "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "Mono.TextTemplating": "3.0.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
-        "requested": "[10.7.0, )",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Direct",
-        "requested": "[10.7.0, )",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
@@ -107,29 +107,29 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Direct",
-        "requested": "[1.15.2, )",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Direct",
-        "requested": "[1.15.1, )",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Direct",
-        "requested": "[1.15.1, )",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "QRCoder": {
@@ -217,36 +217,41 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -315,144 +320,145 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.VisualStudio.SolutionPersistence": {
@@ -601,8 +607,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -722,8 +728,28 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Web/BridgeBeats.Web.csproj
+++ b/src/BridgeBeats.Web/BridgeBeats.Web.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="3.7.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.8.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
+++ b/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
@@ -30,6 +30,7 @@ namespace BridgeBeats.Web.Controllers;
 /// <param name="jwtHandler">Optional Apple Music JWT handler that produces the developer token; when null, Apple Music is not configured.</param>
 /// <param name="cardService">Optional Open Graph card service used to store lookup results and produce shareable card URLs.</param>
 /// <param name="cacheRepository">Optional cache repository used to resolve the ATProto URI for a result.</param>
+/// <param name="probe">Optional saga-progress probe used to set the "lookup in progress" indicator on result cards; when null, the indicator is never shown.</param>
 [Authorize]
 public partial class AppleMusicController(
     UserManager<ApplicationUser> userManager,
@@ -39,7 +40,8 @@ public partial class AppleMusicController(
     ICompositeViewEngine viewEngine,
     AppleJwtHandler? jwtHandler = null,
     IOpenGraphCardService? cardService = null,
-    IMediaLinkCacheRepository? cacheRepository = null
+    IMediaLinkCacheRepository? cacheRepository = null,
+    ILookupProgressProbe? probe = null
 ) : Controller {
 
     /// <summary>
@@ -447,13 +449,19 @@ public partial class AppleMusicController(
 
                 string? atProtoUri = await GetATProtoUriFromCache( lookupResult );
 
+                string appleProbeKey = LookupKeyBuilder.TypedKey(
+                    LookupRequestType.SongIdLookup, SupportedProviders.AppleMusic, songId.Trim( ) );
+                bool appleIsInProgress = probe is not null
+                    && await probe.IsActiveAsync( appleProbeKey );
+
                 MusicLookupViewModel.MusicLookupResultItem item = new( )
                 {
                     CardUrl = cardUrl,
                     ATProtoUri = atProtoUri,
                     Result = lookupResult,
                     PrimaryProvider = primaryProvider,
-                    PrimaryResult = primaryResult
+                    PrimaryResult = primaryResult,
+                    IsLookupInProgress = appleIsInProgress
                 };
 
                 string html = await RenderViewToStringAsync( "_LookupResultCard", item );

--- a/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
+++ b/src/BridgeBeats.Web/Controllers/AppleMusicController.cs
@@ -452,7 +452,7 @@ public partial class AppleMusicController(
                 string appleProbeKey = LookupKeyBuilder.TypedKey(
                     LookupRequestType.SongIdLookup, SupportedProviders.AppleMusic, songId.Trim( ) );
                 bool appleIsInProgress = probe is not null
-                    && await probe.IsActiveAsync( appleProbeKey );
+                    && await probe.IsActiveAsync( appleProbeKey, HttpContext.RequestAborted );
 
                 MusicLookupViewModel.MusicLookupResultItem item = new( )
                 {

--- a/src/BridgeBeats.Web/Controllers/HomeController.cs
+++ b/src/BridgeBeats.Web/Controllers/HomeController.cs
@@ -104,7 +104,7 @@ namespace BridgeBeats.Web.Controllers {
                     ? LookupKeyBuilder.UrlKey( result.InputLinks[0] )
                     : null;
                 bool isLookupInProgress = urlProbeKey is not null && probe is not null
-                    && await probe.IsActiveAsync( urlProbeKey );
+                    && await probe.IsActiveAsync( urlProbeKey, HttpContext.RequestAborted );
 
                 viewModel.Items.Add( new MusicLookupViewModel.MusicLookupResultItem {
                     CardUrl = cardUrl,
@@ -255,7 +255,8 @@ namespace BridgeBeats.Web.Controllers {
             // Get ATProto URI from cache if available
             string? atProtoUri = await GetATProtoUriFromCache( result );
 
-            bool isLookupInProgress = probe is not null && await probe.IsActiveAsync( lookupKey );
+            bool isLookupInProgress = probe is not null
+                && await probe.IsActiveAsync( lookupKey, HttpContext.RequestAborted );
 
             viewModel.Items.Add( new MusicLookupViewModel.MusicLookupResultItem {
                 CardUrl = cardUrl,
@@ -444,7 +445,7 @@ namespace BridgeBeats.Web.Controllers {
                             ? LookupKeyBuilder.UrlKey( result.InputLinks[0] )
                             : null;
                         bool streamIsInProgress = streamProbeKey is not null && probe is not null
-                            && await probe.IsActiveAsync( streamProbeKey );
+                            && await probe.IsActiveAsync( streamProbeKey, HttpContext.RequestAborted );
 
                         // Create single-item model
                         MusicLookupViewModel.MusicLookupResultItem item = new( ) {

--- a/src/BridgeBeats.Web/Controllers/HomeController.cs
+++ b/src/BridgeBeats.Web/Controllers/HomeController.cs
@@ -24,12 +24,14 @@ namespace BridgeBeats.Web.Controllers {
     /// <param name="mediaLinkService">Optional media-link service used to resolve lookups; when null, lookup endpoints report that the service is unavailable.</param>
     /// <param name="cardService">Optional Open Graph card service used to store results and produce shareable card URLs.</param>
     /// <param name="cacheRepository">Optional cache repository used to resolve the ATProto URI for a result.</param>
+    /// <param name="probe">Optional saga-progress probe used to set the "lookup in progress" indicator on result cards; when null, the indicator is never shown.</param>
     public partial class HomeController(
         ILogger<HomeController> logger,
         ICompositeViewEngine viewEngine,
         IMediaLinkService? mediaLinkService = null,
         IOpenGraphCardService? cardService = null,
-        IMediaLinkCacheRepository? cacheRepository = null
+        IMediaLinkCacheRepository? cacheRepository = null,
+        ILookupProgressProbe? probe = null
     ) : Controller {
 
         /// <summary>
@@ -98,12 +100,19 @@ namespace BridgeBeats.Web.Controllers {
                 // Get ATProto URI from cache if available
                 string? atProtoUri = await GetATProtoUriFromCache( result );
 
+                string? urlProbeKey = result.InputLinks.Count > 0
+                    ? LookupKeyBuilder.UrlKey( result.InputLinks[0] )
+                    : null;
+                bool isLookupInProgress = urlProbeKey is not null && probe is not null
+                    && await probe.IsActiveAsync( urlProbeKey );
+
                 viewModel.Items.Add( new MusicLookupViewModel.MusicLookupResultItem {
                     CardUrl = cardUrl,
                     ATProtoUri = atProtoUri,
                     Result = result,
                     PrimaryProvider = primaryProvider,
-                    PrimaryResult = primaryResult
+                    PrimaryResult = primaryResult,
+                    IsLookupInProgress = isLookupInProgress
                 } );
             }
 
@@ -138,7 +147,7 @@ namespace BridgeBeats.Web.Controllers {
             }
 
             MediaLinkResult? result = await mediaLinkService.GetInfoByISRCAsync( isrc );
-            return await CreateViewModelFromResult( result, "No results found for ISRC" );
+            return await CreateViewModelFromResult( result, "No results found for ISRC", LookupKeyBuilder.IsrcKey( isrc ) );
         }
 
         /// <summary>
@@ -165,7 +174,7 @@ namespace BridgeBeats.Web.Controllers {
             }
 
             MediaLinkResult? result = await mediaLinkService.GetInfoByUPCAsync( upc );
-            return await CreateViewModelFromResult( result, "No results found for UPC" );
+            return await CreateViewModelFromResult( result, "No results found for UPC", LookupKeyBuilder.UpcKey( upc ) );
         }
 
         /// <summary>
@@ -193,20 +202,22 @@ namespace BridgeBeats.Web.Controllers {
             }
 
             MediaLinkResult? result = await mediaLinkService.GetInfoAsync( title, artist );
-            return await CreateViewModelFromResult( result, "No results found for title/artist" );
+            return await CreateViewModelFromResult( result, "No results found for title/artist", LookupKeyBuilder.MetadataKey( title, artist ) );
         }
 
         /// <summary>
         /// Builds a single-item lookup view model from a resolved result, selecting the primary provider,
-        /// storing an Open Graph card when enabled, and resolving the ATProto URI. Falls back to a message when
-        /// there is no usable result.
+        /// storing an Open Graph card when enabled, resolving the ATProto URI, and probing the saga to
+        /// set the "lookup in progress" indicator. Falls back to a message when there is no usable result.
         /// </summary>
         /// <param name="result">The resolved media-link result, or null when nothing matched.</param>
         /// <param name="noResultsMessage">The message to display when no usable result is present.</param>
+        /// <param name="lookupKey">The normalized lookup key used to probe saga progress.</param>
         /// <returns>The <c>_LookupResults</c> partial view populated with the item or the no-results message.</returns>
         private async Task<IActionResult> CreateViewModelFromResult(
             MediaLinkResult? result,
-            string noResultsMessage
+            string noResultsMessage,
+            string lookupKey
         ) {
             MusicLookupViewModel viewModel = new( );
 
@@ -244,12 +255,15 @@ namespace BridgeBeats.Web.Controllers {
             // Get ATProto URI from cache if available
             string? atProtoUri = await GetATProtoUriFromCache( result );
 
+            bool isLookupInProgress = probe is not null && await probe.IsActiveAsync( lookupKey );
+
             viewModel.Items.Add( new MusicLookupViewModel.MusicLookupResultItem {
                 CardUrl = cardUrl,
                 ATProtoUri = atProtoUri,
                 Result = result,
                 PrimaryProvider = primaryProvider,
-                PrimaryResult = primaryResult
+                PrimaryResult = primaryResult,
+                IsLookupInProgress = isLookupInProgress
             } );
 
             return PartialView( "_LookupResults", viewModel );
@@ -426,13 +440,20 @@ namespace BridgeBeats.Web.Controllers {
                         // Get ATProto URI from cache if available
                         string? atProtoUri = await GetATProtoUriFromCache( result );
 
+                        string? streamProbeKey = result.InputLinks.Count > 0
+                            ? LookupKeyBuilder.UrlKey( result.InputLinks[0] )
+                            : null;
+                        bool streamIsInProgress = streamProbeKey is not null && probe is not null
+                            && await probe.IsActiveAsync( streamProbeKey );
+
                         // Create single-item model
                         MusicLookupViewModel.MusicLookupResultItem item = new( ) {
                             CardUrl = cardUrl,
                             ATProtoUri = atProtoUri,
                             Result = result,
                             PrimaryProvider = primaryProvider,
-                            PrimaryResult = primaryResult
+                            PrimaryResult = primaryResult,
+                            IsLookupInProgress = streamIsInProgress
                         };
 
                         // Render partial view to string and stream it

--- a/src/BridgeBeats.Web/Controllers/HomeController.cs
+++ b/src/BridgeBeats.Web/Controllers/HomeController.cs
@@ -67,9 +67,14 @@ namespace BridgeBeats.Web.Controllers {
 
             // Perform lookup server-side and collect all results
             MusicLookupViewModel viewModel = new( );
+            List<string> placeholderMessages = [];
             await foreach (MediaLinkResult result in mediaLinkService.GetInfoAsync( uri )) {
                 if (result.Results.Count == 0) {
-                    continue; // Skip empty results
+                    if (result.Messages is { Count: > 0 }) {
+                        placeholderMessages.AddRange(
+                            result.Messages.Where( message => !string.IsNullOrWhiteSpace( message ) ) );
+                    }
+                    continue;
                 }
 
                 // Find primary result
@@ -117,7 +122,9 @@ namespace BridgeBeats.Web.Controllers {
             }
 
             if (viewModel.Items.Count == 0) {
-                viewModel.Message = "No results found";
+                viewModel.Message = placeholderMessages.Count > 0
+                    ? string.Join( " ", placeholderMessages )
+                    : "No results found";
             }
 
             return PartialView( "_LookupResults", viewModel );
@@ -208,7 +215,8 @@ namespace BridgeBeats.Web.Controllers {
         /// <summary>
         /// Builds a single-item lookup view model from a resolved result, selecting the primary provider,
         /// storing an Open Graph card when enabled, resolving the ATProto URI, and probing the saga to
-        /// set the "lookup in progress" indicator. Falls back to a message when there is no usable result.
+        /// set the "lookup in progress" indicator. Preserves provider guidance from result-less placeholders,
+        /// falling back to the supplied no-results message only when no guidance is available.
         /// </summary>
         /// <param name="result">The resolved media-link result, or null when nothing matched.</param>
         /// <param name="noResultsMessage">The message to display when no usable result is present.</param>
@@ -222,7 +230,7 @@ namespace BridgeBeats.Web.Controllers {
             MusicLookupViewModel viewModel = new( );
 
             if (result == null || result.Results.Count == 0) {
-                viewModel.Message = noResultsMessage;
+                viewModel.Message = GetResultMessage( result, noResultsMessage );
                 return PartialView( "_LookupResults", viewModel );
             }
 
@@ -242,7 +250,7 @@ namespace BridgeBeats.Web.Controllers {
             }
 
             if (primaryResult == null) {
-                viewModel.Message = noResultsMessage;
+                viewModel.Message = GetResultMessage( result, noResultsMessage );
                 return PartialView( "_LookupResults", viewModel );
             }
 
@@ -268,6 +276,18 @@ namespace BridgeBeats.Web.Controllers {
             } );
 
             return PartialView( "_LookupResults", viewModel );
+        }
+
+        private static string GetResultMessage( MediaLinkResult? result, string fallback ) {
+            if (result?.Messages is not { Count: > 0 }) {
+                return fallback;
+            }
+
+            string message = string.Join(
+                " ",
+                result.Messages.Where( value => !string.IsNullOrWhiteSpace( value ) )
+            );
+            return string.IsNullOrWhiteSpace( message ) ? fallback : message;
         }
 
         /// <summary>

--- a/src/BridgeBeats.Web/Models/MusicLookupViewModel.cs
+++ b/src/BridgeBeats.Web/Models/MusicLookupViewModel.cs
@@ -45,6 +45,12 @@ namespace BridgeBeats.Web.Models {
             /// The per-provider lookup result for <see cref="PrimaryProvider"/>.
             /// </summary>
             public MusicLookupResult PrimaryResult { get; set; } = null!;
+
+            /// <summary>
+            /// <see langword="true"/> when a non-finalized saga is still active for this result,
+            /// meaning the lookup is in progress and more provider results may arrive.
+            /// </summary>
+            public bool IsLookupInProgress { get; set; }
         }
     }
 }

--- a/src/BridgeBeats.Web/Views/Shared/_LookupResultCard.cshtml
+++ b/src/BridgeBeats.Web/Views/Shared/_LookupResultCard.cshtml
@@ -79,10 +79,10 @@
                 </a>
             }
         </div>
-        @if (Model.Result.IsPartial || Model.Result.Messages is { Count: > 0 }) {
+        @if (Model.IsLookupInProgress || Model.Result.Messages is { Count: > 0 }) {
             <div class="alert alert-warning embed-partial-notice mb-0 mt-2" role="status">
-                @if (Model.Result.IsPartial) {
-                    <strong>Incomplete results</strong>
+                @if (Model.IsLookupInProgress) {
+                    <strong>Still looking up…</strong>
                 }
                 @if (Model.Result.Messages is { Count: > 0 }) {
                     foreach (var message in Model.Result.Messages) {

--- a/src/BridgeBeats.Web/Views/Shared/_LookupResults.cshtml
+++ b/src/BridgeBeats.Web/Views/Shared/_LookupResults.cshtml
@@ -78,10 +78,10 @@
                             </a>
                         }
                     </div>
-                    @if (item.Result.IsPartial || item.Result.Messages is { Count: > 0 }) {
+                    @if (item.IsLookupInProgress || item.Result.Messages is { Count: > 0 }) {
                         <div class="alert alert-warning embed-partial-notice mb-0 mt-2" role="status">
-                            @if (item.Result.IsPartial) {
-                                <strong>Incomplete results</strong>
+                            @if (item.IsLookupInProgress) {
+                                <strong>Still looking up…</strong>
                             }
                             @if (item.Result.Messages is { Count: > 0 }) {
                                 foreach (var message in item.Result.Messages) {

--- a/src/BridgeBeats.Web/packages.lock.json
+++ b/src/BridgeBeats.Web/packages.lock.json
@@ -4,26 +4,26 @@
     "net10.0": {
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[3.7.0, )",
-        "resolved": "3.7.0",
-        "contentHash": "7Ld/wUsxSEKBjAk8nPZ13qkju5kNoh20gf0JHPeHrK41tMZRpIq9amXFAOHncicjg0U5M035I+6/z3cBsYBHfg=="
+        "requested": "[3.8.0, )",
+        "resolved": "3.8.0",
+        "contentHash": "bF+KnfJSd9KLUOZxl07IdhmQcvz/adqU+GVub7+SVOydHpJGOGIWqwngZ3JxgtDpKYRA6vlk+0tv82G0KXRuhw=="
       },
       "Swashbuckle.AspNetCore": {
         "type": "Direct",
-        "requested": "[10.2.1, )",
-        "resolved": "10.2.1",
-        "contentHash": "SDU6akgCV/H4jFMRfyJ0mgO5jWOuuAqekvEThXg8c/LjnfNz5Nkaz+RUpeTVJKWIRX4wDKC/6R3ogJ4AsRE32A==",
+        "requested": "[10.2.3, )",
+        "resolved": "10.2.3",
+        "contentHash": "8KNh1RWvofdU6DVLyBs4Z/OpUMnmf8oNvJQc0QxpwySRbi42bwLfdVMMrXZWANg5U5KQGQq1xW6r/hlcqw99tQ==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "10.0.0",
-          "Swashbuckle.AspNetCore.Swagger": "10.2.1",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1",
-          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.1"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.3",
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.3",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.3"
         }
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -74,114 +74,119 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.ApiDescription.Server": {
         "type": "Transitive",
@@ -190,110 +195,111 @@
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -340,26 +346,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -494,8 +500,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -543,24 +549,24 @@
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "ej4inPhiWCq+0utG8yaKhIhE8M3k3R/qRaGhpgDZB+O/s+o62/zRMO1Cn2CtQccsrqPE9PYnzCp6hQGYGpJOyQ==",
+        "resolved": "10.2.3",
+        "contentHash": "1jUUs3WQnrS0FUtaZPLSy1yYMEwS1zlvDmvQ2/eldPHUANX0LJSLVZecCMgSMdeGiRqeaRrIXLtSz++TCiTMww==",
         "dependencies": {
           "Microsoft.OpenApi": "2.7.5"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "JYX6i/y0xEtQWH/hZyfcage1/ldwww83ueD/gBc34uSnMwyvRLUsOpYcxlliFFxFbZMrY6t+R9ENqolE7zTEOg==",
+        "resolved": "10.2.3",
+        "contentHash": "y7t4coDRAeFYChmvlMRiH2OjbiRrm9AVIDgt17fQfs3x9PVAI5PiwWYOhg+4F13R4Q36WDc9lqfoOnNa3tNbGg==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "10.2.1"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.3"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -592,114 +598,34 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
-        }
-      }
-    },
-    "net10.0/linux-arm64": {
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "SourceGear.sqlite3": {
-        "type": "Transitive",
-        "resolved": "3.50.4.5",
-        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
-      },
-      "System.Drawing.Common": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
-        "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
-        }
-      }
-    },
-    "net10.0/linux-x64": {
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "SourceGear.sqlite3": {
-        "type": "Transitive",
-        "resolved": "3.50.4.5",
-        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
-      },
-      "System.Drawing.Common": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
-        "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
+          "idunno.Security.Ssrf": "[5.4.0, )"
         }
       }
     },
     "net10.0/osx-arm64": {
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "SourceGear.sqlite3": {
-        "type": "Transitive",
-        "resolved": "3.50.4.5",
-        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
-      },
-      "System.Drawing.Common": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
-        "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
-        }
-      }
-    },
-    "net10.0/win-arm64": {
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
-      "SourceGear.sqlite3": {
-        "type": "Transitive",
-        "resolved": "3.50.4.5",
-        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
-      },
-      "System.Drawing.Common": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
-        "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
-        }
-      }
-    },
-    "net10.0/win-x64": {
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
         "resolved": "6.0.0",

--- a/src/BridgeBeats.Worker.AppleMusic/packages.lock.json
+++ b/src/BridgeBeats.Worker.AppleMusic/packages.lock.json
@@ -4,8 +4,8 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -56,221 +56,227 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -317,26 +323,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -471,8 +477,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -548,30 +554,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.Discord/BridgeBeats.Worker.Discord.csproj
+++ b/src/BridgeBeats.Worker.Discord/BridgeBeats.Worker.Discord.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
-    <PackageReference Include="NetCord.Hosting" Version="1.0.0-beta.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageReference Include="NetCord.Hosting" Version="1.0.0-beta.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Worker.Discord/packages.lock.json
+++ b/src/BridgeBeats.Worker.Discord/packages.lock.json
@@ -4,27 +4,27 @@
     "net10.0": {
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
-        "requested": "[10.7.0, )",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "NetCord.Hosting": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.2, )",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "wRyycx2LP3yob3ck6O57mxqeKgKRj39j0mnQLfWJOoynIggNuLxIJNw4nGXCbYDCYQSfYK2GMS91IFJ5Vbhpbw==",
+        "requested": "[1.0.0-beta.11, )",
+        "resolved": "1.0.0-beta.11",
+        "contentHash": "81v1p+ns7Z/ky822idTHKEGy4tt8trC6MY+hB2i0k0rKqguCsSxo8syXMNlvksYBk+TLiQzJgHkfQ+aA+VmXJA==",
         "dependencies": {
-          "NetCord": "1.0.0-beta.2"
+          "NetCord": "1.0.0-beta.11"
         }
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -75,212 +75,218 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -290,8 +296,8 @@
       },
       "NetCord": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "XHThYWQU2rzutsJt7Ga8qTPZ0i3ckP9JQzhZonJHOir+QmNoL7hXLGKxu22C4DxMQ20N4loWkC/fr4JE7i+Fag=="
+        "resolved": "1.0.0-beta.11",
+        "contentHash": "1mzToSQ3J6wtHt1NirCJ4O9Dt1Ou/G9sSiLrFpub3KwWFpUWZqi/bncjAeCCMymosBYTasbqI+M5r6m/3DoLHg=="
       },
       "OpenTelemetry": {
         "type": "Transitive",
@@ -332,26 +338,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -486,8 +492,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -563,30 +569,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.JetStreamWatcher/BridgeBeats.Worker.JetStreamWatcher.csproj
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/BridgeBeats.Worker.JetStreamWatcher.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="idunno.AtProto" Version="2.0.0" />
-    <PackageReference Include="idunno.Bluesky" Version="2.0.0" />
+    <PackageReference Include="idunno.AtProto" Version="3.0.0" />
+    <PackageReference Include="idunno.Bluesky" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Worker.JetStreamWatcher/packages.lock.json
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/packages.lock.json
@@ -4,35 +4,35 @@
     "net10.0": {
       "idunno.AtProto": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.Bluesky": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -83,196 +83,202 @@
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -319,26 +325,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -473,8 +479,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -550,30 +556,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.Maintenance/packages.lock.json
+++ b/src/BridgeBeats.Worker.Maintenance/packages.lock.json
@@ -4,8 +4,8 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -56,221 +56,227 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -317,26 +323,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -471,8 +477,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -548,30 +554,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -514,7 +514,6 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 return;
             }
 
-            finalResult.IsPartial = true;
             finalResult.RateLimitedProviders = saga.RateLimitInfo?.Select( r => r.Provider ).ToList( );
 
             bool uriRecorded = false;

--- a/src/BridgeBeats.Worker.SagaCoordinator/packages.lock.json
+++ b/src/BridgeBeats.Worker.SagaCoordinator/packages.lock.json
@@ -4,8 +4,8 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -56,221 +56,227 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -317,26 +323,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -471,8 +477,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -548,30 +554,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.Spotify/packages.lock.json
+++ b/src/BridgeBeats.Worker.Spotify/packages.lock.json
@@ -4,8 +4,8 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -56,221 +56,227 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -317,26 +323,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -471,8 +477,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -548,30 +554,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }

--- a/src/BridgeBeats.Worker.Tidal/packages.lock.json
+++ b/src/BridgeBeats.Worker.Tidal/packages.lock.json
@@ -4,8 +4,8 @@
     "net10.0": {
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.4.3",
-        "contentHash": "+pUrLb77ncuHFYvzazux63fVcrqKp4qUw6QFr3CJd0uYbfWtqJ5aZ/47sm1keMlqaggWkv4D+F+6sK8yYB1eLw==",
+        "resolved": "13.4.6",
+        "contentHash": "eIdqyDrChSFrGInWzY6fp175grYvYVpaiWcymYMDSvrDj8gpGddOqEFKftylOMlxUEBkaxLt1itm0KHBY8DhZg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.6.0",
@@ -56,221 +56,227 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "lcvq1v4YQA28Sq4TyyY7+XawcIi3VlG6z7AcbYKIXGmp4GLK8V/AwBuY8JBZwNipABBB0RBZCSZFw6SSwP5FuQ==",
+        "resolved": "3.0.0",
+        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.18.0",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
+          "OpenTelemetry.Extensions.Hosting": "1.16.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.0",
+          "SimpleBase": "5.6.1",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "2.0.0",
+          "idunno.AtProto.Types": "3.0.0",
           "idunno.Security.Ssrf": "5.3.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "UPzED3vgp3yCYHz/3zNAt+gy3W5eX7ieTeXxBFs32D6rDcKBjveKTG+nyKax294oSljAv8ZHb6LTBW/mHikzrQ==",
+        "resolved": "3.0.0",
+        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
         "dependencies": {
-          "SimpleBase": "5.6.0"
+          "SimpleBase": "5.6.1"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "96qzrShtaxJUdbZlWLQKe8ygjJl8edmz8yl91pqov+pHcrtsP+oPynxwKWeL2yQ9SadkM7ru9Gtb+YmDO9atcQ==",
+        "resolved": "3.0.0",
+        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
         "dependencies": {
-          "idunno.AtProto": "2.0.0"
+          "idunno.AtProto": "3.0.0"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5yHCQ6fDsOKJTCyXCHb7Q4KFPrlTF5k+u5unV7GXI89NJkvgk6nXr6jGxdBi003Sx8MzTjZGpjABLmpOZ2Pg1A==",
+        "resolved": "10.0.10",
+        "contentHash": "/ZV8RMWbWob1ZGsF5f1wVJNNlFLPKCf2ba834PpQiNhirVQ/ksup5SujtuUsvByHEZgv+9dmjC/4Xdi75axmXQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "iZrONyMKPjxfVZnUktqO30QjzNwAGH+AxM61s8lKQnVhgbQ3bn0hiXI129ZmVicEbIcwljyy2OVsIYUR51ZHKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.10"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "HH9/nnRF/YmRrc3hUlgXjMBYKH5kFmd5UWC81l9U0ySQhwHTcgvDPSewB8DyQHzFJzNGgG7VFK6ynC6+XQz9WA==",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "3bPEmACAaPJJSw+m5XwTSi3yZnVtaifa4d8gLsNMzW0Qu28jS5kADSfgJRBlq49RJ1K098VCzEDRJwM8gE6f2w==",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
-          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q=="
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A=="
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA=="
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ=="
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Telemetry": "10.7.0"
+          "Microsoft.Extensions.Telemetry": "10.8.0"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
-          "Microsoft.Extensions.Resilience": "10.7.0"
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "resolved": "10.8.0",
+        "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A=="
+        "resolved": "10.8.0",
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
         "dependencies": {
-          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
-          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
-          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Extensions.Telemetry.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "8VUcDy66uw1GUC/ytyRJAUgGxydPu2rLtUbUAiniCHd5SMB/01Q28XgqFyxIqb3srz6HWTgSsZdDbkdVJr3LXQ=="
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "ZUMJt3r1zOi67AVSfnh3u9hg9KCq06roOIX5gs7FqsucSZ/VTsI89DI9h2gHyU0xOtj/qVZV2ugWS6JlLMTwHQ==",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.18.0"
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c2l/VEtW1XI/ifcu49xzDwgrZZ0a0aX/TwCPC7mEHFQk/KixDgtSdjB5eDhYyCO38GJiRUjeRTz9aWCy1t55ww==",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.18.0"
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.18.0",
-        "contentHash": "c6ksXXFj5oPPsl8pfsui5zv8Gs7uxrGetXCTc1p7k7Nue/C8iBMtAVgtRrH7Esqe596QWD7KS3exKYY1FJG2iw==",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "8.18.0"
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -317,26 +323,26 @@
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Http": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.Runtime": {
         "type": "Transitive",
-        "resolved": "1.15.1",
-        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "resolved": "1.16.0",
+        "contentHash": "3mKCZZo32UYn/vcVFxxrWgO+BcDy9EZBdW1rfCzdtK+CGCFIMnf6AY96MrnVnyNK/f3ehq9t6qLec8OTNxgzRw==",
         "dependencies": {
-          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+          "OpenTelemetry.Api": "[1.16.0, 2.0.0)"
         }
       },
       "PeterO.Cbor": {
@@ -471,8 +477,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.0",
-        "contentHash": "1nNr/DCvcxTrQzN1gUnYzFpLkbAKcFYhF/aMK34jVxrPUjMwL/J3KNEp89M0WaW2k9FUpacxRe4BmjFFjOv3zw=="
+        "resolved": "5.6.1",
+        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -548,30 +554,50 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[2.0.0, )",
-          "idunno.Bluesky": "[2.0.0, )"
+          "idunno.AtProto": "[3.0.0, )",
+          "idunno.Bluesky": "[3.0.0, )"
         }
       },
       "bridgebeats.core": {
         "type": "Project",
         "dependencies": {
           "AspNetCore.Authentication.ApiKey": "[9.0.0, )",
-          "Aspire.StackExchange.Redis": "[13.4.3, )",
+          "Aspire.StackExchange.Redis": "[13.4.6, )",
           "BridgeBeats.Contracts": "[1.0.0, )",
-          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
-          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.8.0, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
           "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.16.0, )",
           "QRCoder": "[1.8.0, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
-          "idunno.Security.Ssrf": "[5.3.0, )"
+          "idunno.Security.Ssrf": "[5.4.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.50.4.5",
+        "contentHash": "UtnipXhJYZKQOQIfpws/msLK7IRhMplE1CZCaZLIQXRnGD474QVpO/J9nMlQQY8NZueGz1aidjoxDRnrC1NT3Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       }
     }


### PR DESCRIPTION
## Description

- Remove IsPartial from MediaLinkResultRecord (property, ctor param, mappings)
- Drop isPartial from ConvertToRecord / ConvertFromRecord in ATProtoStorageService
- Make RedisMediaLinkCache.CheckRecordFreshness age-only; partiality is no longer a staleness trigger (the cache-refresh sweep handles re-lookup)
- Update now-stale comments in LookupOrchestrator and CacheFreshness
- Add serialization regression guard asserting no isPartial key on the record; invert the freshness test (recent subset record is fresh); add cold-path orchestrator coverage (cold subset hit returns final, no SagaId)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

<!-- Only check items that are relevant to your changes -->

- [X] Tests added/updated for new functionality
- [X] Documentation updated (README, API docs, configuration docs)
- [X] No secrets or credentials committed
- [ ] Breaking changes documented in PR description

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
