### PR TITLE
Harden queue delivery and saga lifecycle handling

### DIFF
--- a/Tests/BridgeBeats.Tests.csproj
+++ b/Tests/BridgeBeats.Tests.csproj
@@ -22,10 +22,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2">
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.Redis" Version="4.13.0" />

--- a/Tests/EndToEnd/HomeControllerTests.cs
+++ b/Tests/EndToEnd/HomeControllerTests.cs
@@ -605,7 +605,7 @@ public class HomeControllerRenderingTests {
             .ReturnsAsync( stubResult );
         _ = mock
             .Setup( s => s.GetInfoAsync( It.IsAny<string>( ) ) )
-            .Returns( (string _) => YieldResult( stubResult ) );
+            .Returns( ( string _ ) => YieldResult( stubResult ) );
         return mock.Object;
     }
 

--- a/Tests/GlobalUsings.cs
+++ b/Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using BridgeBeats.Tests.Infrastructure;

--- a/Tests/Infrastructure/RedisSagaStateManagerTestExtensions.cs
+++ b/Tests/Infrastructure/RedisSagaStateManagerTestExtensions.cs
@@ -1,0 +1,129 @@
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Queue;
+
+namespace BridgeBeats.Tests.Infrastructure;
+
+/// <summary>Test conveniences that obtain the current token before exercising fenced Redis operations.</summary>
+internal static class RedisSagaStateManagerTestExtensions {
+    internal static async Task UpdateProviderStateAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        ProviderLookupState state,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        if (!await manager.TryUpdateProviderStateAsync( sagaId, state, token, cancellationToken )) {
+            throw new InvalidOperationException( $"Lost saga fence for '{sagaId}'." );
+        }
+    }
+
+    internal static async Task SetPartialResultUriAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        string uri,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        if (!await manager.TrySetPartialResultUriAsync( sagaId, uri, token, cancellationToken )) {
+            throw new InvalidOperationException( $"Lost saga fence for '{sagaId}'." );
+        }
+    }
+
+    internal static async Task SetFinalResultUriAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        string uri,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        SagaFinalResultWriteOutcome outcome = await manager.TrySetFinalResultUriAsync( sagaId, uri, token, cancellationToken );
+        if (outcome is not SagaFinalResultWriteOutcome.Stored and not SagaFinalResultWriteOutcome.Idempotent) {
+            throw new InvalidOperationException( $"Lost saga fence for '{sagaId}'." );
+        }
+    }
+
+    internal static async Task<bool> DeleteAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        CancellationToken cancellationToken = default
+    ) {
+        LookupSagaState? saga = await manager.GetAsync( sagaId, cancellationToken );
+        return saga?.InstanceToken is { Length: > 0 } token
+            && await manager.TryDeleteAsync( sagaId, token, cancellationToken );
+    }
+
+    internal static async Task<bool> TryClaimFinalizeAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        CancellationToken cancellationToken = default
+    ) {
+        LookupSagaState? saga = await manager.GetAsync( sagaId, cancellationToken );
+        return saga?.InstanceToken is { Length: > 0 } token
+            && await manager.TryClaimFinalizeAsync( sagaId, token, cancellationToken );
+    }
+
+    internal static async Task<bool> TryMarkSecondariesQueuedAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        CancellationToken cancellationToken = default
+    ) {
+        LookupSagaState? saga = await manager.GetAsync( sagaId, cancellationToken );
+        return saga?.InstanceToken is { Length: > 0 } token
+            && await manager.TryMarkSecondariesQueuedAsync( sagaId, token, cancellationToken );
+    }
+
+    internal static async Task ReleaseFinalizeClaimAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        _ = await manager.TryReleaseFinalizeClaimAsync( sagaId, token, cancellationToken );
+    }
+
+    internal static async Task<bool> TryAdvanceWriteGenerationAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        int generation,
+        CancellationToken cancellationToken = default
+    ) {
+        LookupSagaState? saga = await manager.GetAsync( sagaId, cancellationToken );
+        return saga?.InstanceToken is { Length: > 0 } token
+            && await manager.TryAdvanceWriteGenerationAsync( sagaId, generation, token, cancellationToken );
+    }
+
+    internal static async Task ResetWriteGenerationAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        int advancedTo,
+        int priorGeneration,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        _ = await manager.TryResetWriteGenerationAsync(
+            sagaId, advancedTo, priorGeneration, token, cancellationToken );
+    }
+
+    internal static async Task TryInitializeProviderStatesAsync(
+        this RedisSagaStateManager manager,
+        string sagaId,
+        IEnumerable<SupportedProviders> providers,
+        CancellationToken cancellationToken = default
+    ) {
+        string token = await GetTokenAsync( manager, sagaId, cancellationToken );
+        if (!await manager.TryInitializeProviderStatesAsync( sagaId, providers, token, cancellationToken )) {
+            throw new InvalidOperationException( $"Lost saga fence for '{sagaId}'." );
+        }
+    }
+
+    private static async Task<string> GetTokenAsync(
+        RedisSagaStateManager manager,
+        string sagaId,
+        CancellationToken cancellationToken
+    ) {
+        LookupSagaState? saga = await manager.GetAsync( sagaId, cancellationToken );
+        return saga?.InstanceToken
+            ?? throw new InvalidOperationException( $"Saga '{sagaId}' has no readable instance token." );
+    }
+}

--- a/Tests/Integration/DashboardAuthorizationTests.cs
+++ b/Tests/Integration/DashboardAuthorizationTests.cs
@@ -2,7 +2,10 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using BridgeBeats.Contracts.Constants;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Core.Infrastructure.Identity;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
@@ -11,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using StackExchange.Redis;
 
 namespace BridgeBeats.Tests.Integration;
 
@@ -153,6 +157,60 @@ public class DashboardAuthorizationTests : IDisposable {
         Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
     }
 
+    /// <summary>Low-role statistics responses omit the bootstrap panel and sentinel.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Statistics_LowRole_OmitsBootstrapPanelAndSentinel( ) {
+        await SeedStatisticsAsync( );
+        await CreateTestUserAsync( hasRole: false );
+        _client!.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue( "TestScheme" );
+        HttpResponseMessage response = await _client.GetAsync( "/Statistics", TestContext.CancellationToken );
+        string body = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.IsFalse( body.Contains( "Cache Bootstrap Status", StringComparison.Ordinal ) );
+        Assert.IsFalse( body.Contains( "987,654,321", StringComparison.Ordinal ) );
+    }
+
+    /// <summary>Dashboard-role statistics responses render the bootstrap panel and sentinel.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Statistics_Admin_RendersBootstrapPanelAndSentinel( ) {
+        await SeedStatisticsAsync( );
+        await CreateTestUserAsync( hasRole: true );
+        _client!.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue( "TestScheme" );
+        HttpResponseMessage response = await _client.GetAsync( "/Statistics", TestContext.CancellationToken );
+        string body = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        StringAssert.Contains( body, "Cache Bootstrap Status" );
+        StringAssert.Contains( body, "987,654,321" );
+    }
+
+    /// <summary>Anonymous statistics requests are challenged without rendering page content.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Statistics_Anonymous_IsChallengedWithoutStatsBody( ) {
+        await SeedStatisticsAsync( );
+        using HttpClient anonymous = _factory!.CreateClient( new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions {
+            AllowAutoRedirect = false
+        } );
+        HttpResponseMessage response = await anonymous.GetAsync( "/Statistics", TestContext.CancellationToken );
+        string body = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+        Assert.AreEqual( HttpStatusCode.Unauthorized, response.StatusCode );
+        Assert.IsFalse( body.Contains( "Total Records", StringComparison.Ordinal ) );
+    }
+
+    private async Task SeedStatisticsAsync( ) {
+        using IServiceScope scope = _factory!.Services.CreateScope( );
+        IConnectionMultiplexer redis = scope.ServiceProvider.GetRequiredService<IConnectionMultiplexer>( );
+        IDatabase db = redis.GetDatabase( );
+        _ = await db.StringSetAsync( StatisticsStatus.RedisKey, JsonSerializer.Serialize( new StatisticsStatus {
+            Snapshot = new LookupStatistics { TotalRecords = 1, GeneratedAt = DateTimeOffset.UtcNow }
+        } ) );
+        _ = await db.StringSetAsync( CacheBootstrapStatus.RedisKey, JsonSerializer.Serialize( new CacheBootstrapStatus {
+            LastSuccessCount = 987654321
+        } ) );
+    }
+
     /// <summary>
     /// Verifies that database initialization seeds the Aspire dashboard-access role.
     /// </summary>
@@ -252,6 +310,7 @@ public class DashboardAuthorizationTests : IDisposable {
 
                 // Register this factory as a singleton so the handler can access it
                 _ = services.AddSingleton( this );
+                _ = services.AddSingleton<IStatisticsService, BridgeBeats.Web.Services.RedisStatisticsReader>( );
             } );
         }
 

--- a/Tests/Integration/DashboardAuthorizationTests.cs
+++ b/Tests/Integration/DashboardAuthorizationTests.cs
@@ -26,6 +26,7 @@ namespace BridgeBeats.Tests.Integration;
 /// role.
 /// </summary>
 [TestClass]
+[DoNotParallelize] // Uses the process-wide Redis statistics keys also exercised by StatisticsStatusIntegrationTests.
 public class DashboardAuthorizationTests : IDisposable {
     /// <summary>The test web application factory with the stub authentication scheme installed.</summary>
     private DashboardTestWebApplicationFactory? _factory;

--- a/Tests/Integration/QueueMetricsIntegrationTests.cs
+++ b/Tests/Integration/QueueMetricsIntegrationTests.cs
@@ -131,6 +131,27 @@ public class QueueMetricsIntegrationTests {
         Assert.IsNotNull( s_redis );
     }
 
+    /// <summary>Consumer-group pending, oldest-age, and lag gauges are all published.</summary>
+    [TestMethod]
+    public void RegisterQueueDepthGauges_PublishesConsumerHealthGauges( ) {
+        QueueMetrics.RegisterQueueDepthGauges( s_redis! );
+        HashSet<string> published = [];
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, meterListener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName) {
+                _ = published.Add( instrument.Name );
+                meterListener.EnableMeasurementEvents( instrument );
+            }
+        };
+
+        listener.Start( );
+        listener.RecordObservableInstruments( );
+
+        Assert.Contains( "bridgebeats.queue.pending", published );
+        Assert.Contains( "bridgebeats.queue.pending.oldest_age", published );
+        Assert.Contains( "bridgebeats.queue.consumer.lag", published );
+    }
+
     /// <summary>
     /// Verifies observable gauge collection remains non-fatal when the current Redis multiplexer
     /// cannot provide a database, as can happen while a host-owned connection is being torn down.
@@ -143,7 +164,7 @@ public class QueueMetricsIntegrationTests {
         Mock<IConnectionMultiplexer> unavailableRedis = new( MockBehavior.Strict );
         _ = unavailableRedis
             .Setup( redis => redis.GetDatabase( It.IsAny<int>( ), It.IsAny<object?>( ) ) )
-            .Throws( new ObjectDisposedException( nameof(IConnectionMultiplexer) ) );
+            .Throws( new ObjectDisposedException( nameof( IConnectionMultiplexer ) ) );
 
         QueueMetrics.RegisterQueueDepthGauges( unavailableRedis.Object );
 

--- a/Tests/Integration/RedisRefreshReviewStoreIntegrationTests.cs
+++ b/Tests/Integration/RedisRefreshReviewStoreIntegrationTests.cs
@@ -62,13 +62,13 @@ public sealed class RedisRefreshReviewStoreIntegrationTests {
         await _store.RegisterPendingAsync( entry, TestContext.CancellationToken );
 
         TimeSpan? ttl = await s_redis!.GetDatabase( ).KeyTimeToLiveAsync(
-            $"cache:refresh:pending:{SagaId}" );
+            $"cache:refresh:pending:{SourceUri}" );
         Assert.IsNotNull( ttl );
         Assert.IsGreaterThan( TimeSpan.Zero, ttl.Value );
         Assert.IsLessThanOrEqualTo( TimeSpan.FromMinutes( 60 ), ttl.Value );
 
         await _store.MarkUnresolvedAsync(
-            SagaId, "No provider result.", TestContext.CancellationToken );
+            entry, "No provider result.", TestContext.CancellationToken );
         Assert.HasCount( 1, await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
 
         bool staleDelete = await _store.DeleteUnresolvedAsync(
@@ -86,19 +86,203 @@ public sealed class RedisRefreshReviewStoreIntegrationTests {
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task Complete_PendingEntry_RemovesContext( ) {
-        await _store.RegisterPendingAsync( CreateEntry( ), TestContext.CancellationToken );
+        RefreshReviewEntry entry = CreateEntry( );
+        await _store.RegisterPendingAsync( entry, TestContext.CancellationToken );
 
-        await _store.CompleteAsync( SagaId, TestContext.CancellationToken );
+        await _store.CompleteAsync( SagaId, entry.InstanceToken!, TestContext.CancellationToken );
         await _store.MarkUnresolvedAsync(
-            SagaId, "late failure", TestContext.CancellationToken );
+            entry, "late failure", TestContext.CancellationToken );
 
         Assert.IsEmpty( await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Direct quarantine preserves a shared saga owner's pending context and clears attempts.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PromoteDirect_PreservesSharedPendingOwner_AndIsIdempotent( ) {
+        const string OwnerUri = SourceUri + ":owner";
+        const string PromotedUri = SourceUri + ":promoted";
+        const string SharedSaga = SagaId + ":shared";
+        RefreshReviewEntry owner = CreateEntry( ) with {
+            SourceRecordUri = OwnerUri,
+            SagaId = SharedSaga,
+            InstanceToken = "owner-token"
+        };
+        RefreshReviewEntry promoted = CreateEntry( ) with {
+            SourceRecordUri = PromotedUri,
+            SagaId = SharedSaga,
+            InstanceToken = "owner-token"
+        };
+
+        await _store.RegisterPendingAsync( owner, TestContext.CancellationToken );
+        _ = await _store.IncrementSweepAttemptAsync( PromotedUri, TestContext.CancellationToken );
+        _ = await _store.IncrementSweepAttemptAsync( PromotedUri, TestContext.CancellationToken );
+        await _store.PromoteDirectAsync( promoted, "No completed refresh after three sweeps.", TestContext.CancellationToken );
+        await _store.PromoteDirectAsync( promoted, "No completed refresh after three sweeps.", TestContext.CancellationToken );
+
+        RefreshReviewEntry? pendingOwner = await _store.GetPendingAsync( OwnerUri, TestContext.CancellationToken );
+        Assert.IsNotNull( pendingOwner );
+        Assert.AreEqual( OwnerUri, pendingOwner!.SourceRecordUri );
+        Assert.HasCount( 1, await _store.GetPendingForSagaAsync( SharedSaga, TestContext.CancellationToken ) );
+        Assert.AreEqual( 1, await _store.IncrementSweepAttemptAsync( PromotedUri, TestContext.CancellationToken ) );
+
+        IReadOnlyList<RefreshReviewEntry> unresolved = await _store.GetUnresolvedAsync( TestContext.CancellationToken );
+        Assert.HasCount( 1, unresolved );
+        Assert.AreEqual( PromotedUri, unresolved[0].SourceRecordUri );
+    }
+
+    /// <summary>Promoting an active owner's own context retains pending correlation until completion clears both views.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PromoteDirect_SameOwnerThenComplete_ClearsPendingAndUnresolved( ) {
+        RefreshReviewEntry owner = CreateEntry( ) with { SagaId = SagaId + ":owner", InstanceToken = "owner-token" };
+        await _store.RegisterPendingAsync( owner, TestContext.CancellationToken );
+        await _store.PromoteDirectAsync( owner, "No completed refresh after three sweeps.", TestContext.CancellationToken );
+        Assert.IsNotNull( await _store.GetPendingAsync( owner.SourceRecordUri, TestContext.CancellationToken ) );
+        Assert.HasCount( 1, await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+
+        await _store.CompleteAsync( owner.SagaId, owner.InstanceToken!, TestContext.CancellationToken );
+
+        Assert.IsNull( await _store.GetPendingAsync( owner.SourceRecordUri, TestContext.CancellationToken ) );
+        Assert.IsEmpty( await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Sibling pending entries retain order and are promoted idempotently as separate records.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SiblingPendingEntries_PreserveBothAndPromoteIdempotently( ) {
+        RefreshReviewEntry first = CreateEntry( ) with { SourceRecordUri = SourceUri + ":first" };
+        RefreshReviewEntry second = CreateEntry( ) with { SourceRecordUri = SourceUri + ":second" };
+        await _store.RegisterPendingAsync( first, TestContext.CancellationToken );
+        await _store.RegisterPendingAsync( second, TestContext.CancellationToken );
+
+        IReadOnlyList<RefreshReviewEntry> pending = await _store.GetPendingForSagaAsync(
+            SagaId, TestContext.CancellationToken );
+        CollectionAssert.AreEquivalent( new[] { first.SourceRecordUri, second.SourceRecordUri },
+            pending.Select( entry => entry.SourceRecordUri ).ToArray( ) );
+
+        await _store.MarkUnresolvedAsync( first, "No completed refresh.", TestContext.CancellationToken );
+        await _store.MarkUnresolvedAsync( second, "No completed refresh.", TestContext.CancellationToken );
+        await _store.MarkUnresolvedAsync( first, "No completed refresh.", TestContext.CancellationToken );
+        await _store.MarkUnresolvedAsync( second, "No completed refresh.", TestContext.CancellationToken );
+        IReadOnlyList<RefreshReviewEntry> unresolved = await _store.GetUnresolvedAsync( TestContext.CancellationToken );
+        CollectionAssert.AreEquivalent( new[] { first.SourceRecordUri, second.SourceRecordUri },
+            unresolved.Select( entry => entry.SourceRecordUri ).ToArray( ) );
+    }
+
+    /// <summary>Stale instance cleanup cannot delete a replacement pending entry for the same source.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ReplacementPendingEntry_SurvivesStaleMarkAndComplete( ) {
+        DateTimeOffset older = DateTimeOffset.UtcNow.AddMinutes( -2 );
+        DateTimeOffset newer = DateTimeOffset.UtcNow.AddMinutes( -1 );
+        RefreshReviewEntry stale = CreateEntry( ) with { InstanceToken = "stale-x", CreatedAt = older };
+        RefreshReviewEntry replacement = stale with { InstanceToken = "current-y", CreatedAt = newer };
+
+        await _store.RegisterPendingAsync( stale, TestContext.CancellationToken );
+        await _store.RegisterPendingAsync( replacement, TestContext.CancellationToken );
+        await _store.RegisterPendingAsync( stale, TestContext.CancellationToken );
+        Assert.AreEqual( replacement.InstanceToken,
+            (await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ))!.InstanceToken,
+            "Retrying an older registration must not replace the newer saga generation." );
+        await _store.MarkUnresolvedAsync( stale, "stale", TestContext.CancellationToken );
+        Assert.AreEqual( replacement.InstanceToken,
+            (await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ))!.InstanceToken );
+        Assert.IsEmpty( await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+
+        await _store.RegisterPendingAsync( stale, TestContext.CancellationToken );
+        await _store.PromoteDirectAsync( stale, "stale", TestContext.CancellationToken );
+        await _store.RegisterPendingAsync( replacement, TestContext.CancellationToken );
+        await _store.CompleteAsync( stale, TestContext.CancellationToken );
+        Assert.AreEqual( replacement.InstanceToken,
+            (await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ))!.InstanceToken );
+        Assert.HasCount( 1, await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+        await _store.CompleteAsync( replacement, TestContext.CancellationToken );
+        Assert.IsNull( await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ) );
+        Assert.IsEmpty( await _store.GetUnresolvedAsync( TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Completing one saga instance cannot remove an unresolved replacement for another instance.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Complete_StalePendingInstance_PreservesDifferentUnresolvedReplacement( ) {
+        DateTimeOffset olderAcrossPositiveOffset = new DateTimeOffset( 2026, 1, 1, 10, 0, 0, TimeSpan.Zero )
+            .ToOffset( TimeSpan.FromHours( 14 ) );
+        DateTimeOffset newerAcrossNegativeOffset = new DateTimeOffset( 2026, 1, 1, 11, 0, 0, TimeSpan.Zero )
+            .ToOffset( TimeSpan.FromHours( -12 ) );
+        RefreshReviewEntry pendingOwner = CreateEntry( ) with {
+            SagaId = SagaId + ":owner",
+            InstanceToken = "owner-token",
+            CreatedAt = olderAcrossPositiveOffset
+        };
+        RefreshReviewEntry unresolvedReplacement = pendingOwner with {
+            SagaId = SagaId + ":replacement",
+            InstanceToken = "replacement-token",
+            CreatedAt = newerAcrossNegativeOffset
+        };
+
+        await _store.RegisterPendingAsync( pendingOwner, TestContext.CancellationToken );
+        await _store.PromoteDirectAsync(
+            unresolvedReplacement,
+            "No completed refresh after three sweeps.",
+            TestContext.CancellationToken );
+        await _store.CompleteAsync( pendingOwner, TestContext.CancellationToken );
+
+        Assert.IsNull( await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ) );
+        IReadOnlyList<RefreshReviewEntry> unresolved = await _store.GetUnresolvedAsync( TestContext.CancellationToken );
+        Assert.HasCount( 1, unresolved );
+        Assert.AreEqual( unresolvedReplacement.SagaId, unresolved[0].SagaId );
+        Assert.AreEqual( unresolvedReplacement.InstanceToken, unresolved[0].InstanceToken );
+        IDatabase db = s_redis!.GetDatabase( );
+        Assert.AreEqual( SourceUri, (await db.HashGetAsync( "cache:refresh:unresolved:sagas", unresolvedReplacement.SagaId )).ToString( ) );
+        Assert.IsFalse( await db.HashExistsAsync( "cache:refresh:pending:sagas", pendingOwner.SagaId ) );
+        Assert.IsFalse( await db.SetContainsAsync( $"cache:refresh:pending:saga:{pendingOwner.SagaId}", SourceUri ) );
+        Assert.IsFalse( await db.KeyExistsAsync( $"cache:refresh:pending:{SourceUri}" ) );
+    }
+
+    /// <summary>Marking an older pending saga cannot overwrite a newer unresolved replacement.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task Mark_StalePendingInstance_PreservesDifferentUnresolvedReplacement( ) {
+        DateTimeOffset olderAcrossPositiveOffset = new DateTimeOffset( 2026, 1, 1, 10, 0, 0, TimeSpan.Zero )
+            .ToOffset( TimeSpan.FromHours( 14 ) );
+        DateTimeOffset newerAcrossNegativeOffset = new DateTimeOffset( 2026, 1, 1, 11, 0, 0, TimeSpan.Zero )
+            .ToOffset( TimeSpan.FromHours( -12 ) );
+        RefreshReviewEntry pendingOwner = CreateEntry( ) with {
+            SagaId = SagaId + ":owner",
+            InstanceToken = "owner-token",
+            CreatedAt = olderAcrossPositiveOffset
+        };
+        RefreshReviewEntry unresolvedReplacement = pendingOwner with {
+            SagaId = SagaId + ":replacement",
+            InstanceToken = "replacement-token",
+            CreatedAt = newerAcrossNegativeOffset
+        };
+
+        await _store.RegisterPendingAsync( pendingOwner, TestContext.CancellationToken );
+        await _store.PromoteDirectAsync(
+            unresolvedReplacement,
+            "No completed refresh after three sweeps.",
+            TestContext.CancellationToken );
+        await _store.MarkUnresolvedAsync( pendingOwner, "Older terminal failure.", TestContext.CancellationToken );
+
+        Assert.IsNull( await _store.GetPendingAsync( SourceUri, TestContext.CancellationToken ) );
+        IReadOnlyList<RefreshReviewEntry> unresolved = await _store.GetUnresolvedAsync( TestContext.CancellationToken );
+        Assert.HasCount( 1, unresolved );
+        Assert.AreEqual( unresolvedReplacement.SagaId, unresolved[0].SagaId );
+        Assert.AreEqual( unresolvedReplacement.InstanceToken, unresolved[0].InstanceToken );
+        IDatabase db = s_redis!.GetDatabase( );
+        Assert.AreEqual( SourceUri, (await db.HashGetAsync( "cache:refresh:unresolved:sagas", unresolvedReplacement.SagaId )).ToString( ) );
+        Assert.IsFalse( await db.HashExistsAsync( "cache:refresh:pending:sagas", pendingOwner.SagaId ) );
+        Assert.IsFalse( await db.SetContainsAsync( $"cache:refresh:pending:saga:{pendingOwner.SagaId}", SourceUri ) );
+        Assert.IsFalse( await db.KeyExistsAsync( $"cache:refresh:pending:{SourceUri}" ) );
     }
 
     private static RefreshReviewEntry CreateEntry( ) => new( ) {
         SourceRecordUri = SourceUri,
         SourceRecordCid = SourceCid,
         SagaId = SagaId,
+        InstanceToken = "integration-token",
         LookupType = LookupRequestType.IsrcLookup,
         LookupValue = "INTEGRATION"
     };

--- a/Tests/Integration/RedisRequestQueueTests.cs
+++ b/Tests/Integration/RedisRequestQueueTests.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Infrastructure.Queue;
 using Microsoft.Extensions.Logging;
@@ -21,7 +24,307 @@ namespace BridgeBeats.Tests.Integration;
 [TestClass]
 [TestCategory( "Integration" )]
 [TestCategory( "Docker" )]
+[DoNotParallelize]
 public partial class RedisRequestQueueTests {
+
+    /// <summary>Generic dequeue emits one scoped span and measurement for each Redis boundary.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_TelemetryHasExactOuterReadDepthAndPelBoundaries( ) {
+        List<string> spans = [];
+        Dictionary<string, int> measurements = [];
+        using ActivityListener activityListener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => spans.Add( activity.OperationName )
+        };
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && (instrument.Name.Contains( "dequeue", StringComparison.Ordinal ))) {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( instrument, _, _, _ ) =>
+            measurements[instrument.Name] = measurements.GetValueOrDefault( instrument.Name ) + 1 );
+        ActivitySource.AddActivityListener( activityListener );
+        meterListener.Start( );
+
+        await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
+        _ = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+
+        _ = Assert.ContainsSingle( spans.Where( name => name == "queue.dequeue" ) );
+        Assert.Contains( "queue.dequeue.depth_probe", spans );
+        Assert.Contains( "queue.dequeue.pel_scan", spans );
+        Assert.Contains( "queue.dequeue.read_group", spans );
+        Assert.AreEqual( 1, measurements.GetValueOrDefault( "bridgebeats.queue.dequeue.depth_probe.duration" ) );
+        Assert.IsGreaterThan( 0, measurements.GetValueOrDefault( "bridgebeats.queue.dequeue.pel_scan.duration" ) );
+        Assert.IsGreaterThan( 0, measurements.GetValueOrDefault( "bridgebeats.queue.dequeue.read_group.duration" ) );
+    }
+
+    /// <summary>Both public dequeue overloads close their Redis-boundary telemetry on NOGROUP errors.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_NogroupException_ClosesPlainAndRateAwareTelemetry( ) {
+        List<string> spans = [];
+        using ActivityListener activityListener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => spans.Add( activity.OperationName )
+        };
+        ActivitySource.AddActivityListener( activityListener );
+
+        IDatabase db = s_redis!.GetDatabase( );
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        _ = await db.ExecuteAsync( "XGROUP", "DESTROY", stream, "spotify-workers" );
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => _queue.DequeueAsync( TestContext.CancellationToken ) );
+        await _queue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+        _ = await db.ExecuteAsync( "XGROUP", "DESTROY", stream, "spotify-workers" );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+        await _queue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+
+        Assert.IsGreaterThanOrEqualTo( 2, spans.Count( name => name == "queue.dequeue" ) );
+        Assert.Contains( "queue.dequeue.depth_probe", spans );
+        Assert.Contains( "queue.dequeue.read_group", spans );
+        Assert.Contains( "queue.dequeue.pel_scan", spans );
+    }
+
+    /// <summary>Deletes a claimed stream body and verifies the dequeue scan removes its ghost PEL entry.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_GhostPelEntry_IsRemovedOnScan( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        IDatabase db = s_redis!.GetDatabase();
+        List<string> ghostIds = [];
+        for (int i = 0; i < 50; i++) {
+            await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+            QueuedMessage<QueuedLookupRequest>? claimed = await _queue.DequeueAsync(TestContext.CancellationToken);
+            Assert.IsNotNull( claimed );
+            ghostIds.Add( claimed.MessageId[(claimed.MessageId.LastIndexOf( ':' ) + 1)..] );
+        }
+        _ = await db.StreamDeleteAsync( stream, [.. ghostIds.Select( id => (RedisValue)id )] );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new();
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        _ = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        RedisResult pendingSummary = await db.ExecuteAsync("XPENDING", stream, "spotify-workers");
+        RedisResult[] pendingParts = (RedisResult[])pendingSummary!;
+        Assert.AreEqual( 0, (long)pendingParts[0] );
+        Assert.IsEmpty( await db.StreamRangeAsync( stream, ghostIds.First( ), ghostIds.Last( ) ) );
+        Assert.IsNull( await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Own-PEL pagination eventually reaches entries beyond the per-call scan cap.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_OwnPelPagination_ReachesEntriesBeyondFifty( ) {
+        const int Count = 505;
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [new RateLimitedEndpoint( "IsrcLookup", DateTimeOffset.UtcNow.AddMinutes( 5 ) )] );
+        for (int i = 0; i < Count; i++) {
+            await _queue.EnqueueAsync( CreateTestRequest( ) with { RateLimitedEndpoint = "IsrcLookup" }, QueuePriority.Interactive, TestContext.CancellationToken );
+        }
+        QueuedLookupRequest tailRequest = CreateTestRequest( lookupType: LookupRequestType.SongIdLookup );
+        await _queue.EnqueueAsync( tailRequest, QueuePriority.Interactive, TestContext.CancellationToken );
+
+        // Seed the current consumer's PEL without using the rate-aware path: the first 505 entries
+        // are deliberately blocked, so the rate-aware scan must advance past them to the tail.
+        for (int i = 0; i < Count; i++) {
+            QueuedMessage<QueuedLookupRequest>? message = await _queue.DequeueAsync( TestContext.CancellationToken );
+            Assert.IsNotNull( message );
+            _queue.ReleaseDelivery( message.MessageId );
+        }
+        QueuedMessage<QueuedLookupRequest>? seededTail = await _queue.DequeueAsync( TestContext.CancellationToken );
+        Assert.IsNotNull( seededTail );
+        Assert.AreEqual( tailRequest.RequestId, seededTail.Payload.RequestId );
+        _queue.ReleaseDelivery( seededTail.MessageId );
+
+        QueuedMessage<QueuedLookupRequest>? tail = null;
+        for (int i = 0; i < 20 && tail is null; i++) {
+            tail = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        }
+        Assert.IsNotNull( tail );
+        Assert.AreEqual( tailRequest.RequestId, tail.Payload.RequestId );
+    }
+
+    /// <summary>XAUTOCLAIM cursor reaches an aged eligible tail beyond a young dead-consumer prefix.</summary>
+    [TestMethod]
+    [Timeout( 60000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_DeadConsumerPelPagination_ReachesAgedTailBeyondFiveHundred( ) {
+        const int Count = 505;
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        IDatabase db = s_redis!.GetDatabase( );
+        for (int i = 0; i < Count; i++) {
+            await _queue.EnqueueAsync( CreateTestRequest( ) with { RateLimitedEndpoint = "IsrcLookup" }, QueuePriority.Interactive, TestContext.CancellationToken );
+        }
+        QueuedLookupRequest tailRequest = CreateTestRequest( lookupType: LookupRequestType.SongIdLookup );
+        await _queue.EnqueueAsync( tailRequest, QueuePriority.Interactive, TestContext.CancellationToken );
+        StreamEntry[] claimed = await db.StreamReadGroupAsync( stream, "spotify-workers", "dead-consumer", StreamPosition.NewMessages, Count + 1, noAck: false );
+        Assert.HasCount( Count + 1, claimed );
+        RedisValue[] ids = [.. claimed.Select( entry => entry.Id )];
+        _ = await db.ExecuteAsync( "XCLAIM", stream, "spotify-workers", "dead-consumer", "0", ids[^1], "IDLE", "1800000", "JUSTID" );
+
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [new RateLimitedEndpoint( "IsrcLookup", DateTimeOffset.UtcNow.AddMinutes( 5 ) )] );
+        QueuedMessage<QueuedLookupRequest>? found = null;
+        for (int i = 0; i < 20 && found is null; i++) {
+            found = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        }
+        Assert.IsNotNull( found );
+        Assert.AreEqual( tailRequest.RequestId, found.Payload.RequestId );
+    }
+
+    /// <summary>Fresh malformed, literal-null, and missing payload entries are ACKed and deleted.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_FreshPoisonEntries_AreRemovedFromPelAndStream( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        IDatabase db = s_redis!.GetDatabase( );
+        _ = await db.StreamAddAsync( stream, [new NameValueEntry( QueueStreamFieldNames.Payload, "{not-json" )] );
+        _ = await db.StreamAddAsync( stream, [new NameValueEntry( QueueStreamFieldNames.Payload, "null" )] );
+        _ = await db.StreamAddAsync( stream, [new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )] );
+
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        Assert.IsNull( await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+
+        RedisResult pendingSummary = await db.ExecuteAsync( "XPENDING", stream, "spotify-workers" );
+        RedisResult[] pendingParts = (RedisResult[])pendingSummary!;
+        Assert.AreEqual( 0, (long)pendingParts[0] );
+        Assert.IsEmpty( await db.StreamRangeAsync( stream, "-", "+" ) );
+    }
+
+    /// <summary>An already-owned malformed payload is removed from the current consumer PEL.</summary>
+    [TestMethod]
+    public async Task DequeueAsync_OwnPoisonEntry_IsRemovedFromPelAndStream( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        IDatabase db = s_redis!.GetDatabase( );
+        RedisValue id = await db.StreamAddAsync( stream, [new NameValueEntry( QueueStreamFieldNames.Payload, "null" )] );
+        string consumer = (string)typeof( RedisRequestQueue<QueuedLookupRequest> )
+            .GetField( "_consumerId", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic )!
+            .GetValue( _queue )!;
+        _ = await db.StreamReadGroupAsync( stream, "spotify-workers", consumer, StreamPosition.NewMessages, 1, noAck: false );
+
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        Assert.IsNull( await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+        Assert.IsEmpty( await db.StreamRangeAsync( stream, id, id ) );
+    }
+
+    /// <summary>A malformed payload abandoned by another consumer is reclaimed and removed.</summary>
+    [TestMethod]
+    public async Task DequeueAsync_ReclaimedPoisonEntry_IsRemovedFromPelAndStream( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        IDatabase db = s_redis!.GetDatabase( );
+        RedisValue id = await db.StreamAddAsync( stream, [new NameValueEntry( QueueStreamFieldNames.Payload, "{broken" )] );
+        _ = await db.StreamReadGroupAsync( stream, "spotify-workers", "dead-consumer", StreamPosition.NewMessages, 1, noAck: false );
+        _ = await db.ExecuteAsync( "XCLAIM", stream, "spotify-workers", "dead-consumer", 0, id, "IDLE", 1_800_000 );
+
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        Assert.IsNull( await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+        Assert.IsEmpty( await db.StreamRangeAsync( stream, id, id ) );
+    }
+
+    /// <summary>Redis does not reclaim a live entry while it is below the generic worker idle threshold.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task AutoClaim_BelowIdleThreshold_DoesNotReclaim( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? claimed = await _queue.DequeueAsync(TestContext.CancellationToken);
+        Assert.IsNotNull( claimed );
+        string id = claimed.MessageId[(claimed.MessageId.LastIndexOf(':') + 1)..];
+        _ = await s_redis!.GetDatabase( ).ExecuteAsync( "XCLAIM", stream, "spotify-workers", "probe-consumer", 1, id, "IDLE", 1 );
+        RedisRequestQueue<QueuedLookupRequest> second = NewQueue("probe-consumer");
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        Assert.IsNull( await second.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+        RedisResult pending = await s_redis!.GetDatabase( ).ExecuteAsync( "XPENDING", stream, "spotify-workers" );
+        Assert.IsGreaterThan( 0, (long)((RedisResult[])pending!)[0] );
+    }
+
+    /// <summary>Redis XAUTOCLAIM reassigns a pending entry once the idle threshold is met.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task AutoClaim_EligibleIdleEntry_IsReclaimed( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? claimed = await _queue.DequeueAsync(TestContext.CancellationToken);
+        Assert.IsNotNull( claimed );
+        string id = claimed.MessageId[(claimed.MessageId.LastIndexOf(':') + 1)..];
+        IDatabase db = s_redis!.GetDatabase( );
+        _ = await db.ExecuteAsync( "XCLAIM", stream, "spotify-workers", "dead-consumer", 0, id, "TIME", 1 );
+        StreamAutoClaimResult aged = await db.StreamAutoClaimAsync( stream, "spotify-workers", "probe", 15 * 60 * 1000, "0-0", 10 );
+        Assert.IsNotNull( aged.ClaimedEntries.FirstOrDefault( entry => entry.Id == id ) );
+        // Reassign the aged entry to the dead consumer without waiting so the production dequeue
+        // surface must reclaim it.
+        _ = await db.ExecuteAsync( "XCLAIM", stream, "spotify-workers", "dead-consumer", 0, id, "TIME", 1 );
+        RedisRequestQueue<QueuedLookupRequest> second = NewQueue("reclaimer");
+        await second.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [] );
+        QueuedMessage<QueuedLookupRequest>? reclaimed = await second.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        Assert.IsNotNull( reclaimed );
+        Assert.AreEqual( id, reclaimed.MessageId[(reclaimed.MessageId.LastIndexOf( ':' ) + 1)..] );
+    }
+
+    /// <summary>XAUTOCLAIM leaves an aged message pending when its endpoint is rate-limited.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task AutoClaim_AgedBlockedEntry_RemainsPending( ) {
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        await _queue.EnqueueAsync( CreateTestRequest( lookupType: LookupRequestType.IsrcLookup ), QueuePriority.Interactive, TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? claimed = await _queue.DequeueAsync( TestContext.CancellationToken );
+        Assert.IsNotNull( claimed );
+        string id = claimed.MessageId[(claimed.MessageId.LastIndexOf( ':' ) + 1)..];
+        IDatabase db = s_redis!.GetDatabase( );
+        _ = await db.ExecuteAsync( "XCLAIM", stream, "spotify-workers", "dead-consumer", 0, id, "TIME", 1 );
+        RedisRequestQueue<QueuedLookupRequest> second = NewQueue( "blocked-reclaimer" );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [new RateLimitedEndpoint( "IsrcLookup", DateTimeOffset.UtcNow.AddMinutes( 5 ) )] );
+        Assert.IsNull( await second.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+        RedisResult pending = await db.ExecuteAsync( "XPENDING", stream, "spotify-workers" );
+        Assert.IsGreaterThan( 0, (long)((RedisResult[])pending!)[0] );
+    }
+
+    /// <summary>Consumer-group recreation is idempotent after an operational group deletion.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task EnsureConsumerGroups_RecreatesDeletedGroup( ) {
+        IDatabase db = s_redis!.GetDatabase();
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        _ = await db.ExecuteAsync( "XGROUP", "DESTROY", stream, "spotify-workers" );
+        await _queue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+        RedisResult groups = await db.ExecuteAsync("XINFO", "GROUPS", stream);
+        RedisResult[] groupArray = (RedisResult[])groups!;
+        Assert.IsGreaterThan( 0, groupArray.Length );
+    }
+
+    /// <summary>Recreated groups start at the stream beginning and can drain pre-existing entries.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task EnsureConsumerGroups_RecreatesDeletedGroup_DequeuesPreExistingEntry( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        string stream = $"queue:{s_runToken}:spotify:interactive";
+        await _queue.EnqueueAsync( CreateTestRequest( lookupType: LookupRequestType.IsrcLookup ), QueuePriority.Interactive, TestContext.CancellationToken );
+        _ = await db.ExecuteAsync( "XGROUP", "DESTROY", stream, "spotify-workers" );
+
+        await _queue.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+
+        QueuedMessage<QueuedLookupRequest>? message = await _queue.DequeueAsync( TestContext.CancellationToken );
+        Assert.IsNotNull( message );
+    }
 
     /// <summary>The shared Redis connection used by the queue under test.</summary>
     private static IConnectionMultiplexer? s_redis;
@@ -102,6 +405,13 @@ public partial class RedisRequestQueueTests {
             _ = await db.KeyDeleteAsync( key );
         }
     }
+
+    private RedisRequestQueue<QueuedLookupRequest> NewQueue( string _ ) => new(
+        s_redis!,
+        new Mock<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ).Object,
+        _settings,
+        SupportedProviders.Spotify,
+        keyPrefix: s_runToken );
 
     /// <summary>
     /// Verifies enqueuing at interactive priority increases only the interactive depth.
@@ -215,6 +525,28 @@ public partial class RedisRequestQueueTests {
         Assert.AreEqual( 0, depth.Total );
     }
 
+    /// <summary>Unreadable deliveries are preserved in the DLQ instead of being silently destroyed.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_UnreadablePayload_MovesRawEntryToDlq( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        string interactive = $"queue:{s_runToken}:spotify:interactive";
+        string dlq = $"queue:{s_runToken}:spotify:dlq";
+        _ = await db.StreamAddAsync( interactive, [
+            new NameValueEntry( QueueStreamFieldNames.Payload, "{not-json" ),
+            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ] );
+
+        QueuedMessage<QueuedLookupRequest>? message = await _queue.DequeueAsync( TestContext.CancellationToken );
+
+        Assert.IsNull( message );
+        Assert.AreEqual( 0L, await db.StreamLengthAsync( interactive ) );
+        Assert.AreEqual( 1L, await db.StreamLengthAsync( dlq ) );
+        StreamEntry[] entries = await db.StreamRangeAsync( dlq );
+        Assert.AreEqual( "{not-json", entries[0][QueueStreamFieldNames.Payload].ToString( ) );
+        Assert.AreEqual( "Unreadable queue payload.", entries[0]["dlqReason"].ToString( ) );
+    }
+
     /// <summary>
     /// Verifies moving a dequeued message to the dead-letter queue removes it from the main queue and
     /// makes it retrievable from the DLQ.
@@ -230,6 +562,8 @@ public partial class RedisRequestQueueTests {
         Assert.IsNotNull( message );
 
         // Act
+        await _queue.MoveToDlqAsync( message.MessageId, "Test failure reason", TestContext.CancellationToken );
+        // Retrying after an ambiguous client-side outcome must not create a second DLQ entry.
         await _queue.MoveToDlqAsync( message.MessageId, "Test failure reason", TestContext.CancellationToken );
 
         // Assert - main queue empty, DLQ has message
@@ -473,6 +807,70 @@ public partial class RedisRequestQueueTests {
         QueuedMessage<QueuedLookupRequest>? requeued = await _queue.DequeueAsync( TestContext.CancellationToken );
         Assert.IsNotNull( requeued );
         Assert.AreEqual( request.RequestId, requeued.Payload.RequestId );
+    }
+
+    /// <summary>An own-PEL scan cannot return a delivery that a local task is still processing.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task DequeueAsync_ActiveOwnPelDelivery_IsNotReturnedConcurrently( ) {
+        await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+        Mock<BridgeBeats.Contracts.Interfaces.IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( value => value.GetAllRateLimitedAsync(
+                It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
+
+        QueuedMessage<QueuedLookupRequest>? first = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        Assert.IsNotNull( first );
+
+        QueuedMessage<QueuedLookupRequest>? duplicate = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        Assert.IsNull( duplicate );
+
+        ((IQueueDeliveryTracker)_queue).ReleaseDelivery( first.MessageId );
+        QueuedMessage<QueuedLookupRequest>? recovered = await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken );
+        Assert.IsNotNull( recovered );
+        Assert.AreEqual( first.MessageId, recovered.MessageId );
+        await _queue.AcknowledgeAsync( recovered.MessageId, TestContext.CancellationToken );
+    }
+
+    /// <summary>A transient requeue atomically replaces the delivery and advances its attempt.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RequeueAsync_TransientRetry_IncrementsAttemptExactlyOnce( ) {
+        QueuedLookupRequest request = CreateTestRequest( ) with { AttemptCount = 2 };
+        await _queue.EnqueueAsync( request, QueuePriority.Interactive, TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? original = await _queue.DequeueAsync( TestContext.CancellationToken );
+        Assert.IsNotNull( original );
+
+        await _queue.RequeueAsync( original.MessageId, cancellationToken: TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? retry = await _queue.DequeueAsync( TestContext.CancellationToken );
+
+        Assert.IsNotNull( retry );
+        Assert.AreEqual( 3, retry.Payload.AttemptCount );
+        await _queue.AcknowledgeAsync( retry.MessageId, TestContext.CancellationToken );
+    }
+
+    /// <summary>Rate-aware workers defer an ordinary transient retry until its backoff expires.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task RequeueAsync_TransientRetry_HonorsNotBefore( ) {
+        await _queue.EnqueueAsync( CreateTestRequest( ), QueuePriority.Interactive, TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? original = await _queue.DequeueAsync( TestContext.CancellationToken );
+        Assert.IsNotNull( original );
+        await _queue.RequeueAsync( original.MessageId, cancellationToken: TestContext.CancellationToken );
+
+        Mock<IRateLimitTracker> tracker = new( );
+        _ = tracker.Setup( value => value.GetAllRateLimitedAsync(
+                It.IsAny<SupportedProviders>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
+        Assert.IsNull( await _queue.DequeueAsync( tracker.Object, TestContext.CancellationToken ) );
+
+        await Task.Delay( TimeSpan.FromMilliseconds( 1100 ), TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest>? retry = await _queue.DequeueAsync(
+            tracker.Object, TestContext.CancellationToken );
+        Assert.IsNotNull( retry );
+        Assert.AreEqual( 1, retry.Payload.AttemptCount );
+        Assert.IsNotNull( retry.Payload.NotBefore );
+        await _queue.AcknowledgeAsync( retry.MessageId, TestContext.CancellationToken );
     }
 
     /// <summary>

--- a/Tests/Integration/RedisSagaStateManagerTests.cs
+++ b/Tests/Integration/RedisSagaStateManagerTests.cs
@@ -22,6 +22,155 @@ namespace BridgeBeats.Tests.Integration;
 [DoNotParallelize] // Shares Redis saga:* keys with SagaPollingIntegrationTests
 public class RedisSagaStateManagerTests {
 
+    /// <summary>Concurrent first creation returns one authoritative token and core state.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ConcurrentFirstCreate_ReturnsOneAuthoritativeTokenAndCoreState( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:CONCURRENT-FIRST-CREATE" );
+        LookupSagaState[] reads = await Task.WhenAll( Enumerable.Range( 0, 16 ).Select( index =>
+            _sagaManager.GetOrCreateAsync(
+                sagaId,
+                $"isrc:CONCURRENT-FIRST-CREATE-{index}",
+                LookupRequestType.IsrcLookup,
+                $"CONCURRENT-FIRST-CREATE-{index}",
+                index % 2 == 0 ? QueuePriority.Interactive : QueuePriority.Background,
+                TestContext.CancellationToken ) ) );
+
+        string token = reads[0].InstanceToken!;
+        Assert.IsFalse( string.IsNullOrWhiteSpace( token ) );
+        Assert.IsTrue( reads.All( read => read.InstanceToken == token ) );
+        Assert.IsTrue( reads.All( read => read.LookupKey == reads[0].LookupKey ) );
+        Assert.IsTrue( reads.All( read => read.LookupValue == reads[0].LookupValue ) );
+        LookupSagaState persisted = (await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken ))!;
+        Assert.AreEqual( token, persisted.InstanceToken );
+        Assert.AreEqual( reads[0].LookupKey, persisted.LookupKey );
+        Assert.AreEqual( reads[0].LookupValue, persisted.LookupValue );
+    }
+
+    /// <summary>Verifies stale instance tokens cannot mutate a recreated saga.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task StaleInstanceToken_CannotClaimRecreatedSaga( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId("isrc:STALE-TOKEN");
+        LookupSagaState first = await _sagaManager.GetOrCreateAsync(sagaId, "isrc:STALE-TOKEN", LookupRequestType.IsrcLookup, "STALE-TOKEN", cancellationToken: TestContext.CancellationToken);
+        Assert.IsNotNull( first.InstanceToken );
+        Assert.IsTrue( await _sagaManager.DeleteAsync( sagaId, TestContext.CancellationToken ) );
+        LookupSagaState second = await _sagaManager.GetOrCreateAsync(sagaId, "isrc:STALE-TOKEN", LookupRequestType.IsrcLookup, "STALE-TOKEN", cancellationToken: TestContext.CancellationToken);
+        Assert.AreNotEqual( first.InstanceToken, second.InstanceToken );
+        Assert.IsFalse( await _sagaManager.TryClaimFinalizeAsync( sagaId, first.InstanceToken!, TestContext.CancellationToken ) );
+        Assert.IsTrue( await _sagaManager.TryClaimFinalizeAsync( sagaId, second.InstanceToken!, TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Initial-provider writes cannot recreate or mutate a saga after its instance is replaced.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task StaleInstanceToken_CannotSetInitialProviderOnRecreatedSaga( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:STALE-INITIAL-PROVIDER" );
+        LookupSagaState first = await _sagaManager.GetOrCreateAsync(
+            sagaId, "isrc:STALE-INITIAL-PROVIDER", LookupRequestType.IsrcLookup,
+            "STALE-INITIAL-PROVIDER", cancellationToken: TestContext.CancellationToken );
+        Assert.IsNotNull( first.InstanceToken );
+        Assert.IsTrue( await _sagaManager.DeleteAsync( sagaId, TestContext.CancellationToken ) );
+        LookupSagaState second = await _sagaManager.GetOrCreateAsync(
+            sagaId, "isrc:STALE-INITIAL-PROVIDER", LookupRequestType.IsrcLookup,
+            "STALE-INITIAL-PROVIDER", cancellationToken: TestContext.CancellationToken );
+
+        Assert.IsFalse( await _sagaManager.TrySetInitialProviderAsync(
+            sagaId, SupportedProviders.Spotify, first.InstanceToken!, TestContext.CancellationToken ) );
+        Assert.IsTrue( await _sagaManager.TrySetInitialProviderAsync(
+            sagaId, SupportedProviders.AppleMusic, second.InstanceToken!, TestContext.CancellationToken ) );
+        LookupSagaState current = (await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken ))!;
+        Assert.AreEqual( SupportedProviders.AppleMusic, current.InitialProvider );
+    }
+
+    /// <summary>An explicitly stale finalize lease is replaced with a fresh instance and clean provider state.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ExplicitlyStaleFinalizeClaim_IsReplacedWithoutProviderContamination( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:STALE-FINALIZE" );
+        IDatabase db = s_redis!.GetDatabase( );
+        await db.HashSetAsync( $"saga:{sagaId}", [
+            new HashEntry( "lookupKey", "isrc:STALE-FINALIZE" ),
+            new HashEntry( "lookupType", "IsrcLookup" ),
+            new HashEntry( "lookupValue", "STALE-FINALIZE" ),
+            new HashEntry( "finalizeClaimed", "True" ),
+            new HashEntry( "finalizeClaimedAt", DateTimeOffset.UtcNow.AddHours( -1 ).ToUnixTimeMilliseconds( ) ),
+            new HashEntry( "instanceToken", "stale-instance" ) ] );
+        await db.HashSetAsync( $"saga:{sagaId}:provider:Spotify", [
+            new HashEntry( "isComplete", "True" ), new HashEntry( "isSuccess", "True" ),
+            new HashEntry( "resultJson", "stale-result" ), new HashEntry( "completedAt", "" ),
+            new HashEntry( "errorMessage", "" ) ] );
+
+        LookupSagaState replacement = await _sagaManager.GetOrCreateAsync(
+            sagaId, "isrc:STALE-FINALIZE", LookupRequestType.IsrcLookup, "STALE-FINALIZE",
+            cancellationToken: TestContext.CancellationToken );
+
+        Assert.AreNotEqual( "stale-instance", replacement.InstanceToken );
+        Assert.IsEmpty( replacement.ProviderStates );
+        Assert.IsNull( replacement.FinalResultUri );
+    }
+
+    /// <summary>A fresh finalize claim is not mistaken for a leftover during get-or-create.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task FreshFinalizeClaim_IsNotReplaced( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:FRESH-FINALIZE" );
+        IDatabase db = s_redis!.GetDatabase( );
+        await db.HashSetAsync( $"saga:{sagaId}", [
+            new HashEntry( "lookupKey", "isrc:FRESH-FINALIZE" ),
+            new HashEntry( "lookupType", "IsrcLookup" ),
+            new HashEntry( "lookupValue", "FRESH-FINALIZE" ),
+            new HashEntry( "finalizeClaimed", "True" ),
+            new HashEntry( "finalizeClaimedAt", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds( ) ),
+            new HashEntry( "instanceToken", "fresh-instance" ) ] );
+
+        LookupSagaState current = await _sagaManager.GetOrCreateAsync(
+            sagaId, "isrc:FRESH-FINALIZE", LookupRequestType.IsrcLookup, "FRESH-FINALIZE",
+            cancellationToken: TestContext.CancellationToken );
+
+        Assert.AreEqual( "fresh-instance", current.InstanceToken );
+        Assert.AreEqual( "True", (await db.HashGetAsync( $"saga:{sagaId}", "finalizeClaimed" )).ToString( ) );
+    }
+
+    /// <summary>A malformed persisted timestamp follows the typed unreadable-saga path.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task GetAsync_MalformedCreatedAt_ThrowsUnreadableSagaState( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:MALFORMED-TIMESTAMP" );
+        await s_redis!.GetDatabase( ).HashSetAsync( $"saga:{sagaId}", [
+            new HashEntry( "lookupKey", "isrc:MALFORMED-TIMESTAMP" ),
+            new HashEntry( "lookupType", "IsrcLookup" ),
+            new HashEntry( "lookupValue", "MALFORMED-TIMESTAMP" ),
+            new HashEntry( "createdAt", "not-a-timestamp" ),
+            new HashEntry( "instanceToken", "malformed-instance" ) ] );
+
+        _ = await Assert.ThrowsAsync<BridgeBeats.Contracts.Exceptions.UnreadableSagaStateException>(
+            ( ) => _sagaManager.GetAsync( sagaId, TestContext.CancellationToken ) );
+    }
+
+    /// <summary>A finalized saga's durable result URI is never replaced by a later get-or-create.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task FinalizedSaga_GetOrCreate_NeverReplacesFinalResultUri( ) {
+        string sagaId = ISagaStateManager.GenerateSagaId( "isrc:FINALIZED-URI" );
+        IDatabase db = s_redis!.GetDatabase( );
+        await db.HashSetAsync( $"saga:{sagaId}", [
+            new HashEntry( "lookupKey", "isrc:FINALIZED-URI" ),
+            new HashEntry( "lookupType", "IsrcLookup" ),
+            new HashEntry( "lookupValue", "FINALIZED-URI" ),
+            new HashEntry( "finalizeClaimed", "True" ),
+            new HashEntry( "finalizeClaimedAt", DateTimeOffset.UtcNow.AddHours( -1 ).ToUnixTimeMilliseconds( ) ),
+            new HashEntry( "finalResultUri", "at://durable/final" ),
+            new HashEntry( "instanceToken", "final-instance" ) ] );
+
+        LookupSagaState current = await _sagaManager.GetOrCreateAsync(
+            sagaId, "isrc:FINALIZED-URI", LookupRequestType.IsrcLookup, "FINALIZED-URI",
+            cancellationToken: TestContext.CancellationToken );
+
+        Assert.AreEqual( "at://durable/final", current.FinalResultUri );
+        Assert.AreEqual( "final-instance", current.InstanceToken );
+    }
+
     /// <summary>The shared Redis connection used by the saga manager under test.</summary>
     private static IConnectionMultiplexer? s_redis;
 
@@ -307,6 +456,93 @@ public class RedisSagaStateManagerTests {
         Assert.AreEqual( finalUri, saga.FinalResultUri );
     }
 
+    /// <summary>The fenced final URI remains first-writer-wins and is idempotent for the same URI.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task TrySetFinalResultUriAsync_PreservesFirstWriter( ) {
+        string lookupKey = "isrc:FIRSTWRITER0001";
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+        LookupSagaState saga = await _sagaManager.GetOrCreateAsync(
+            sagaId, lookupKey, LookupRequestType.IsrcLookup, "FIRSTWRITER0001",
+            cancellationToken: TestContext.CancellationToken );
+
+        SagaFinalResultWriteOutcome first = await _sagaManager.TrySetFinalResultUriAsync(
+            sagaId, "at://did:plc:test/link/first", saga.InstanceToken!, TestContext.CancellationToken );
+        SagaFinalResultWriteOutcome idempotentReplay = await _sagaManager.TrySetFinalResultUriAsync(
+            sagaId, "at://did:plc:test/link/first", saga.InstanceToken!, TestContext.CancellationToken );
+        SagaFinalResultWriteOutcome conflictingWriter = await _sagaManager.TrySetFinalResultUriAsync(
+            sagaId, "at://did:plc:test/link/second", saga.InstanceToken!, TestContext.CancellationToken );
+
+        Assert.AreEqual( SagaFinalResultWriteOutcome.Stored, first );
+        Assert.AreEqual( SagaFinalResultWriteOutcome.Idempotent, idempotentReplay );
+        Assert.AreEqual( SagaFinalResultWriteOutcome.Conflict, conflictingWriter );
+        Assert.AreEqual( "at://did:plc:test/link/first",
+            (await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken ))!.FinalResultUri );
+    }
+
+    /// <summary>Partial-result mutations renew the core hash TTL just like other saga writes.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task PartialResultMutations_RefreshSagaTtl( ) {
+        const string SagaId = "partial-ttl-refresh";
+        LookupSagaState saga = await _sagaManager.GetOrCreateAsync(
+            SagaId, "isrc:PARTIALTTL001", LookupRequestType.IsrcLookup, "PARTIALTTL001",
+            cancellationToken: TestContext.CancellationToken );
+        IDatabase db = s_redis!.GetDatabase( );
+        _ = await db.KeyExpireAsync( $"saga:{SagaId}", TimeSpan.FromSeconds( 2 ) );
+
+        Assert.IsTrue( await _sagaManager.TrySetPartialResultUriAsync(
+            SagaId, "at://did:plc:test/link/partial", saga.InstanceToken!, TestContext.CancellationToken ) );
+        TimeSpan? afterUri = await db.KeyTimeToLiveAsync( $"saga:{SagaId}" );
+        Assert.IsNotNull( afterUri );
+        Assert.IsGreaterThan( TimeSpan.FromMinutes( 50 ), afterUri.Value );
+
+        _ = await db.KeyExpireAsync( $"saga:{SagaId}", TimeSpan.FromSeconds( 2 ) );
+        Assert.IsTrue( await _sagaManager.TrySetIsPartialAsync(
+            SagaId, true, saga.InstanceToken!, TestContext.CancellationToken ) );
+        TimeSpan? afterFlag = await db.KeyTimeToLiveAsync( $"saga:{SagaId}" );
+        Assert.IsNotNull( afterFlag );
+        Assert.IsGreaterThan( TimeSpan.FromMinutes( 50 ), afterFlag.Value );
+    }
+
+    /// <summary>Marker, claim-release, and generation-reset writes all renew the core saga TTL.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task GuardedControlMutations_RefreshSagaTtl( ) {
+        const string SagaId = "guarded-control-ttl-refresh";
+        LookupSagaState saga = await _sagaManager.GetOrCreateAsync(
+            SagaId, "isrc:CONTROLTTL001", LookupRequestType.IsrcLookup, "CONTROLTTL001",
+            cancellationToken: TestContext.CancellationToken );
+        string token = saga.InstanceToken!;
+        IDatabase db = s_redis!.GetDatabase( );
+        string key = $"saga:{SagaId}";
+
+        _ = await db.KeyExpireAsync( key, TimeSpan.FromSeconds( 2 ) );
+        Assert.IsTrue( await _sagaManager.TryMarkSecondariesQueuedAsync(
+            SagaId, token, TestContext.CancellationToken ) );
+        await AssertTtlRenewedAsync( db, key );
+
+        Assert.IsTrue( await _sagaManager.TryClaimFinalizeAsync(
+            SagaId, token, TestContext.CancellationToken ) );
+        _ = await db.KeyExpireAsync( key, TimeSpan.FromSeconds( 2 ) );
+        Assert.IsTrue( await _sagaManager.TryReleaseFinalizeClaimAsync(
+            SagaId, token, TestContext.CancellationToken ) );
+        await AssertTtlRenewedAsync( db, key );
+
+        Assert.IsTrue( await _sagaManager.TryAdvanceWriteGenerationAsync(
+            SagaId, 1, token, TestContext.CancellationToken ) );
+        _ = await db.KeyExpireAsync( key, TimeSpan.FromSeconds( 2 ) );
+        Assert.IsTrue( await _sagaManager.TryResetWriteGenerationAsync(
+            SagaId, 1, 0, token, TestContext.CancellationToken ) );
+        await AssertTtlRenewedAsync( db, key );
+    }
+
+    private static async Task AssertTtlRenewedAsync( IDatabase db, string key ) {
+        TimeSpan? ttl = await db.KeyTimeToLiveAsync( key );
+        Assert.IsNotNull( ttl );
+        Assert.IsGreaterThan( TimeSpan.FromMinutes( 50 ), ttl.Value );
+    }
+
     /// <summary>
     /// Verifies deleting a saga returns true and removes the saga and its provider states so a
     /// subsequent fetch returns null.
@@ -538,7 +774,7 @@ public class RedisSagaStateManagerTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task InitializeProviderStatesAsync_PreservesExistingProviderState( ) {
+    public async Task TryInitializeProviderStatesAsync_PreservesExistingProviderState( ) {
         // Arrange
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -563,7 +799,7 @@ public class RedisSagaStateManagerTests {
         await _sagaManager.UpdateProviderStateAsync( sagaId, completedState, TestContext.CancellationToken );
 
         // Act - re-initialize including the already-completed provider
-        await _sagaManager.InitializeProviderStatesAsync(
+        await _sagaManager.TryInitializeProviderStatesAsync(
             sagaId,
             [SupportedProviders.Spotify, SupportedProviders.AppleMusic],
             TestContext.CancellationToken

--- a/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
+++ b/Tests/Integration/SagaFinalizeClaimIntegrationTests.cs
@@ -92,7 +92,7 @@ public class SagaFinalizeClaimIntegrationTests {
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task Finalize_UnderConcurrentTriggers_WritesExactlyOnce( ) {
         // Arrange - seed one complete, finalizable saga
-        _ = await _sagaManager.GetOrCreateAsync(
+        LookupSagaState seededSaga = await _sagaManager.GetOrCreateAsync(
             TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999001",
             QueuePriority.Interactive, TestContext.CancellationToken
         );
@@ -128,7 +128,8 @@ public class SagaFinalizeClaimIntegrationTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = false
+            IsPartial = false,
+            InstanceToken = seededSaga.InstanceToken
         };
 
         // Build all mocks needed by SagaCoordinatorBackgroundService
@@ -154,28 +155,28 @@ public class SagaFinalizeClaimIntegrationTests {
             .Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( completeSaga );
         _ = sagaMgrWrapper
-            .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, ct ) );
+            .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, seededSaga.InstanceToken!, ct ) );
         _ = sagaMgrWrapper
-            .Setup( s => s.ReleaseFinalizeClaimAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string _, CancellationToken ct ) => _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, ct ) );
+            .Setup( s => s.TryReleaseFinalizeClaimAsync( TestSagaId, seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, string _, CancellationToken ct ) => _sagaManager.TryReleaseFinalizeClaimAsync( TestSagaId, seededSaga.InstanceToken!, ct ) );
         _ = sagaMgrWrapper
-            .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, int gen, string _, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, seededSaga.InstanceToken!, ct ) );
         _ = sagaMgrWrapper
-            .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
-        _ = sagaMgrWrapper
-            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = sagaMgrWrapper
-            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = sagaMgrWrapper
-            .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
         _ = sagaMgrWrapper
-            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TrySetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TryDeleteAsync( It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagaMgrWrapper
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( false ); // ISRC saga: secondaries guard returns false (no fan-out)
 
         // N = 8 concurrent acquirers through a release gate

--- a/Tests/Integration/SagaPollingIntegrationTests.cs
+++ b/Tests/Integration/SagaPollingIntegrationTests.cs
@@ -85,7 +85,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_ReturnsCompleteSagasWithNoFinalUri( ) {
+    public async Task GetPendingReconciliationAsync_ReturnsCompleteSagasWithNoFinalUri( ) {
         // Arrange - Create a saga that is complete but not finalized
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -117,7 +117,7 @@ public class SagaPollingIntegrationTests {
         );
 
         // Act - Query for unfinalized sagas with minimum age of 0 seconds
-        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.Zero,
             limit: 100,
             cancellationToken: TestContext.CancellationToken
@@ -136,7 +136,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_ExcludesSagasWithFinalUri( ) {
+    public async Task GetPendingReconciliationAsync_IncludesFinalizedSagaUntilWaitersAreReleased( ) {
         // Arrange - Create a finalized saga
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -153,18 +153,20 @@ public class SagaPollingIntegrationTests {
             SupportedProviders.Spotify, true, true, "{}", DateTimeOffset.UtcNow, null
         ), TestContext.CancellationToken );
 
-        // Set final result URI - this should exclude it from polling
+        // Final URI persistence deliberately keeps the saga indexed until waiter release succeeds.
         await _sagaManager.SetFinalResultUriAsync( sagaId, "at://did:plc:test/link/abc", TestContext.CancellationToken );
 
         // Act
-        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.Zero,
             limit: 100,
             cancellationToken: TestContext.CancellationToken
         );
 
-        // Assert - Should be empty since saga was finalized
-        Assert.IsEmpty( results );
+        Assert.HasCount( 1, results );
+        LookupSagaState result = results[0];
+        Assert.AreEqual( sagaId, result.SagaId );
+        Assert.AreEqual( "at://did:plc:test/link/abc", result.FinalResultUri );
     }
 
     /// <summary>
@@ -173,7 +175,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_ExcludesIncompleteSagas( ) {
+    public async Task GetPendingReconciliationAsync_ExcludesIncompleteSagas( ) {
         // Arrange - Create an incomplete saga
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -192,7 +194,7 @@ public class SagaPollingIntegrationTests {
         ), TestContext.CancellationToken );
 
         // Act
-        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.Zero,
             limit: 100,
             cancellationToken: TestContext.CancellationToken
@@ -208,7 +210,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_RespectsMinimumAge( ) {
+    public async Task GetPendingReconciliationAsync_RespectsMinimumAge( ) {
         // Arrange - Create a saga that was just created
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -226,7 +228,7 @@ public class SagaPollingIntegrationTests {
         ), TestContext.CancellationToken );
 
         // Act - Query with 15-second minimum age (saga is too young)
-        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.FromSeconds( 15 ),
             limit: 100,
             cancellationToken: TestContext.CancellationToken
@@ -242,7 +244,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_RespectsLimit( ) {
+    public async Task GetPendingReconciliationAsync_RespectsLimit( ) {
         // Arrange - Create multiple sagas
         for (int i = 0; i < 5; i++) {
             string lookupKey = $"isrc:USRC{i:D10}";
@@ -270,7 +272,7 @@ public class SagaPollingIntegrationTests {
         }
 
         // Act - Query with limit of 3
-        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.Zero,
             limit: 3,
             cancellationToken: TestContext.CancellationToken
@@ -286,7 +288,7 @@ public class SagaPollingIntegrationTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task GetCompletedButUnfinalizedAsync_CleansUpExpiredSagasFromIndex( ) {
+    public async Task GetPendingReconciliationAsync_CleansUpExpiredSagasFromIndex( ) {
         // Arrange - Add a saga ID to the pending index but don't create the saga itself
         IDatabase db = s_redis!.GetDatabase( );
         _ = await db.SetAddAsync( "saga:pending", "expired-saga-id" );
@@ -296,7 +298,7 @@ public class SagaPollingIntegrationTests {
         Assert.Contains<RedisValue>( v => v.ToString( ) == "expired-saga-id", pendingBefore );
 
         // Act - Query should clean up the orphaned index entry
-        _ = await _sagaManager.GetCompletedButUnfinalizedAsync(
+        _ = await _sagaManager.GetPendingReconciliationAsync(
             minimumAge: TimeSpan.Zero,
             limit: 100,
             cancellationToken: TestContext.CancellationToken
@@ -305,6 +307,36 @@ public class SagaPollingIntegrationTests {
         // Assert - Orphaned entry should be removed from index
         RedisValue[] pendingAfter = await db.SetMembersAsync( "saga:pending" );
         Assert.DoesNotContain<RedisValue>( v => v.ToString( ) == "expired-saga-id", pendingAfter );
+    }
+
+    /// <summary>A malformed indexed saga is pruned without preventing healthy sagas from reconciling.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task GetPendingReconciliationAsync_UnreadableSaga_DoesNotAbortSweep( ) {
+        const string HealthySagaId = "healthy-reconciliation-saga";
+        LookupSagaState healthy = await _sagaManager.GetOrCreateAsync(
+            HealthySagaId, "isrc:HEALTHY000001", LookupRequestType.IsrcLookup, "HEALTHY000001",
+            cancellationToken: TestContext.CancellationToken );
+        _ = await _sagaManager.TryInitializeProviderStatesAsync(
+            HealthySagaId, [SupportedProviders.Spotify], healthy.InstanceToken!, TestContext.CancellationToken );
+        _ = await _sagaManager.TryUpdateProviderStateAsync(
+            HealthySagaId,
+            new ProviderLookupState( SupportedProviders.Spotify, true, true, "{}", DateTimeOffset.UtcNow, null ),
+            healthy.InstanceToken!, TestContext.CancellationToken );
+
+        IDatabase db = s_redis!.GetDatabase( );
+        const string PoisonSagaId = "poison-reconciliation-saga";
+        await db.HashSetAsync( $"saga:{PoisonSagaId}", [
+            new HashEntry( "lookupKey", "isrc:POISON000001" ),
+            new HashEntry( "instanceToken", "poison-token" )
+        ] );
+        _ = await db.SetAddAsync( "saga:pending", PoisonSagaId );
+
+        IReadOnlyList<LookupSagaState> results = await _sagaManager.GetPendingReconciliationAsync(
+            TimeSpan.Zero, cancellationToken: TestContext.CancellationToken );
+
+        Assert.Contains( HealthySagaId, results.Select( saga => saga.SagaId ) );
+        Assert.IsFalse( await db.SetContainsAsync( "saga:pending", PoisonSagaId ) );
     }
 
     /// <summary>
@@ -370,11 +402,11 @@ public class SagaPollingIntegrationTests {
     }
 
     /// <summary>
-    /// Verifies setting a saga's final result URI removes it from the pending index.
+    /// Verifies final URI persistence retains the reconciliation entry until waiter release removes it.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task SetFinalResultUriAsync_RemovesFromPendingIndex( ) {
+    public async Task SetFinalResultUriAsync_RetainsPendingIndexUntilExplicitRemoval( ) {
         // Arrange
         string lookupKey = "isrc:USRC12345678";
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
@@ -395,9 +427,13 @@ public class SagaPollingIntegrationTests {
         // Act
         await _sagaManager.SetFinalResultUriAsync( sagaId, "at://did:plc:test/link/abc", TestContext.CancellationToken );
 
-        // Assert - Should be removed from pending index
+        // Finalized-but-unnotified sagas remain discoverable by the polling backstop.
         RedisValue[] membersAfter = await db.SetMembersAsync( "saga:pending" );
-        Assert.DoesNotContain<RedisValue>( m => m.ToString( ) == sagaId, membersAfter );
+        Assert.Contains<RedisValue>( m => m.ToString( ) == sagaId, membersAfter );
+
+        await _sagaManager.RemoveFromPendingIndexAsync( sagaId, TestContext.CancellationToken );
+        RedisValue[] membersAfterRelease = await db.SetMembersAsync( "saga:pending" );
+        Assert.DoesNotContain<RedisValue>( m => m.ToString( ) == sagaId, membersAfterRelease );
     }
 
     /// <summary>

--- a/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
+++ b/Tests/Integration/SagaWriteGenerationIntegrationTests.cs
@@ -85,14 +85,14 @@ public class SagaWriteGenerationIntegrationTests {
     /// N=8 concurrent handlers all racing to finalize the same completion through the terminal path
     /// (<see cref="SagaCoordinatorBackgroundService.InvokeFinalizeForTestAsync"/>). The finalize-claim
     /// CAS ensures exactly one handler wins the claim and performs the PDS write; all others are
-    /// rejected by <see cref="ISagaStateManager.TryClaimFinalizeAsync"/> before writing. This is the
+    /// rejected by the finalize-claim CAS before writing. This is the
     /// concurrent-terminal-trigger proof for the #315 claim-dedup guard.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task ConcurrentTerminalTriggers_SameCompletion_ProducesExactlyOnePdsWrite( ) {
         // Arrange - seed one complete, finalizable saga
-        _ = await _sagaManager.GetOrCreateAsync(
+        LookupSagaState seededSaga = await _sagaManager.GetOrCreateAsync(
             TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
             QueuePriority.Interactive, TestContext.CancellationToken
         );
@@ -127,7 +127,8 @@ public class SagaWriteGenerationIntegrationTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = false
+            IsPartial = false,
+            InstanceToken = seededSaga.InstanceToken
         };
 
         SagaCoordinatorBackgroundService BuildService( ) {
@@ -152,28 +153,28 @@ public class SagaWriteGenerationIntegrationTests {
                 .Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
                 .ReturnsAsync( completeSaga );
             _ = sagaMgrWrapper
-                .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, ct ) );
+                .Setup( s => s.TryClaimFinalizeAsync( TestSagaId, seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, string _, CancellationToken ct ) => _sagaManager.TryClaimFinalizeAsync( TestSagaId, seededSaga.InstanceToken!, ct ) );
             _ = sagaMgrWrapper
-                .Setup( s => s.ReleaseFinalizeClaimAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, CancellationToken ct ) => _sagaManager.ReleaseFinalizeClaimAsync( TestSagaId, ct ) );
+                .Setup( s => s.TryReleaseFinalizeClaimAsync( TestSagaId, seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, string _, CancellationToken ct ) => _sagaManager.TryReleaseFinalizeClaimAsync( TestSagaId, seededSaga.InstanceToken!, ct ) );
             _ = sagaMgrWrapper
-                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int gen, string _, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, seededSaga.InstanceToken!, ct ) );
             _ = sagaMgrWrapper
-                .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
-            _ = sagaMgrWrapper
-                .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( Task.CompletedTask );
-            _ = sagaMgrWrapper
-                .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( Task.CompletedTask );
-            _ = sagaMgrWrapper
-                .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Setup( s => s.TryResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
                 .ReturnsAsync( true );
             _ = sagaMgrWrapper
-                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TrySetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( true );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryDeleteAsync( It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( true );
+            _ = sagaMgrWrapper
+                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), seededSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
                 .ReturnsAsync( false );
 
             return new SagaCoordinatorBackgroundService(
@@ -221,7 +222,7 @@ public class SagaWriteGenerationIntegrationTests {
     /// <summary>
     /// N=8 concurrent handlers all racing to write the same generation (k=1) through the
     /// non-terminal partial path (<see cref="SagaCoordinatorBackgroundService.InvokeWriteForTestAsync"/>
-    /// with <c>terminal: false</c>). The write-generation CAS (<see cref="ISagaStateManager.TryAdvanceWriteGenerationAsync"/>)
+    /// with <c>terminal: false</c>). The write-generation CAS
     /// must ensure exactly one PDS write — the first racer to advance the generation wins; all
     /// others find the CAS already advanced and return without writing. This is the direct
     /// concurrent-partial-write dedup proof for the generation CAS.
@@ -230,7 +231,7 @@ public class SagaWriteGenerationIntegrationTests {
     [Timeout( 30000, CooperativeCancellation = true )]
     public async Task ConcurrentPartialHandlers_SameGeneration_ProducesExactlyOnePdsWrite( ) {
         // Arrange - seed the saga
-        _ = await _sagaManager.GetOrCreateAsync(
+        LookupSagaState seededPartialSaga = await _sagaManager.GetOrCreateAsync(
             TestSagaId, TestLookupKey, LookupRequestType.IsrcLookup, "USRC99999002",
             QueuePriority.Interactive, TestContext.CancellationToken
         );
@@ -265,7 +266,8 @@ public class SagaWriteGenerationIntegrationTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = seededPartialSaga.InstanceToken
         };
 
         SagaCoordinatorBackgroundService BuildPartialService( ) {
@@ -290,19 +292,22 @@ public class SagaWriteGenerationIntegrationTests {
             HashSet<SupportedProviders> enabledProviders = [SupportedProviders.Spotify];
 
             Mock<ISagaStateManager> sagaMgrWrapper = new( );
-            // Only TryAdvanceWriteGenerationAsync and ResetWriteGenerationAsync hit real Redis;
+            _ = sagaMgrWrapper
+                .Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( partialSaga );
+            // Only token-fenced generation operations hit real Redis;
             // all other saga manager calls are mocked to succeed without side effects.
             _ = sagaMgrWrapper
-                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, int gen, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, ct ) );
+                .Setup( s => s.TryAdvanceWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), seededPartialSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .Returns( ( string _, int gen, string _, CancellationToken ct ) => _sagaManager.TryAdvanceWriteGenerationAsync( TestSagaId, gen, seededPartialSaga.InstanceToken!, ct ) );
             _ = sagaMgrWrapper
-                .Setup( s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( ( string _, int advTo, int prior, CancellationToken ct ) => _sagaManager.ResetWriteGenerationAsync( TestSagaId, advTo, prior, ct ) );
+                .Setup( s => s.TryResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), seededPartialSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( true );
             _ = sagaMgrWrapper
-                .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-                .Returns( Task.CompletedTask );
+                .Setup( s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), seededPartialSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+                .ReturnsAsync( true );
             _ = sagaMgrWrapper
-                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), seededPartialSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
                 .ReturnsAsync( false );
 
             return new SagaCoordinatorBackgroundService(
@@ -444,7 +449,7 @@ public class SagaWriteGenerationIntegrationTests {
     }
 
     /// <summary>
-    /// Verifies the conditional semantics of <see cref="RedisSagaStateManager.ResetWriteGenerationAsync"/>:
+    /// Verifies the conditional semantics of the fenced write-generation reset:
     /// a stale caller (handler A) that attempts to reset after a newer handler (handler B) has
     /// already advanced the generation further must NOT clobber the higher generation. The stored
     /// value must remain at the higher generation after the stale reset attempt.

--- a/Tests/Integration/SpotifyBulkRejectionFallbackIntegrationTests.cs
+++ b/Tests/Integration/SpotifyBulkRejectionFallbackIntegrationTests.cs
@@ -18,8 +18,8 @@ namespace BridgeBeats.Tests.Integration;
 /// <summary>
 /// Integration test for the 4xx bulk-rejection fallback: seeds the bulk track stream, mocks the
 /// lookup service to throw <see cref="SpotifyBulkRejectedException"/>, runs one cycle, and verifies
-/// that the bulk stream drains to 0 and each item is forwarded to the inner queue at Interactive
-/// priority rather than being re-added to the bulk stream.
+/// that the bulk stream drains to 0 and each item is atomically forwarded to the interactive
+/// stream rather than being re-added to the bulk stream.
 /// </summary>
 /// <remarks>
 /// Guards against a regression where the rejection path silently discards items (the stream drains
@@ -69,6 +69,7 @@ public class SpotifyBulkRejectionFallbackIntegrationTests {
     public async Task TestInitialize( ) {
         IDatabase db = s_redis!.GetDatabase( );
         _ = await db.KeyDeleteAsync( SpotifyConstants.BulkTrackIdStream );
+        _ = await db.KeyDeleteAsync( SpotifyConstants.BackgroundStream );
     }
 
     /// <summary>
@@ -124,16 +125,9 @@ public class SpotifyBulkRejectionFallbackIntegrationTests {
         _ = lookupServiceMock.Setup( s => s.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
             .ThrowsAsync( new SpotifyBulkRejectedException( 400, null, SupportedProviders.Spotify ) );
 
-        // Mock the inner request queue to capture Interactive re-enqueues
-        List<(QueuedLookupRequest Request, QueuePriority Priority)> capturedEnqueues = [];
+        // The handoff now writes atomically through Redis; the generic queue remains required by
+        // the service for unrelated DLQ paths but is not involved in rejection forwarding.
         Mock<IRequestQueue<QueuedLookupRequest>> requestQueueMock = new( );
-        _ = requestQueueMock.Setup( q => q.EnqueueAsync(
-                It.IsAny<QueuedLookupRequest>( ),
-                It.IsAny<QueuePriority>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( QueuedLookupRequest r, QueuePriority p, CancellationToken _ ) =>
-                capturedEnqueues.Add( (r, p) ) )
-            .Returns( Task.CompletedTask );
 
         // Wire up remaining mocks
         Mock<IRateLimitTracker> rateLimitTrackerMock = new( );
@@ -185,14 +179,91 @@ public class SpotifyBulkRejectionFallbackIntegrationTests {
         Assert.AreEqual( 0L, depthAfter,
             "Bulk track stream must be empty after the 4xx rejection cycle — original entries must be acknowledged" );
 
-        // Assert (b): items forwarded to the inner queue at Interactive priority, not re-added to bulk
-        Assert.HasCount( 2, capturedEnqueues,
-            "Both items must be forwarded to the inner queue as individual Interactive lookups" );
-        Assert.IsTrue( capturedEnqueues.All( e => e.Priority == QueuePriority.Interactive ),
-            "All re-enqueued items must carry Interactive priority" );
+        // Assert (b): exactly two items were atomically forwarded to the single-item background stream.
+        StreamEntry[] background = await db.StreamRangeAsync( SpotifyConstants.BackgroundStream );
+        Assert.HasCount( 2, background,
+            "Both items must be forwarded as individual background lookups" );
+        List<QueuedLookupRequest?> forwarded = [.. background
+            .Select( entry => JsonSerializer.Deserialize<QueuedLookupRequest>(
+                entry[QueueStreamFieldNames.Payload].ToString( ), s_jsonOptions ) )];
         Assert.IsTrue(
-            capturedEnqueues.Any( e => e.Request.LookupValue == TrackId1 ) &&
-            capturedEnqueues.Any( e => e.Request.LookupValue == TrackId2 ),
+            forwarded.Any( request => request?.LookupValue == TrackId1 ) &&
+            forwarded.Any( request => request?.LookupValue == TrackId2 ),
             "Both track IDs must appear in the re-enqueued items" );
+        Assert.IsTrue( forwarded.All( request => request?.EnqueueOrigin == QueueEnqueueOrigin.Requeue ) );
+        Assert.IsTrue( forwarded.All( request => request?.BypassBulkRouting == true ) );
+        requestQueueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
+    }
+
+    /// <summary>
+    /// A delivery left pending in this consumer's PEL is returned on the next dequeue without
+    /// waiting for the aged XAUTOCLAIM threshold; this is the recovery path after a lost XACK.
+    /// </summary>
+    [TestMethod]
+    public async Task BulkTrackOwnPelEntry_IsRecoveredBeforeAutoClaimIdleThreshold( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        const string TrackId = "spotifyOwnPelRecoveryTrack";
+        QueuedLookupRequest request = new( ) {
+            RequestId = Guid.NewGuid( ).ToString( "N" ),
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.SongIdLookup,
+            LookupValue = TrackId,
+            SagaId = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            OriginPriority = QueuePriority.Bulk,
+            AttemptCount = 0
+        };
+        _ = await db.StreamAddAsync( SpotifyConstants.BulkTrackIdStream, [
+            new NameValueEntry( QueueStreamFieldNames.Payload, JsonSerializer.Serialize( request, s_jsonOptions ) ),
+            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ] );
+
+        SpotifyBatchQueueHelper helper = new(
+            s_redis,
+            new Mock<ILogger<SpotifyBatchQueueHelper>>( ).Object );
+        await helper.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+
+        IReadOnlyList<QueuedMessage<QueuedLookupRequest>> first =
+            await helper.DequeueTrackIdBatchAsync( 1, TestContext.CancellationToken );
+        Assert.HasCount( 1, first );
+
+        // Do not ACK: this is the lost-ACK state. The entry remains owned by this helper's consumer.
+        IReadOnlyList<QueuedMessage<QueuedLookupRequest>> recovered =
+            await helper.DequeueTrackIdBatchAsync( 1, TestContext.CancellationToken );
+
+        Assert.HasCount( 1, recovered );
+        Assert.AreEqual( first[0].MessageId, recovered[0].MessageId );
+    }
+
+    /// <summary>A repeated rejection handoff cannot create a second interactive replacement.</summary>
+    [TestMethod]
+    public async Task ForwardToBackground_RepeatedForSameSource_IsIdempotent( ) {
+        IDatabase db = s_redis!.GetDatabase( );
+        QueuedLookupRequest request = new( ) {
+            RequestId = Guid.NewGuid( ).ToString( "N" ),
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.SongIdLookup,
+            LookupValue = "spotifyAtomicHandoffTrack",
+            SagaId = "dddddddddddddddddddddddddddddddd",
+            OriginPriority = QueuePriority.Bulk
+        };
+        _ = await db.StreamAddAsync( SpotifyConstants.BulkTrackIdStream, [
+            new NameValueEntry( QueueStreamFieldNames.Payload, JsonSerializer.Serialize( request, s_jsonOptions ) ),
+            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ] );
+        SpotifyBatchQueueHelper helper = new(
+            s_redis!, new Mock<ILogger<SpotifyBatchQueueHelper>>( ).Object );
+        await helper.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+        QueuedMessage<QueuedLookupRequest> message = (await helper.DequeueTrackIdBatchAsync(
+            1, TestContext.CancellationToken )).Single( );
+
+        bool first = await helper.ForwardToSingleItemAsync( message, TestContext.CancellationToken );
+        bool repeated = await helper.ForwardToSingleItemAsync( message, TestContext.CancellationToken );
+
+        Assert.IsTrue( first );
+        Assert.IsFalse( repeated );
+        Assert.AreEqual( 0L, await db.StreamLengthAsync( SpotifyConstants.BulkTrackIdStream ) );
+        Assert.AreEqual( 1L, await db.StreamLengthAsync( SpotifyConstants.BackgroundStream ) );
     }
 }

--- a/Tests/Integration/StaleCacheRefreshSagaCompletionIntegrationTests.cs
+++ b/Tests/Integration/StaleCacheRefreshSagaCompletionIntegrationTests.cs
@@ -141,7 +141,7 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
 
         // Assert — at least one leg enqueued and registered set captured.
         Assert.IsNotEmpty( enqueuedLegs, "Refresh pass must enqueue at least one leg." );
-        Assert.IsNotNull( registeredProviders, "InitializeProviderStatesAsync must have been called." );
+        Assert.IsNotNull( registeredProviders, "TryInitializeProviderStatesAsync must have been called." );
 
         HashSet<SupportedProviders> registered = [.. registeredProviders];
         string sagaId = enqueuedLegs[0].SagaId;
@@ -154,9 +154,12 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
             "Registered provider set must equal the enqueued-leg provider set (mode-B fix)." );
 
         // Now complete all enqueued legs: write a successful ProviderLookupState for each.
+        LookupSagaState? initializedSaga = await _sagaManager.GetAsync( sagaId, TestContext.CancellationToken );
+        Assert.IsNotNull( initializedSaga );
+        Assert.IsFalse( string.IsNullOrWhiteSpace( initializedSaga!.InstanceToken ) );
         foreach (QueuedLookupRequest leg in enqueuedLegs) {
             string resultJson = BuildResultJson( leg.Provider, TestIsrc );
-            await _sagaManager.UpdateProviderStateAsync(
+            bool updated = await _sagaManager.TryUpdateProviderStateAsync(
                 sagaId,
                 new ProviderLookupState(
                     Provider: leg.Provider,
@@ -165,7 +168,9 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
                     ResultJson: resultJson,
                     CompletedAt: DateTimeOffset.UtcNow,
                     ErrorMessage: null ),
+                initializedSaga.InstanceToken!,
                 TestContext.CancellationToken );
+            Assert.IsTrue( updated, $"Provider state update for {leg.Provider} must use the active saga instance." );
         }
 
         // Read the saga back and verify IsComplete.
@@ -214,7 +219,7 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
             sagaId, LookupKey, LookupRequestType.IsrcLookup, TestIsrc,
             QueuePriority.Bulk, TestContext.CancellationToken );
 
-        await _sagaManager.InitializeProviderStatesAsync(
+        await _sagaManager.TryInitializeProviderStatesAsync(
             sagaId, [SupportedProviders.Spotify], TestContext.CancellationToken );
 
         await _sagaManager.UpdateProviderStateAsync(
@@ -375,6 +380,24 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
             firstPassLegs.Select( l => l.Provider ).ToArray( ),
             "First pass must produce one leg per enabled provider." );
 
+        // The first pass has drained its two legs before the record is selected again. Mark both
+        // provider legs terminal so FIX 5's active-saga guard does not suppress the intentional
+        // cross-window fallback scenario below.
+        foreach (SupportedProviders provider in firstPassLegs.Select( l => l.Provider ).Distinct( )) {
+            await _sagaManager.UpdateProviderStateAsync(
+                firstPassLegs[0].SagaId,
+                new ProviderLookupState(
+                    Provider: provider,
+                    IsComplete: true,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: "Simulated first-pass completion"
+                ),
+                TestContext.CancellationToken
+            );
+        }
+
         // ── Step 2: Simulate Apple lookup failure — write back record with Spotify only. ──────
         // The age-only rule: LookedUpAt must be past the cache window for re-selection.
         MediaLinkResult partialRecord = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -61 ) };
@@ -439,7 +462,7 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
 
     /// <summary>
     /// Builds a saga manager wrapper that delegates all calls to the real <see cref="RedisSagaStateManager"/>
-    /// but also invokes <paramref name="captureRegistered"/> when <c>InitializeProviderStatesAsync</c> is called.
+    /// but also invokes <paramref name="captureRegistered"/> when <c>TryInitializeProviderStatesAsync</c> is called.
     /// </summary>
     private static Mock<ISagaStateManager> BuildSagaManagerWrapper(
         RedisSagaStateManager realManager,
@@ -455,11 +478,11 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
                 realManager.GetOrCreateAsync( id, key, type, val, prio, ct ) );
 
         _ = wrapper
-            .Setup( s => s.InitializeProviderStatesAsync(
-                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string id, IEnumerable<SupportedProviders> providers, CancellationToken ct ) => {
+            .Setup( s => s.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( async ( string id, IEnumerable<SupportedProviders> providers, string token, CancellationToken ct ) => {
                 captureRegistered?.Invoke( providers );
-                return realManager.InitializeProviderStatesAsync( id, providers, ct );
+                return await realManager.TryInitializeProviderStatesAsync( id, providers, token, ct );
             } );
 
         _ = wrapper
@@ -467,10 +490,10 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
             .Returns( ( string id, CancellationToken ct ) => realManager.GetAsync( id, ct ) );
 
         _ = wrapper
-            .Setup( s => s.UpdateProviderStateAsync(
-                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string id, ProviderLookupState state, CancellationToken ct ) =>
-                realManager.UpdateProviderStateAsync( id, state, ct ) );
+            .Setup( s => s.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string id, ProviderLookupState state, string token, CancellationToken ct ) =>
+                realManager.TryUpdateProviderStateAsync( id, state, token, ct ) );
 
         return wrapper;
     }
@@ -615,10 +638,10 @@ public class StaleCacheRefreshSagaCompletionIntegrationTests {
                 It.IsAny<RefreshReviewEntry>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );
         _ = store.Setup( candidate => candidate.MarkUnresolvedAsync(
-                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );
         _ = store.Setup( candidate => candidate.CompleteAsync(
-                It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );
         return store.Object;
     }

--- a/Tests/Integration/WorkerEndpointContractIntegrationTests.cs
+++ b/Tests/Integration/WorkerEndpointContractIntegrationTests.cs
@@ -1,0 +1,426 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using BridgeBeats.Contracts.Constants;
+using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Contracts.Records.WorkerApi;
+using BridgeBeats.Core.Domain.Extensions;
+using BridgeBeats.Core.Domain.Providers.Common;
+using BridgeBeats.Core.Domain.Services.Queue;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using StackExchange.Redis;
+
+namespace BridgeBeats.Tests.Integration;
+
+/// <summary>End-to-end contract tests through the production worker endpoint mapper and proxy.</summary>
+[TestClass]
+public sealed class WorkerEndpointContractIntegrationTests {
+    /// <summary>MSTest cancellation token for HTTP requests.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Non-JSON rate-limit responses use numeric or HTTP-date Retry-After metadata.</summary>
+    [TestMethod]
+    [DataRow( "10" )]
+    public async Task ProductionProxy_NonJson429_ParsesRetryMetadataIntoBaseException( string retryAfter ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        _ = response.Headers.TryAddWithoutValidation( "Retry-After", retryAfter );
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => new HttpMusicLookupService( SupportedProviders.Spotify, CreateStaticFactory( response ), "spotify", NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-429" ) );
+        Assert.IsGreaterThanOrEqualTo( 0, exception.RetryAfterValue.TotalSeconds );
+    }
+
+    /// <summary>HTTP-date Retry-After metadata is accepted on a non-JSON 429 response.</summary>
+    [TestMethod]
+    public async Task ProductionProxy_NonJson429_HttpDateParsesIntoBaseException( ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        _ = response.Headers.TryAddWithoutValidation( "Retry-After", DateTimeOffset.UtcNow.AddMinutes( 10 ).ToString( "R" ) );
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => new HttpMusicLookupService( SupportedProviders.Spotify, CreateStaticFactory( response ), "spotify", NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-429-DATE" ) );
+        Assert.IsGreaterThan( 0, exception.RetryAfterValue.TotalSeconds );
+    }
+
+    /// <summary>Missing or invalid rate-limit metadata remains a status-bearing failure.</summary>
+    [TestMethod]
+    [DataRow( null )]
+    [DataRow( "not-a-date" )]
+    public async Task ProductionProxy_429MissingOrInvalidRetryMetadata_ThrowsStatusBearingFailure( string? retryAfter ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        if (retryAfter is not null) _ = response.Headers.TryAddWithoutValidation( "Retry-After", retryAfter );
+        HttpRequestException exception = await Assert.ThrowsExactlyAsync<HttpRequestException>(
+            ( ) => new HttpMusicLookupService( SupportedProviders.Spotify, CreateStaticFactory( response ), "spotify", NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-429" ) );
+        Assert.AreEqual( HttpStatusCode.TooManyRequests, exception.StatusCode );
+    }
+
+    /// <summary>The precise envelope delay wins over the ceiling-rounded Retry-After header.</summary>
+    [TestMethod]
+    public async Task ProductionProxy_429EnvelopePrecisionPreventsFalseThresholdExceeded( ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests ) {
+            Content = JsonContent.Create( ProviderLookupResponse.Error(
+                "Provider rate limit exceeded.", retryAfterSeconds: 30.2, retryThresholdSeconds: 30.5 ) )
+        };
+        _ = response.Headers.TryAddWithoutValidation( "Retry-After", "31" );
+
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => new HttpMusicLookupService(
+                    SupportedProviders.Spotify,
+                    CreateStaticFactory( response ),
+                    "spotify",
+                    NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-PRECISE-RETRY" ) );
+
+        Assert.AreEqual( 30.2, exception.RetryAfterValue.TotalSeconds, 0.001 );
+    }
+
+    /// <summary>Non-JSON 503 and 200 responses become status-bearing protocol failures.</summary>
+    [TestMethod]
+    [DataRow( HttpStatusCode.ServiceUnavailable )]
+    [DataRow( HttpStatusCode.OK )]
+    public async Task ProductionProxy_NonJsonResponse_ThrowsStatusBearingProtocolFailure( HttpStatusCode status ) {
+        using HttpResponseMessage response = new( status ) { Content = new StringContent( "not-json" ) };
+        HttpRequestException exception = await Assert.ThrowsExactlyAsync<HttpRequestException>(
+            ( ) => new HttpMusicLookupService( SupportedProviders.Spotify, CreateStaticFactory( response ), "spotify", NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-PROTOCOL" ) );
+        Assert.AreEqual( status, exception.StatusCode );
+    }
+
+    private static IHttpClientFactory CreateStaticFactory( HttpResponseMessage response ) {
+        Mock<IHttpClientFactory> factory = new( );
+        _ = factory.Setup( value => value.CreateClient( It.IsAny<string>( ) ) )
+            .Returns( new HttpClient( new StaticResponseHandler( response ) ) { BaseAddress = new Uri( "https://worker.test" ) } );
+        return factory.Object;
+    }
+
+    private sealed class StaticResponseHandler( HttpResponseMessage response ) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+            => Task.FromResult( response );
+    }
+
+    /// <summary>Production proxy success traverses the mapped worker endpoint.</summary>
+    [TestMethod]
+    public async Task CurrentContractSuccess_TraversesEndpointAndProductionProxy( ) {
+        await using WebApplication app = await StartAsync( FakeLookupMode.Success );
+        Mock<IHttpClientFactory> factory = CreateFactory( app );
+        HttpMusicLookupService proxy = new( SupportedProviders.Spotify, factory.Object, "spotify", NullLogger<HttpMusicLookupService>.Instance );
+
+        MusicLookupResult? result = await proxy.GetInfoByISRCAsync( "US-TEST" );
+
+        Assert.IsNotNull( result );
+        Assert.AreEqual( "US-TEST", result!.ExternalId );
+    }
+
+    /// <summary>Current rate-limit responses carry retry metadata and no upstream secret.</summary>
+    [TestMethod]
+    public async Task CurrentContractRateLimit_ExposesCanonicalMetadataAndSanitizesSecrets( ) {
+        await using WebApplication app = await StartAsync( FakeLookupMode.RateLimited );
+        using HttpClient client = app.GetTestClient( );
+        using HttpRequestMessage request = new( HttpMethod.Post, "/lookup/isrc" ) {
+            Content = JsonContent.Create( new LookupByIsrcRequest( "US-SECRET" ) )
+        };
+        using HttpResponseMessage response = await client.SendAsync( request, TestContext.CancellationToken );
+        string body = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.TooManyRequests, response.StatusCode );
+        Assert.AreEqual( "10", response.Headers.GetValues( "Retry-After" ).Single( ) );
+        ProviderLookupResponse? envelope = await response.Content.ReadFromJsonAsync<ProviderLookupResponse>( TestContext.CancellationToken );
+        Assert.IsNotNull( envelope );
+        Assert.AreEqual( "Provider rate limit exceeded.", envelope.ErrorMessage );
+        Assert.AreEqual( 10d, envelope.RetryAfterSeconds );
+        Assert.AreEqual( 5d, envelope.RetryThresholdSeconds );
+        Assert.IsFalse( body.Contains( "secret-upstream-uri", StringComparison.Ordinal ) );
+    }
+
+    /// <summary>Retry-After values beyond the header's integer range are clamped safely.</summary>
+    [TestMethod]
+    public async Task CurrentContractRateLimit_ClampsHugeRetryAfterHeaderToIntMax( ) {
+        await using WebApplication app = await StartAsync( FakeLookupMode.HugeRateLimited );
+        using HttpRequestMessage request = new( HttpMethod.Post, "/lookup/isrc" ) {
+            Content = JsonContent.Create( new LookupByIsrcRequest( "US-HUGE-RETRY" ) )
+        };
+
+        using HttpResponseMessage response = await app.GetTestClient( ).SendAsync( request, TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.TooManyRequests, response.StatusCode );
+        Assert.AreEqual( int.MaxValue.ToString( CultureInfo.InvariantCulture ),
+            response.Headers.GetValues( "Retry-After" ).Single( ) );
+    }
+
+    /// <summary>The current contract distinguishes a successful no-match from a thrown not-found failure.</summary>
+    [TestMethod]
+    public async Task CurrentContractNullResult_Returns200SuccessNotFoundEnvelope( ) {
+        await using WebApplication app = await StartAsync( FakeLookupMode.NotFound );
+        using HttpClient client = app.GetTestClient( );
+        using HttpRequestMessage request = new( HttpMethod.Post, "/lookup/isrc" ) {
+            Content = JsonContent.Create( new LookupByIsrcRequest( "US-MISSING" ) )
+        };
+        using HttpResponseMessage response = await client.SendAsync( request, TestContext.CancellationToken );
+        ProviderLookupResponse? envelope = await response.Content.ReadFromJsonAsync<ProviderLookupResponse>( TestContext.CancellationToken );
+        Assert.AreEqual( HttpStatusCode.OK, response.StatusCode );
+        Assert.IsTrue( envelope!.Success );
+        Assert.IsNull( envelope.Result );
+    }
+
+    /// <summary>The current contract maps classified provider failures to status-bearing responses.</summary>
+    [TestMethod]
+    [DataRow( FakeLookupMode.Upstream, HttpStatusCode.ServiceUnavailable )]
+    [DataRow( FakeLookupMode.Timeout, HttpStatusCode.GatewayTimeout )]
+    [DataRow( FakeLookupMode.Unexpected, HttpStatusCode.InternalServerError )]
+    public async Task CurrentContractFailureMapping_UsesSanitizedStatus( FakeLookupMode mode, HttpStatusCode expectedStatus ) {
+        await using WebApplication app = await StartAsync( mode );
+        using HttpClient client = app.GetTestClient( );
+        using HttpRequestMessage request = new( HttpMethod.Post, "/lookup/isrc" ) {
+            Content = JsonContent.Create( new LookupByIsrcRequest( "US-FAIL" ) )
+        };
+        using HttpResponseMessage response = await client.SendAsync( request, TestContext.CancellationToken );
+        string body = await response.Content.ReadAsStringAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( expectedStatus, response.StatusCode );
+        Assert.IsFalse( body.Contains( "secret-upstream-uri", StringComparison.Ordinal ) );
+        Assert.IsFalse( body.Contains( "secret-exception", StringComparison.Ordinal ) );
+    }
+
+    /// <summary>Unexpected endpoint failures log one exception-bearing entry while returning sanitized 500.</summary>
+    [TestMethod]
+    public async Task CurrentContractUnexpectedFailure_LogsExceptionOnce( ) {
+        CapturingLoggerProvider provider = new( );
+        await using WebApplication app = await StartAsync( FakeLookupMode.Unexpected, provider );
+        using HttpRequestMessage request = new( HttpMethod.Post, "/lookup/isrc" ) {
+            Content = JsonContent.Create( new LookupByIsrcRequest( "US-UNEXPECTED" ) )
+        };
+        using HttpResponseMessage response = await app.GetTestClient( ).SendAsync( request, TestContext.CancellationToken );
+
+        Assert.AreEqual( HttpStatusCode.InternalServerError, response.StatusCode );
+        _ = Assert.ContainsSingle( provider.Exceptions );
+        _ = Assert.IsInstanceOfType<InvalidOperationException>( provider.Exceptions[0] );
+    }
+
+    /// <summary>The production proxy maps current-contract not-found to null and 503 to a status-bearing exception.</summary>
+    [TestMethod]
+    public async Task ProductionProxy_MapsCurrentNotFoundAndUnavailable( ) {
+        await using WebApplication notFoundApp = await StartAsync( FakeLookupMode.NotFound );
+        MusicLookupResult? notFound = await new HttpMusicLookupService(
+            SupportedProviders.Spotify, CreateFactory( notFoundApp ).Object, "spotify", NullLogger<HttpMusicLookupService>.Instance )
+            .GetInfoByISRCAsync( "US-MISSING" );
+        Assert.IsNull( notFound );
+
+        await using WebApplication unavailableApp = await StartAsync( FakeLookupMode.Upstream );
+        HttpRequestException error = await Assert.ThrowsExactlyAsync<HttpRequestException>(
+            ( ) => new HttpMusicLookupService(
+                SupportedProviders.Spotify, CreateFactory( unavailableApp ).Object, "spotify", NullLogger<HttpMusicLookupService>.Instance )
+                .GetInfoByISRCAsync( "US-UNAVAILABLE" ) );
+        Assert.AreEqual( HttpStatusCode.ServiceUnavailable, error.StatusCode );
+    }
+
+    /// <summary>
+    /// Runs the real queue processor against the production HTTP proxy and mapped worker endpoint.
+    /// The terminal action proves that null, rate-limit, and transient status responses travel
+    /// through the current contract into the queue processor's corresponding paths.
+    /// </summary>
+    [TestMethod]
+    [DataRow( FakeLookupMode.NotFound, "update" )]
+    [DataRow( FakeLookupMode.RateLimited, "requeue" )]
+    [DataRow( FakeLookupMode.Upstream, "dlq" )]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task QueueProcessor_TraversesCurrentWorkerContract( FakeLookupMode mode, string expectedAction ) {
+        await using WebApplication app = await StartAsync( mode );
+        Mock<IHttpClientFactory> factory = CreateFactory( app );
+        HttpMusicLookupService proxy = new( SupportedProviders.Spotify, factory.Object, "spotify", NullLogger<HttpMusicLookupService>.Instance );
+
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<ISubscriber> subscriber = new( );
+        _ = redis.Setup( value => value.GetSubscriber( It.IsAny<object>( ) ) ).Returns( subscriber.Object );
+        Mock<IRequestQueue<QueuedLookupRequest>> queue = new( );
+        Mock<IRateLimitTracker> rateLimits = new( );
+        Mock<ISagaStateManager> sagas = new( );
+        string sagaId = ISagaStateManager.GenerateSagaId( "IsrcLookup:US-CONTRACT" );
+        QueuedLookupRequest request = new( ) {
+            RequestId = $"contract-request-{Guid.NewGuid( ):N}",
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-CONTRACT",
+            SagaId = sagaId,
+            SagaInstanceToken = "contract-instance",
+            AttemptCount = mode == FakeLookupMode.Upstream ? LookupConstants.MaxQueueRetryAttempts : 0,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        QueuedMessage<QueuedLookupRequest> message = new( "contract-message", request, DateTimeOffset.UtcNow ) {
+            Priority = QueuePriority.Interactive
+        };
+        LookupSagaState saga = new( ) {
+            SagaId = sagaId,
+            LookupKey = "IsrcLookup:US-CONTRACT",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-CONTRACT",
+            InstanceToken = "contract-instance"
+        };
+        _ = sagas.Setup( value => value.GetOrCreateAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+                It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( saga );
+        _ = sagas.Setup( value => value.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( saga );
+        _ = sagas.Setup( value => value.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagas.Setup( value => value.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagas.Setup( value => value.TrySetIsPartialAsync(
+                It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = sagas.Setup( value => value.TrySetRateLimitInfoAsync(
+                It.IsAny<string>( ), It.IsAny<List<ProviderRateLimitInfo>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = rateLimits.Setup( value => value.GetStateAsync(
+                It.IsAny<SupportedProviders>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( new RateLimitState( false, null, null ) );
+
+        TaskCompletionSource<bool> terminalAction = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = sagas.Setup( value => value.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => {
+                if (expectedAction == "update") {
+                    _ = terminalAction.TrySetResult( true );
+                }
+            } )
+            .ReturnsAsync( true );
+        _ = queue.Setup( value => value.EnqueueAsync(
+                It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => {
+                if (expectedAction == "requeue") {
+                    _ = terminalAction.TrySetResult( true );
+                }
+            } );
+        _ = queue.Setup( value => value.RequeueAsync(
+                It.IsAny<string>( ), It.IsAny<TimeSpan?>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => { } );
+        _ = queue.Setup( value => value.MoveToDlqAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => terminalAction.TrySetResult( true ) );
+
+        int dequeueCount = 0;
+        _ = queue.Setup( value => value.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => Interlocked.Increment( ref dequeueCount ) == 1 ? message : null );
+
+        QueueProcessorBackgroundService processor = new(
+            redis.Object,
+            queue.Object,
+            rateLimits.Object,
+            sagas.Object,
+            proxy,
+            SupportedProviders.Spotify,
+            NullLogger<QueueProcessorBackgroundService>.Instance );
+        await processor.StartAsync( CancellationToken.None );
+        _ = await terminalAction.Task.WaitAsync( TimeSpan.FromSeconds( 10 ), TestContext.CancellationToken );
+        await processor.StopAsync( CancellationToken.None );
+
+        switch (expectedAction) {
+            case "update":
+                sagas.Verify( value => value.TryUpdateProviderStateAsync(
+                    sagaId, It.Is<ProviderLookupState>( state => state.IsComplete && !state.IsSuccess ),
+                    It.IsAny<string>( ),
+                    It.IsAny<CancellationToken>( ) ), Times.Once );
+                break;
+            case "requeue":
+                queue.Verify( value => value.EnqueueAsync(
+                    It.Is<QueuedLookupRequest>( value => value.AttemptCount == 1 && value.EnqueueOrigin == QueueEnqueueOrigin.Requeue ),
+                    QueuePriority.Background, It.IsAny<CancellationToken>( ) ), Times.Once );
+                break;
+            case "dlq":
+                queue.Verify( value => value.MoveToDlqAsync( "contract-message", It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+                break;
+        }
+    }
+
+    private static Mock<IHttpClientFactory> CreateFactory( WebApplication app ) {
+        Mock<IHttpClientFactory> factory = new( );
+        _ = factory.Setup( f => f.CreateClient( "spotify" ) )
+            .Returns( ( ) => new HttpClient( app.GetTestServer( ).CreateHandler( ) ) { BaseAddress = new Uri( "http://localhost" ) } );
+        return factory;
+    }
+
+    private static async Task<WebApplication> StartAsync( FakeLookupMode mode, ILoggerProvider? loggerProvider = null ) {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder( new WebApplicationOptions {
+            ApplicationName = typeof( WorkerEndpointContractIntegrationTests ).Assembly.FullName
+        } );
+        _ = builder.WebHost.UseTestServer( );
+        if (loggerProvider is not null) {
+            _ = builder.Logging.ClearProviders( ).AddProvider( loggerProvider );
+        }
+        _ = builder.Services.AddSingleton( new FakeLookupService( mode ) );
+        WebApplication app = builder.Build( );
+        _ = app.MapProviderLookupEndpoints<FakeLookupService>( );
+        await app.StartAsync( );
+        return app;
+    }
+
+    /// <summary>Behavior selected by the test lookup implementation.</summary>
+    public enum FakeLookupMode {
+        /// <summary>Return a successful result.</summary>
+        Success,
+        /// <summary>Throw a rate-limit exception.</summary>
+        RateLimited,
+        /// <summary>Throw a rate-limit exception whose Retry-After exceeds the header integer range.</summary>
+        HugeRateLimited,
+        /// <summary>Return no result.</summary>
+        NotFound,
+        /// <summary>Throw an upstream HTTP exception.</summary>
+        Upstream,
+        /// <summary>Throw a timeout.</summary>
+        Timeout,
+        /// <summary>Throw an unexpected exception.</summary>
+        Unexpected
+    }
+
+    private sealed class FakeLookupService( FakeLookupMode mode ) : IMusicLookupService {
+        public static SupportedProviders Provider => SupportedProviders.Spotify;
+        public Task<MusicLookupResult?> GetInfoAsync( string uri ) => ResolveAsync( );
+        public Task<MusicLookupResult?> GetInfoAsync( string title, string artist ) => ResolveAsync( );
+        public Task<MusicLookupResult?> GetInfoAsync( MusicLookupResult lookup ) => ResolveAsync( );
+        public Task<MusicLookupResult?> GetInfoByIDAsync( string providerId, bool isAlbum ) => ResolveAsync( );
+        public Task<MusicLookupResult?> GetInfoByUPCAsync( string upc ) => ResolveAsync( );
+        public Task<MusicLookupResult?> GetInfoByISRCAsync( string isrc ) => ResolveAsync( );
+
+        private Task<MusicLookupResult?> ResolveAsync( ) => mode switch {
+            FakeLookupMode.Success => Task.FromResult<MusicLookupResult?>( new MusicLookupResult { ExternalId = "US-TEST", Artist = "Artist", Title = "Title" } ),
+            FakeLookupMode.NotFound => Task.FromResult<MusicLookupResult?>( null ),
+            FakeLookupMode.Upstream => Task.FromException<MusicLookupResult?>( new HttpRequestException( "secret-upstream-uri", null, HttpStatusCode.BadGateway ) ),
+            FakeLookupMode.Timeout => Task.FromException<MusicLookupResult?>( new TimeoutException( "secret-exception" ) ),
+            FakeLookupMode.Unexpected => Task.FromException<MusicLookupResult?>( new InvalidOperationException( "secret-exception" ) ),
+            FakeLookupMode.HugeRateLimited => Task.FromException<MusicLookupResult?>( new RetryAfterExceededException(
+                TimeSpan.FromSeconds( (double)int.MaxValue + 1000 ), TimeSpan.FromSeconds( 5 ), new Uri( "https://secret-upstream-uri" ), SupportedProviders.Spotify ) ),
+            _ => Task.FromException<MusicLookupResult?>( new RetryAfterExceededException(
+                TimeSpan.FromSeconds( 10 ), TimeSpan.FromSeconds( 5 ), new Uri( "https://secret-upstream-uri" ), SupportedProviders.Spotify ) )
+        };
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider {
+        public List<Exception> Exceptions { get; } = [];
+        public ILogger CreateLogger( string categoryName ) => new CapturingLogger( Exceptions );
+        public void Dispose( ) { }
+    }
+
+    private sealed class CapturingLogger( List<Exception> exceptions ) : ILogger {
+        public IDisposable BeginScope<TState>( TState state ) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled( LogLevel logLevel ) => true;
+        public void Log<TState>( LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter ) {
+            if (exception is not null) exceptions.Add( exception );
+        }
+        private sealed class NullScope : IDisposable {
+            public static NullScope Instance { get; } = new( );
+            public void Dispose( ) { }
+        }
+    }
+}

--- a/Tests/Unit/JetStreamWatcherServiceTests.cs
+++ b/Tests/Unit/JetStreamWatcherServiceTests.cs
@@ -28,6 +28,7 @@ public class JetStreamWatcherServiceTests {
     private Mock<IRequestQueue<QueuedLookupRequest>> _queueMock = null!;
     /// <summary>Mocked logger used to assert log-level and EventId assertions.</summary>
     private Mock<ILogger<JetStreamWatcherService>> _loggerMock = null!;
+    private Mock<ISagaStateManager> _sagaManagerMock = null!;
 
     /// <summary>MSTest-injected test context; provides per-test cancellation.</summary>
     public TestContext TestContext { get; set; } = null!;
@@ -38,6 +39,19 @@ public class JetStreamWatcherServiceTests {
         _queueResolverMock = new Mock<IProviderQueueResolver<QueuedLookupRequest>>( );
         _queueMock = new Mock<IRequestQueue<QueuedLookupRequest>>( );
         _loggerMock = new Mock<ILogger<JetStreamWatcherService>>( );
+        _sagaManagerMock = new Mock<ISagaStateManager>( );
+        _ = _sagaManagerMock.Setup( manager => manager.GetOrCreateAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ),
+                It.IsAny<string>( ), It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string sagaId, string lookupKey, LookupRequestType lookupType,
+                string lookupValue, QueuePriority? priority, CancellationToken _ ) => new LookupSagaState {
+                    SagaId = sagaId,
+                    LookupKey = lookupKey,
+                    LookupType = lookupType,
+                    LookupValue = lookupValue,
+                    OriginPriority = priority ?? QueuePriority.Background,
+                    InstanceToken = "jetstream-instance"
+                } );
 
         // Stub IsEnabled true so [LoggerMessage]-gated calls reach Log() and Verify() is non-vacuous.
         // This is required because [LoggerMessage] source-generated code gates every call with
@@ -294,7 +308,7 @@ public class JetStreamWatcherServiceTests {
     /// Builds a <see cref="JetStreamWatcherService"/> with mocked dependencies.
     /// </summary>
     private JetStreamWatcherService CreateService( ) =>
-        new( _loggerMock.Object, _queueResolverMock.Object );
+        new( _loggerMock.Object, _queueResolverMock.Object, _sagaManagerMock.Object );
 }
 
 #pragma warning restore CS1591

--- a/Tests/Unit/LookupOrchestratorTests.cs
+++ b/Tests/Unit/LookupOrchestratorTests.cs
@@ -369,12 +369,32 @@ public class LookupOrchestratorTests {
             It.IsAny<string>( ),
             It.Is<string>( k => k.Contains( "IsrcLookup" ) ),
             LookupRequestType.IsrcLookup,
-            It.Is<string>( v => v.Equals( TestIsrc, StringComparison.InvariantCultureIgnoreCase ) )
+            It.Is<string>( v => v.Equals( TestIsrc, StringComparison.InvariantCultureIgnoreCase ) ),
+            QueuePriority.Interactive
         ), Times.Once );
         _queueMock.Verify(
             q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), QueuePriority.Interactive ),
-            Times.Once
+            Times.Exactly( _enabledProviders.Count )
         );
+    }
+
+    /// <summary>A fenced provider-state initialization loss aborts before enqueue or completion publication.</summary>
+    [TestMethod]
+    public async Task LookupByIsrcAsync_WhenProviderInitializationFenceIsLost_ShouldAbortBeforeEnqueue( ) {
+        SetupCacheMiss( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        _ = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            ( ) => _orchestrator.LookupByIsrcAsync( TestIsrc ) );
+
+        _queueMock.Verify( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ) ), Times.Never );
+        _deduplicatorMock.Verify( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ), Times.Never );
+        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), null ), Times.Once );
     }
 
     /// <summary>
@@ -404,8 +424,49 @@ public class LookupOrchestratorTests {
                 It.Is<QueuedLookupRequest>( r => r.OriginPriority == QueuePriority.Interactive ),
                 QueuePriority.Interactive
             ),
-            Times.Once
+            Times.Exactly( _enabledProviders.Count )
         );
+    }
+
+    /// <summary>
+    /// A manual lookup promotes an existing maintenance saga and enqueues interactive copies only for its unfinished
+    /// direct provider legs. The generation token lets those copies race old bulk deliveries safely.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task LookupByIsrcAsync_WhenMaintenanceSagaExists_ShouldPromotePendingLegsToInteractive( ) {
+        SetupCacheMiss( );
+        SetupDeduplicationInFlight( );
+        SetupDeduplicationWaitWithResult( );
+
+        LookupSagaState maintenanceSaga = CreateSagaState(
+            providers: [
+                (SupportedProviders.Spotify, true),
+                (SupportedProviders.AppleMusic, false),
+                (SupportedProviders.Tidal, false)
+        ] );
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( maintenanceSaga );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryPromoteToInteractiveAsync(
+                It.IsAny<string>( ), maintenanceSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _atProtoStorageMock
+            .Setup( a => a.GetMediaLinkResultAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( CreateMediaLinkResult( ) );
+
+        _ = await _orchestrator.LookupByIsrcAsync( TestIsrc );
+
+        _queueMock.Verify( q => q.EnqueueAsync(
+            It.Is<QueuedLookupRequest>( r =>
+                r.Provider != SupportedProviders.Spotify
+                && r.OriginPriority == QueuePriority.Interactive
+                && r.SagaInstanceToken == maintenanceSaga.InstanceToken ),
+            QueuePriority.Interactive ), Times.Exactly( 2 ) );
+        _queueMock.Verify( q => q.EnqueueAsync(
+            It.Is<QueuedLookupRequest>( r => r.Provider == SupportedProviders.Spotify ),
+            It.IsAny<QueuePriority>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -434,7 +495,7 @@ public class LookupOrchestratorTests {
         Assert.IsNotNull( result.Result );
         Assert.IsFalse( result.IsPartial );
         _sagaManagerMock.Verify(
-            s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ),
+            s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ),
             Times.Never
         );
     }
@@ -530,7 +591,7 @@ public class LookupOrchestratorTests {
         _queueMock.Verify( q => q.EnqueueAsync(
             It.Is<QueuedLookupRequest>( r => r.IsAlbum == true && r.LookupType == LookupRequestType.UpcLookup ),
             QueuePriority.Interactive
-        ), Times.Once );
+        ), Times.Exactly( _enabledProviders.Count ) );
     }
 
     #endregion
@@ -611,7 +672,7 @@ public class LookupOrchestratorTests {
                 r.LookupType == LookupRequestType.SongLookup
             ),
             QueuePriority.Interactive
-        ), Times.Once );
+        ), Times.Exactly( _enabledProviders.Count ) );
     }
 
     #endregion
@@ -657,6 +718,27 @@ public class LookupOrchestratorTests {
             It.Is<QueuedLookupRequest>( r => r.LookupType == LookupRequestType.SongIdLookup && r.IsAlbum == false ),
             QueuePriority.Interactive
         ), Times.Once );
+    }
+
+    /// <summary>An initial-provider fence loss aborts before enqueue or completion publication.</summary>
+    [TestMethod]
+    public async Task LookupByProviderIdAsync_WhenInitialProviderFenceIsLost_ShouldAbortBeforeEnqueue( ) {
+        SetupCacheMissForProviderId( );
+        SetupDeduplicationAcquired( );
+        SetupSagaCreation( );
+        _ = _sagaManagerMock
+            .Setup( s => s.TrySetInitialProviderAsync(
+                It.IsAny<string>( ), It.IsAny<SupportedProviders>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        _ = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            ( ) => _orchestrator.LookupByProviderIdAsync( "spotify-id", SupportedProviders.Spotify, false ) );
+
+        _queueMock.Verify( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ) ), Times.Never );
+        _deduplicatorMock.Verify( d => d.WaitForCompletionAsync( It.IsAny<string>( ), It.IsAny<TimeSpan>( ) ), Times.Never );
+        _deduplicatorMock.Verify( d => d.ReleaseAsync( It.IsAny<string>( ), null ), Times.Once );
+        _sagaManagerMock.Verify( s => s.TryInitializeProviderStatesAsync(
+            It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>
@@ -1294,7 +1376,7 @@ public class LookupOrchestratorTests {
         Assert.IsNotNull( result.Result );
         Assert.IsFalse( result.IsPartial );
         _sagaManagerMock.Verify(
-            s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ),
+            s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ),
             Times.Never
         );
     }
@@ -1319,7 +1401,7 @@ public class LookupOrchestratorTests {
         );
 
         _ = _sagaManagerMock
-            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ) )
             .ReturnsAsync( resumedSaga );
 
         _ = _sagaManagerMock
@@ -1371,7 +1453,7 @@ public class LookupOrchestratorTests {
         );
 
         _ = _sagaManagerMock
-            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ) )
             .ReturnsAsync( resumedSaga );
 
         _ = _sagaManagerMock
@@ -1762,7 +1844,7 @@ public class LookupOrchestratorTests {
         SetupDeduplicationAcquired( );
 
         _ = _sagaManagerMock
-            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ) )
             .ThrowsAsync( new InvalidOperationException( "Test error" ) );
 
         // Act & Assert
@@ -1848,6 +1930,7 @@ public class LookupOrchestratorTests {
             LookupType = LookupRequestType.IsrcLookup,
             LookupValue = TestIsrc,
             CreatedAt = DateTimeOffset.UtcNow,
+            InstanceToken = "test-instance",
             IsPartial = isPartial,
             PartialResultUri = partialResultUri,
             FinalResultUri = finalResultUri,
@@ -1925,23 +2008,26 @@ public class LookupOrchestratorTests {
     /// </summary>
     private void SetupSagaCreation( ) {
         _ = _sagaManagerMock
-            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ) ) )
+            .Setup( s => s.GetOrCreateAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ), It.IsAny<QueuePriority>( ) ) )
             .ReturnsAsync( new LookupSagaState {
                 SagaId = "test-saga",
                 LookupKey = "test-key",
                 LookupType = LookupRequestType.IsrcLookup,
                 LookupValue = TestIsrc,
                 CreatedAt = DateTimeOffset.UtcNow,
+                InstanceToken = "test-instance",
                 ProviderStates = []
             } );
 
         _ = _sagaManagerMock
-            .Setup( s => s.InitializeProviderStatesAsync( It.IsAny<string>( ), It.IsAny<HashSet<SupportedProviders>>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         _ = _sagaManagerMock
-            .Setup( s => s.SetInitialProviderAsync( It.IsAny<string>( ), It.IsAny<SupportedProviders>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetInitialProviderAsync(
+                It.IsAny<string>( ), It.IsAny<SupportedProviders>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         _ = _sagaManagerMock
             .Setup( s => s.GetAsync( It.IsAny<string>( ) ) )
@@ -1951,6 +2037,7 @@ public class LookupOrchestratorTests {
                 LookupType = LookupRequestType.IsrcLookup,
                 LookupValue = TestIsrc,
                 CreatedAt = DateTimeOffset.UtcNow,
+                InstanceToken = "test-instance",
                 IsPartial = false,
                 ProviderStates = []
             } );

--- a/Tests/Unit/ProviderTrackGenreCachingTests.cs
+++ b/Tests/Unit/ProviderTrackGenreCachingTests.cs
@@ -21,7 +21,7 @@ public sealed class ProviderTrackGenreCachingTests {
     /// <summary>Apple Music song genre names are cached under the song's catalog id.</summary>
     [TestMethod]
     public async Task AppleMusicTrackLookup_CachesGenreNames( ) {
-        const string response = """
+        const string Response = """
             {
               "data": [{
                 "id": "123456",
@@ -48,7 +48,7 @@ public sealed class ProviderTrackGenreCachingTests {
 
         using ECDsa key = ECDsa.Create( ECCurve.NamedCurves.nistP256 );
         AppleJwtHandler jwtHandler = new( "team", "key", key.ExportPkcs8PrivateKeyPem( ) );
-        Mock<IHttpClientFactory> factory = CreateFactory( "musickit-api", response, "https://api.music.apple.com/v1/catalog/" );
+        Mock<IHttpClientFactory> factory = CreateFactory( "musickit-api", Response, "https://api.music.apple.com/v1/catalog/" );
         AppleMusicLookupService service = new(
             jwtHandler,
             factory.Object,
@@ -64,8 +64,8 @@ public sealed class ProviderTrackGenreCachingTests {
     /// <summary>Tidal genre resources use genreName and are cached under the track id.</summary>
     [TestMethod]
     public async Task TidalTrackLookup_CachesIncludedGenreNames( ) {
-        const string tokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
-        const string trackResponse = """
+        const string TokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
+        const string TrackResponse = """
             {
               "data": {
                 "id": "12345",
@@ -99,9 +99,9 @@ public sealed class ProviderTrackGenreCachingTests {
 
         Mock<IHttpClientFactory> factory = new( );
         _ = factory.Setup( item => item.CreateClient( "tidal-auth" ) )
-            .Returns( CreateClient( tokenResponse, "https://auth.tidal.com/" ) );
+            .Returns( CreateClient( TokenResponse, "https://auth.tidal.com/" ) );
         _ = factory.Setup( item => item.CreateClient( "tidal-api" ) )
-            .Returns( CreateClient( trackResponse, "https://openapi.tidal.com/v2/" ) );
+            .Returns( CreateClient( TrackResponse, "https://openapi.tidal.com/v2/" ) );
 
         TidalTokenHandler tokenHandler = new(
             new TidalCredentials( "client", "secret" ),
@@ -130,8 +130,8 @@ public sealed class ProviderTrackGenreCachingTests {
     /// </summary>
     [TestMethod]
     public async Task TidalAlbumLookup_NeverCachesGenres( ) {
-        const string tokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
-        const string albumResponse = """
+        const string TokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
+        const string AlbumResponse = """
             {
               "data": {
                 "id": "999999",
@@ -157,9 +157,9 @@ public sealed class ProviderTrackGenreCachingTests {
 
         Mock<IHttpClientFactory> factory = new( );
         _ = factory.Setup( item => item.CreateClient( "tidal-auth" ) )
-            .Returns( CreateClient( tokenResponse, "https://auth.tidal.com/" ) );
+            .Returns( CreateClient( TokenResponse, "https://auth.tidal.com/" ) );
         _ = factory.Setup( item => item.CreateClient( "tidal-api" ) )
-            .Returns( CreateClient( albumResponse, "https://openapi.tidal.com/v2/" ) );
+            .Returns( CreateClient( AlbumResponse, "https://openapi.tidal.com/v2/" ) );
 
         TidalTokenHandler tokenHandler = new(
             new TidalCredentials( "client", "secret" ),
@@ -193,8 +193,8 @@ public sealed class ProviderTrackGenreCachingTests {
     /// </summary>
     [TestMethod]
     public async Task TidalTrackLookup_UnresolvedGenreRelationship_CachesEmptyGenreList( ) {
-        const string tokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
-        const string trackResponse = """
+        const string TokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
+        const string TrackResponse = """
             {
               "data": {
                 "id": "12345",
@@ -226,9 +226,9 @@ public sealed class ProviderTrackGenreCachingTests {
 
         Mock<IHttpClientFactory> factory = new( );
         _ = factory.Setup( item => item.CreateClient( "tidal-auth" ) )
-            .Returns( CreateClient( tokenResponse, "https://auth.tidal.com/" ) );
+            .Returns( CreateClient( TokenResponse, "https://auth.tidal.com/" ) );
         _ = factory.Setup( item => item.CreateClient( "tidal-api" ) )
-            .Returns( CreateClient( trackResponse, "https://openapi.tidal.com/v2/" ) );
+            .Returns( CreateClient( TrackResponse, "https://openapi.tidal.com/v2/" ) );
 
         TidalTokenHandler tokenHandler = new(
             new TidalCredentials( "client", "secret" ),
@@ -254,8 +254,8 @@ public sealed class ProviderTrackGenreCachingTests {
     /// </summary>
     [TestMethod]
     public async Task TidalTrackLookup_GenreCacheThrows_StillReturnsResult( ) {
-        const string tokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
-        const string trackResponse = """
+        const string TokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
+        const string TrackResponse = """
             {
               "data": {
                 "id": "12345",
@@ -288,9 +288,9 @@ public sealed class ProviderTrackGenreCachingTests {
 
         Mock<IHttpClientFactory> factory = new( );
         _ = factory.Setup( item => item.CreateClient( "tidal-auth" ) )
-            .Returns( CreateClient( tokenResponse, "https://auth.tidal.com/" ) );
+            .Returns( CreateClient( TokenResponse, "https://auth.tidal.com/" ) );
         _ = factory.Setup( item => item.CreateClient( "tidal-api" ) )
-            .Returns( CreateClient( trackResponse, "https://openapi.tidal.com/v2/" ) );
+            .Returns( CreateClient( TrackResponse, "https://openapi.tidal.com/v2/" ) );
 
         TidalTokenHandler tokenHandler = new(
             new TidalCredentials( "client", "secret" ),
@@ -316,7 +316,7 @@ public sealed class ProviderTrackGenreCachingTests {
     /// </summary>
     [TestMethod]
     public async Task AppleMusicTrackLookup_GenreCacheThrows_StillReturnsResult( ) {
-        const string response = """
+        const string Response = """
             {
               "data": [{
                 "id": "123456",
@@ -343,7 +343,7 @@ public sealed class ProviderTrackGenreCachingTests {
 
         using ECDsa key = ECDsa.Create( ECCurve.NamedCurves.nistP256 );
         AppleJwtHandler jwtHandler = new( "team", "key", key.ExportPkcs8PrivateKeyPem( ) );
-        Mock<IHttpClientFactory> factory = CreateFactory( "musickit-api", response, "https://api.music.apple.com/v1/catalog/" );
+        Mock<IHttpClientFactory> factory = CreateFactory( "musickit-api", Response, "https://api.music.apple.com/v1/catalog/" );
         AppleMusicLookupService service = new(
             jwtHandler,
             factory.Object,

--- a/Tests/Unit/ProviderTrackGenreCachingTests.cs
+++ b/Tests/Unit/ProviderTrackGenreCachingTests.cs
@@ -1,11 +1,14 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Core.Domain.Providers.AppleMusic;
+using BridgeBeats.Core.Domain.Providers.Common;
 using BridgeBeats.Core.Domain.Providers.Tidal;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -310,6 +313,76 @@ public sealed class ProviderTrackGenreCachingTests {
     }
 
     /// <summary>
+    /// A rate limit from Tidal's secondary album lookup escapes both parsing layers so the queue
+    /// retries the provider leg instead of persisting a false no-match.
+    /// </summary>
+    [TestMethod]
+    public async Task TidalTrackLookup_AlbumArtRateLimit_PropagatesTypedException( ) {
+        const string TokenResponse = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}""";
+        const string TrackResponse = """
+            {
+              "data": {
+                "id": "12345",
+                "type": "tracks",
+                "attributes": {
+                  "title": "Track",
+                  "isrc": "USAAA0000001",
+                  "externalLinks": [{"href":"https://tidal.com/browse/track/12345"}]
+                },
+                "relationships": {
+                  "artists": {"data":[{"id":"artist-1","type":"artists"}]},
+                  "albums": {"data":[{"id":"67890","type":"albums"}]}
+                }
+              },
+              "included": [
+                {"id":"artist-1","type":"artists","attributes":{"name":"Artist"}},
+                {"id":"67890","type":"albums","attributes":{"title":"Album"}}
+              ]
+            }
+            """;
+
+        Mock<IGenreCacheService> genreCache = new( MockBehavior.Strict );
+        Mock<IHttpClientFactory> factory = new( );
+        _ = factory.Setup( item => item.CreateClient( "tidal-auth" ) )
+            .Returns( CreateClient( TokenResponse, "https://auth.tidal.com/" ) );
+
+        SequencedResponseHandler apiHandler = new(
+            new HttpResponseMessage( HttpStatusCode.OK ) {
+                Content = new StringContent( TrackResponse, Encoding.UTF8, "application/json" )
+            },
+            CreateRateLimitedResponse( TimeSpan.FromSeconds( 17 ) )
+        );
+        _ = factory.Setup( item => item.CreateClient( "tidal-api" ) )
+            .Returns( ( ) => {
+                TerminalProviderRateLimitHandler terminalRateLimitHandler = new( SupportedProviders.Tidal ) {
+                    InnerHandler = apiHandler
+                };
+                return new HttpClient( terminalRateLimitHandler, disposeHandler: false ) {
+                    BaseAddress = new Uri( "https://openapi.tidal.com/v2/" )
+                };
+            } );
+
+        TidalTokenHandler tokenHandler = new(
+            new TidalCredentials( "client", "secret" ),
+            factory.Object,
+            NullLogger<TidalTokenHandler>.Instance );
+        TidalLookupService service = new(
+            tokenHandler,
+            factory.Object,
+            NullLogger<TidalLookupService>.Instance,
+            new JsonSerializerOptions( ),
+            genreCache.Object );
+
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => service.GetInfoByIDAsync( "12345", false )
+        );
+
+        Assert.AreEqual( 2, apiHandler.CallCount, "Expected a primary lookup followed by an album-art lookup." );
+        Assert.AreEqual( TimeSpan.FromSeconds( 17 ), exception.RetryAfterValue );
+        Assert.AreEqual( SupportedProviders.Tidal, exception.Provider );
+    }
+
+    /// <summary>
     /// A genre-cache write failure never fails the Apple Music lookup:
     /// <c>ParseAppleMusicSongResponse</c> catches and logs the exception rather than letting it
     /// propagate, so the mapped result is still returned.
@@ -367,6 +440,12 @@ public sealed class ProviderTrackGenreCachingTests {
     private static HttpClient CreateClient( string body, string baseAddress )
         => new( new FixedResponseHandler( body ) ) { BaseAddress = new Uri( baseAddress ) };
 
+    private static HttpResponseMessage CreateRateLimitedResponse( TimeSpan retryAfter ) {
+        HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        response.Headers.RetryAfter = new RetryConditionHeaderValue( retryAfter );
+        return response;
+    }
+
     private sealed class FixedResponseHandler( string body ) : HttpMessageHandler {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -375,5 +454,21 @@ public sealed class ProviderTrackGenreCachingTests {
             Content = new StringContent( body, Encoding.UTF8, "application/json" ),
             RequestMessage = request
         } );
+    }
+
+    private sealed class SequencedResponseHandler( params HttpResponseMessage[] responses ) : HttpMessageHandler {
+        private int _nextResponse;
+
+        public int CallCount => _nextResponse;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) {
+            int index = Interlocked.Increment( ref _nextResponse ) - 1;
+            HttpResponseMessage response = responses[index];
+            response.RequestMessage = request;
+            return Task.FromResult( response );
+        }
     }
 }

--- a/Tests/Unit/QueueContractsTests.cs
+++ b/Tests/Unit/QueueContractsTests.cs
@@ -228,6 +228,18 @@ public class QueueContractsTests {
         Assert.AreEqual( original, deserialized );
     }
 
+    /// <summary>Delivery-lane priority is derived at dequeue time and is not persisted.</summary>
+    [TestMethod]
+    public void QueuedMessage_Serialization_OmitsDerivedPriority( ) {
+        QueuedMessage<string> message = new( "msg-789", "payload", DateTimeOffset.UtcNow ) {
+            Priority = QueuePriority.Interactive
+        };
+
+        string json = JsonSerializer.Serialize( message, s_jsonOptions );
+
+        Assert.DoesNotContain( "\"priority\"", json );
+    }
+
     #endregion
 
     #region QueueDepth Tests

--- a/Tests/Unit/QueueMetricsTests.cs
+++ b/Tests/Unit/QueueMetricsTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Core.Infrastructure.Queue;
@@ -12,7 +13,27 @@ namespace BridgeBeats.Tests.Unit;
 /// with an in-process <see cref="System.Diagnostics.Metrics.MeterListener"/>.
 /// </summary>
 [TestClass]
+[DoNotParallelize]
 public class QueueMetricsTests {
+
+    /// <summary>Queue ActivitySource spans retain the required provider and priority tags.</summary>
+    [TestMethod]
+    public void ActivitySource_EmitsQueueSpanWithProviderAndPriorityTags( ) {
+        Activity? observed = null;
+        using ActivityListener listener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => observed = activity
+        };
+        ActivitySource.AddActivityListener( listener );
+        using (Activity? activity = QueueMetrics.ActivitySource.StartActivity( "queue.message.wall" )) {
+            _ = (activity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (activity?.SetTag( QueueMetricTags.Priority, "bulk" ));
+        }
+        Assert.IsNotNull( observed );
+        Assert.AreEqual( "spotify", observed!.GetTagItem( QueueMetricTags.Provider ) );
+        Assert.AreEqual( "bulk", observed.GetTagItem( QueueMetricTags.Priority ) );
+    }
 
     #region Meter Tests
 
@@ -65,18 +86,30 @@ public class QueueMetricsTests {
         Assert.AreEqual( "bridgebeats.queue.dequeued.total", QueueMetrics.DequeuedTotal.Name );
     }
 
-    /// <summary>The acknowledged-total counter is registered (non-null).</summary>
+    /// <summary>The delivery-removed counter is registered (non-null).</summary>
     [TestMethod]
-    public void AcknowledgedTotal_IsNotNull( ) {
+    public void DeliveryRemovedTotal_IsNotNull( ) {
         // Assert
-        Assert.IsNotNull( QueueMetrics.AcknowledgedTotal );
+        Assert.IsNotNull( QueueMetrics.DeliveryRemovedTotal );
     }
 
-    /// <summary>The acknowledged-total counter is named <c>bridgebeats.queue.acknowledged.total</c>.</summary>
+    /// <summary>The delivery-removed counter has its semantic name.</summary>
     [TestMethod]
-    public void AcknowledgedTotal_HasCorrectName( ) {
+    public void DeliveryRemovedTotal_HasCorrectName( ) {
         // Assert
-        Assert.AreEqual( "bridgebeats.queue.acknowledged.total", QueueMetrics.AcknowledgedTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.delivery.removed.total", QueueMetrics.DeliveryRemovedTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.dlq.total", QueueMetrics.DlqTotal.Name );
+    }
+
+    /// <summary>The rollout counters and timing instruments expose stable semantic names.</summary>
+    [TestMethod]
+    public void OperationalHealthInstruments_HaveExpectedNames( ) {
+        Assert.AreEqual( "bridgebeats.queue.terminal.total", QueueMetrics.TerminalOutcomeTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.saga.lifecycle.total", QueueMetrics.SagaLifecycleTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.refresh.outcome.total", QueueMetrics.MaintenanceOutcomeTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.refresh.leg.enqueued.total", QueueMetrics.RefreshLegEnqueuedTotal.Name );
+        Assert.AreEqual( "bridgebeats.queue.sojourn.duration", QueueMetrics.QueueSojournDuration.Name );
+        Assert.AreEqual( "bridgebeats.queue.ratelimit.discovery.duration", QueueMetrics.RateLimitDiscoveryDuration.Name );
     }
 
     /// <summary>The requeued-total counter is registered (non-null).</summary>
@@ -182,6 +215,13 @@ public class QueueMetricsTests {
 
         // Assert - No exception thrown means success
         Assert.IsNotNull( QueueMetrics.EnqueuedTotal );
+    }
+
+    /// <summary>Enqueue origins are exposed as a bounded telemetry dimension.</summary>
+    [TestMethod]
+    public void EnqueueOrigin_UsesTypedContract( ) {
+        QueueMetrics.RecordEnqueue( SupportedProviders.Spotify, QueuePriority.Bulk, QueueEnqueueOrigin.RefreshSweep );
+        Assert.AreEqual( "bridgebeats.queue.enqueued.total", QueueMetrics.EnqueuedTotal.Name );
     }
 
     /// <summary>The dequeued-total counter accepts an <c>Add</c> with provider and priority tags.</summary>
@@ -359,10 +399,10 @@ public class QueueMetricsTests {
         Assert.AreEqual( "{requests}", QueueMetrics.DequeuedTotal.Unit );
     }
 
-    /// <summary>The acknowledged-total counter uses the <c>{requests}</c> unit.</summary>
+    /// <summary>The delivery-removed counter uses the <c>{requests}</c> unit.</summary>
     [TestMethod]
-    public void AcknowledgedTotal_HasCorrectUnit( ) {
-        Assert.AreEqual( "{requests}", QueueMetrics.AcknowledgedTotal.Unit );
+    public void DeliveryRemovedTotal_HasCorrectUnit( ) {
+        Assert.AreEqual( "{requests}", QueueMetrics.DeliveryRemovedTotal.Unit );
     }
 
     /// <summary>The requeued-total counter uses the <c>{requests}</c> unit.</summary>
@@ -468,18 +508,19 @@ public class QueueMetricsTests {
     }
 
     /// <summary>
-    /// <c>RecordAcknowledge</c> adds 1 to the acknowledged-total counter, tagging with the
-    /// lower-cased provider (<c>tidal</c>).
+    /// <c>RecordDeliveryRemoved</c> adds 1 to the delivery-removed counter, tagging with the
+    /// lower-cased provider and source priority.
     /// </summary>
     [TestMethod]
-    public void RecordAcknowledge_RecordsWithLowercaseProvider( ) {
+    public void RecordDeliveryRemoved_RecordsProviderAndPriority( ) {
         // Arrange
         long recordedValue = 0;
         string? recordedProvider = null;
+        string? recordedPriority = null;
 
         using MeterListener listener = new( );
         listener.InstrumentPublished = ( instrument, meterListener ) => {
-            if (instrument.Meter.Name == QueueMetrics.MeterName && instrument.Name == "bridgebeats.queue.acknowledged.total") {
+            if (instrument.Meter.Name == QueueMetrics.MeterName && instrument.Name == "bridgebeats.queue.delivery.removed.total") {
                 meterListener.EnableMeasurementEvents( instrument );
             }
         };
@@ -489,6 +530,8 @@ public class QueueMetricsTests {
             foreach (KeyValuePair<string, object?> tag in tags) {
                 if (tag.Key == QueueMetricTags.Provider) {
                     recordedProvider = tag.Value?.ToString( );
+                } else if (tag.Key == QueueMetricTags.Priority) {
+                    recordedPriority = tag.Value?.ToString( );
                 }
             }
         } );
@@ -496,11 +539,12 @@ public class QueueMetricsTests {
         listener.Start( );
 
         // Act
-        QueueMetrics.RecordAcknowledge( SupportedProviders.Tidal );
+        QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Tidal, QueuePriority.Background );
 
         // Assert
         Assert.AreEqual( 1, recordedValue );
         Assert.AreEqual( "tidal", recordedProvider );
+        Assert.AreEqual( "background", recordedPriority );
     }
 
     /// <summary>
@@ -666,7 +710,8 @@ public class QueueMetricsTests {
             SupportedProviders.Tidal,
             LookupRequestType.IsrcLookup,
             "success",
-            3.75
+            3.75,
+            QueuePriority.Background
         );
 
         // Assert
@@ -677,13 +722,11 @@ public class QueueMetricsTests {
     }
 
     /// <summary>
-    /// <c>RecordInteractiveDeferral</c> adds 1 to the interactive-deferred counter
-    /// (<c>bridgebeats.ratelimit.interactive_deferred.total</c>), tagging with the lower-cased
-    /// provider (<c>spotify</c>) and the endpoint (<c>tracks</c>). This counter tracks
-    /// interactive-origin requests pushed to the background lane after a rate limit.
+    /// <c>RecordInteractiveRetry</c> adds 1 to the interactive retry counter, tagging with the
+    /// lower-cased provider and endpoint.
     /// </summary>
     [TestMethod]
-    public void RecordInteractiveDeferral_RecordsWithLowercaseProviderAndEndpoint( ) {
+    public void RecordInteractiveRetry_RecordsWithLowercaseProviderAndEndpoint( ) {
         // Arrange
         long recordedValue = 0;
         string? recordedProvider = null;
@@ -691,7 +734,7 @@ public class QueueMetricsTests {
 
         using MeterListener listener = new( );
         listener.InstrumentPublished = ( instrument, meterListener ) => {
-            if (instrument.Meter.Name == QueueMetrics.MeterName && instrument.Name == "bridgebeats.ratelimit.interactive_deferred.total") {
+            if (instrument.Meter.Name == QueueMetrics.MeterName && instrument.Name == "bridgebeats.ratelimit.interactive_retry.total") {
                 meterListener.EnableMeasurementEvents( instrument );
             }
         };
@@ -710,12 +753,33 @@ public class QueueMetricsTests {
         listener.Start( );
 
         // Act
-        QueueMetrics.RecordInteractiveDeferral( SupportedProviders.Spotify, "tracks" );
+        QueueMetrics.RecordInteractiveRetry( SupportedProviders.Spotify, "tracks" );
 
         // Assert
         Assert.AreEqual( 1, recordedValue );
         Assert.AreEqual( "spotify", recordedProvider );
         Assert.AreEqual( "tracks", recordedEndpoint );
+    }
+
+    /// <summary>Verifies enqueue emits exactly one measurement with all bounded tags.</summary>
+    [TestMethod]
+    public void RecordEnqueue_EmitsOriginProviderPriorityExactlyOnce( ) {
+        long count = 0;
+        Dictionary<string, string?> tagsSeen = [];
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, ml ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") ml.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, value, tags, _ ) => {
+            count += value;
+            foreach (KeyValuePair<string, object?> tag in tags) tagsSeen[tag.Key] = tag.Value?.ToString( );
+        } );
+        listener.Start( );
+        QueueMetrics.RecordEnqueue( SupportedProviders.AppleMusic, QueuePriority.Bulk, QueueEnqueueOrigin.RefreshSweep );
+        Assert.AreEqual( 1, count );
+        Assert.AreEqual( "applemusic", tagsSeen[QueueMetricTags.Provider] );
+        Assert.AreEqual( "bulk", tagsSeen[QueueMetricTags.Priority] );
+        Assert.AreEqual( "refresh_sweep", tagsSeen[QueueMetricTags.Origin] );
     }
 
     #endregion

--- a/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
+++ b/Tests/Unit/QueueProcessorBackgroundServiceTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using System.Text.Json;
+using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Exceptions;
@@ -6,6 +9,8 @@ using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Domain.Services.Queue;
 using BridgeBeats.Core.Infrastructure.Logging;
+using BridgeBeats.Core.Infrastructure.Queue;
+using BridgeBeats.Core.Infrastructure.Utilities;
 using Microsoft.Extensions.Logging;
 using Moq;
 using StackExchange.Redis;
@@ -23,6 +28,7 @@ namespace BridgeBeats.Tests.Unit;
 /// interactive-to-background deferral log; and generic-exception retry-then-DLQ semantics.
 /// </summary>
 [TestClass]
+[DoNotParallelize]
 public class QueueProcessorBackgroundServiceTests {
     /// <summary>Mocked Redis multiplexer; returns <see cref="_subscriberMock"/> for pub/sub.</summary>
     private Mock<IConnectionMultiplexer> _redisMock = null!;
@@ -51,6 +57,8 @@ public class QueueProcessorBackgroundServiceTests {
         WriteIndented = false
     };
 
+    private static readonly ConcurrentDictionary<string, (string LookupKey, LookupRequestType LookupType, string LookupValue)> s_requestIdentities = new( );
+
     /// <summary>Builds fresh dependency mocks and wires the subscriber before each test.</summary>
     [TestInitialize]
     public void Initialize( ) {
@@ -61,6 +69,47 @@ public class QueueProcessorBackgroundServiceTests {
         _sagaManagerMock = new Mock<ISagaStateManager>( );
         _lookupServiceMock = new Mock<IMusicLookupService>( );
         _loggerMock = new Mock<ILogger<QueueProcessorBackgroundService>>( );
+
+        _ = _sagaManagerMock.Setup( s => s.GetOrCreateAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+                It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string sagaId, string lookupKey, LookupRequestType lookupType, string lookupValue, QueuePriority? priority, CancellationToken _ ) =>
+                new LookupSagaState {
+                    SagaId = sagaId,
+                    LookupKey = lookupKey,
+                    LookupType = lookupType,
+                    LookupValue = lookupValue,
+                    InstanceToken = "test-instance",
+                    OriginPriority = priority ?? QueuePriority.Background
+                } );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync(
+                It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string sagaId, CancellationToken _ ) => {
+                (string lookupKey, LookupRequestType lookupType, string lookupValue) = s_requestIdentities.GetValueOrDefault(
+                    sagaId, ($"{LookupRequestType.IsrcLookup}:test-value", LookupRequestType.IsrcLookup, "test-value") );
+                return new LookupSagaState {
+                    SagaId = sagaId,
+                    LookupKey = lookupKey,
+                    LookupType = lookupType,
+                    LookupValue = lookupValue,
+                    InstanceToken = "test-instance",
+                    ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                        [TestProvider] = new( TestProvider, false, false, null, null, null )
+                    }
+                };
+            } );
+        _ = _sagaManagerMock.Setup( s => s.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( s => s.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( s => s.TrySetIsPartialAsync(
+                It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( s => s.TrySetRateLimitInfoAsync(
+                It.IsAny<string>( ), It.IsAny<List<ProviderRateLimitInfo>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         _ = _redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( _subscriberMock.Object );
     }
@@ -243,15 +292,16 @@ public class QueueProcessorBackgroundServiceTests {
         QueueProcessorBackgroundService service = CreateService( );
         using CancellationTokenSource cts = new( );
         _ = service.StartAsync( cts.Token );
-        await Task.Delay( 200, TestContext.CancellationToken );
+        await Task.Delay( 1200, TestContext.CancellationToken );
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
         _lookupServiceMock.Verify( lookup => lookup.GetInfoByIDAsync( "stale-native-id", false ), Times.Once );
         _lookupServiceMock.Verify( lookup => lookup.GetInfoByISRCAsync( "USRC12345678" ), Times.Once );
-        _sagaManagerMock.Verify( manager => manager.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
             request.SagaId,
             It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
@@ -321,17 +371,10 @@ public class QueueProcessorBackgroundServiceTests {
         await service.StopAsync( CancellationToken.None );
 
         // Assert
-        _sagaManagerMock.Verify(
-            s => s.GetOrCreateAsync(
-                request.SagaId,
-                It.IsAny<string>( ),
-                request.LookupType,
-                request.LookupValue,
-                It.Is<QueuePriority?>( p => p == QueuePriority.Bulk ),
-                It.IsAny<CancellationToken>( )
-            ),
-            Times.Once
-        );
+        _sagaManagerMock.Verify( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ), Times.AtLeastOnce );
+        _sagaManagerMock.Verify( s => s.GetOrCreateAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+            It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -348,6 +391,7 @@ public class QueueProcessorBackgroundServiceTests {
 
         TimeSpan timeRemaining = TimeSpan.FromSeconds( 30 );
         SetupRateLimited( timeRemaining );
+        SetupSagaNotComplete( request.SagaId );
 
         int callCount = 0;
         _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
@@ -401,17 +445,76 @@ public class QueueProcessorBackgroundServiceTests {
 
         // Assert
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state =>
                     state.Provider == TestProvider &&
                     state.IsComplete &&
                     state.IsSuccess
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
         );
+    }
+
+    /// <summary>Enabling queue metrics changes observations only, never business Redis/queue calls.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SuccessfulLeg_MetricsListenerOnAndOff_HasIdenticalBusinessCallCounts( ) {
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" );
+        SetupSagaNotComplete( request.SagaId );
+        bool deliver = true;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                if (!deliver) return null;
+                deliver = false;
+                return CreateMessage( request );
+            } );
+
+        static int Count( Mock mock, string method ) => mock.Invocations.Count( invocation => invocation.Method.Name == method );
+        async Task<(int Gets, int Updates, int Acks, int Enqueues, int Publishes)> RunAsync( bool listen ) {
+            using MeterListener? listener = listen ? new MeterListener( ) : null;
+            if (listener is not null) {
+                listener.InstrumentPublished = ( instrument, consumer ) => {
+                    if (instrument.Meter.Name == QueueMetrics.MeterName
+                        && instrument.Name == "bridgebeats.queue.saga.leg.completed.total") {
+                        consumer.EnableMeasurementEvents( instrument );
+                    }
+                };
+                listener.Start( );
+            }
+            int gets = Count( _sagaManagerMock, nameof( ISagaStateManager.GetAsync ) );
+            int updates = Count( _sagaManagerMock, nameof( ISagaStateManager.TryUpdateProviderStateAsync ) );
+            int acks = Count( _queueMock, nameof( IRequestQueue<QueuedLookupRequest>.AcknowledgeAsync ) );
+            int enqueues = Count( _queueMock, nameof( IRequestQueue<QueuedLookupRequest>.EnqueueAsync ) );
+            int publishes = Count( _subscriberMock, nameof( ISubscriber.PublishAsync ) );
+            deliver = true;
+            QueueProcessorBackgroundService service = CreateService( );
+            using CancellationTokenSource cts = new( );
+            _ = service.StartAsync( cts.Token );
+            await Task.Delay( 200, TestContext.CancellationToken );
+            await cts.CancelAsync( );
+            await service.StopAsync( CancellationToken.None );
+            return (Count( _sagaManagerMock, nameof( ISagaStateManager.GetAsync ) ) - gets,
+                Count( _sagaManagerMock, nameof( ISagaStateManager.TryUpdateProviderStateAsync ) ) - updates,
+                Count( _queueMock, nameof( IRequestQueue<QueuedLookupRequest>.AcknowledgeAsync ) ) - acks,
+                Count( _queueMock, nameof( IRequestQueue<QueuedLookupRequest>.EnqueueAsync ) ) - enqueues,
+                Count( _subscriberMock, nameof( ISubscriber.PublishAsync ) ) - publishes);
+        }
+
+        (int Gets, int Updates, int Acks, int Enqueues, int Publishes) disabled = await RunAsync( false );
+        (int Gets, int Updates, int Acks, int Enqueues, int Publishes) enabled = await RunAsync( true );
+        Assert.AreEqual( disabled.Gets, enabled.Gets );
+        Assert.AreEqual( disabled.Acks, enabled.Acks );
+        Assert.AreEqual( disabled.Enqueues, enabled.Enqueues );
+        Assert.AreEqual( disabled.Publishes, enabled.Publishes );
+        Assert.AreEqual( 1, disabled.Gets );
+        Assert.AreEqual( 1, disabled.Updates );
+        Assert.AreEqual( 1, disabled.Acks );
     }
 
     /// <summary>A successful lookup acknowledges the originating message exactly once.</summary>
@@ -446,19 +549,206 @@ public class QueueProcessorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// When the lookup completes the whole saga, the service publishes the saga id on the
-    /// <c>saga:completed</c> channel.
+    /// An ACK failure after a successful provider-state commit leaves the original delivery
+    /// pending, without retry mutation or DLQ promotion, even at the terminal attempt boundary.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task ProcessMessage_WhenSagaCompletes_ShouldPublishCompletionEvent( ) {
+    public async Task ProcessMessage_AckFailureAfterCommittedSuccess_LeavesPelPendingWithoutRetryMutation( ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "ACK-AFTER-COMMIT" ) with {
+            AttemptCount = LookupConstants.MaxQueueRetryAttempts - 1
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        SetupSagaNotComplete( request.SagaId );
+        _ = _queueMock.Setup( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XACK unavailable" ) );
+
+        int dequeueCalls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref dequeueCalls );
+                return message;
+            } );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        Assert.AreEqual( 1, dequeueCalls, "ACK recovery must not re-run the committed delivery." );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            request.SagaId,
+            It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, It.IsAny<TimeSpan?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.MoveToDlqAsync(
+            message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>
+    /// After an ACK loss, the committed delivery is acknowledged by its control-plane recovery
+    /// loop without a second provider call or terminal retry mutation.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_AckLossThenCompletedChildRedelivery_AcknowledgesWithoutProviderRetry( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "ACK-CHILD-RECOVERY" ) with {
+            AttemptCount = LookupConstants.MaxQueueRetryAttempts - 1
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        LookupSagaState initialSaga = new( ) {
+            SagaId = request.SagaId,
+            LookupKey = $"{request.LookupType}:{request.LookupValue}",
+            LookupType = request.LookupType,
+            LookupValue = request.LookupValue,
+            InstanceToken = "test-instance",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [TestProvider] = new( TestProvider, false, false, null, null, null )
+            }
+        };
+        LookupSagaState completedChildSaga = initialSaga with {
+            LookupKey = "different-child-root",
+            LookupType = LookupRequestType.UpcLookup,
+            LookupValue = "OTHER-CHILD",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [TestProvider] = new( TestProvider, true, true, "{}", DateTimeOffset.UtcNow, null )
+            }
+        };
+        bool committed = false;
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => committed ? completedChildSaga : initialSaga );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                request.SagaId, It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => committed = true )
+            .ReturnsAsync( true );
+
+        int ackCalls = 0;
+        TaskCompletionSource<bool> recovered = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _queueMock.Setup( queue => queue.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( ) => {
+                if (Interlocked.Increment( ref ackCalls ) == 1) {
+                    return Task.FromException( new RedisServerException( "XACK unavailable" ) );
+                }
+                _ = recovered.TrySetResult( true );
+                return Task.CompletedTask;
+            } );
+        int dequeueCalls = 0;
+        _ = _queueMock.Setup( queue => queue.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => Interlocked.Increment( ref dequeueCalls ) == 1 ? message : null );
+
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        _ = await recovered.Task.WaitAsync( TimeSpan.FromSeconds( 5 ), TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        Assert.AreEqual( 2, ackCalls );
+        _lookupServiceMock.Verify( lookup => lookup.GetInfoByISRCAsync( request.LookupValue ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            request.SagaId, It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.RequeueAsync(
+            message.MessageId, It.IsAny<TimeSpan?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.MoveToDlqAsync(
+            message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>
+    /// If both the initial post-commit ACK and its first scheduled recovery ACK fail, the worker
+    /// retains the active delivery without dequeuing it again or applying retry mutation.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_AckLossThenCompletedChildRecoveryAckLoss_LeavesPelPending( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "ACK-CHILD-RECOVERY-FAIL" ) with {
+            AttemptCount = LookupConstants.MaxQueueRetryAttempts - 1
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        LookupSagaState initialSaga = new( ) {
+            SagaId = request.SagaId,
+            LookupKey = $"{request.LookupType}:{request.LookupValue}",
+            LookupType = request.LookupType,
+            LookupValue = request.LookupValue,
+            InstanceToken = "test-instance",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [TestProvider] = new( TestProvider, false, false, null, null, null )
+            }
+        };
+        LookupSagaState completedChildSaga = initialSaga with {
+            LookupKey = "different-child-root",
+            LookupType = LookupRequestType.UpcLookup,
+            LookupValue = "OTHER-CHILD",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [TestProvider] = new( TestProvider, true, true, "{}", DateTimeOffset.UtcNow, null )
+            }
+        };
+        bool committed = false;
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => committed ? completedChildSaga : initialSaga );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                request.SagaId, It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => committed = true )
+            .ReturnsAsync( true );
+
+        int ackCalls = 0;
+        TaskCompletionSource<bool> recoveryAttempted = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _queueMock.Setup( queue => queue.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( ) => {
+                if (Interlocked.Increment( ref ackCalls ) == 2) {
+                    _ = recoveryAttempted.TrySetResult( true );
+                }
+                return Task.FromException( new RedisServerException( "XACK unavailable" ) );
+            } );
+        int dequeueCalls = 0;
+        _ = _queueMock.Setup( queue => queue.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => Interlocked.Increment( ref dequeueCalls ) <= 2 ? message : null );
+
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        _ = await recoveryAttempted.Task.WaitAsync( TimeSpan.FromSeconds( 5 ), TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        Assert.AreEqual( 2, ackCalls );
+        Assert.AreEqual( 1, dequeueCalls, "ACK recovery must not re-run the committed delivery." );
+        _lookupServiceMock.Verify( lookup => lookup.GetInfoByISRCAsync( request.LookupValue ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            request.SagaId, It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.RequeueAsync(
+            message.MessageId, It.IsAny<TimeSpan?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.MoveToDlqAsync(
+            message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>
+    /// A redelivered message whose provider leg is already complete is acknowledged idempotently
+    /// without invoking the provider or publishing a duplicate completion event.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_WhenSagaCompletes_ShouldAcknowledgeWithoutDuplicateProcessing( ) {
         // Arrange
         QueueProcessorBackgroundService service = CreateService( );
         QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" );
         QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
 
         SetupNotRateLimited( );
-        SetupLookupSuccess( );
         SetupSagaComplete( request.SagaId );
 
         int callCount = 0;
@@ -472,15 +762,12 @@ public class QueueProcessorBackgroundServiceTests {
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
-        // Assert - Should publish to saga:completed channel
-        _subscriberMock.Verify(
-            s => s.PublishAsync(
-                It.Is<RedisChannel>( c => c.ToString( ) == "saga:completed" ),
-                It.Is<RedisValue>( v => v.ToString( ) == request.SagaId ),
-                It.IsAny<CommandFlags>( )
-            ),
-            Times.Once
-        );
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _lookupServiceMock.Verify( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ), Times.Never );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _subscriberMock.Verify( s => s.PublishAsync(
+            It.IsAny<RedisChannel>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
     }
 
     #endregion
@@ -727,9 +1014,10 @@ public class QueueProcessorBackgroundServiceTests {
         // Discriminator: single-arg URI overload must not be called (only title+artist overload is used)
         _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ) ), Times.Never );
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state => state.IsSuccess ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once );
@@ -773,9 +1061,10 @@ public class QueueProcessorBackgroundServiceTests {
         // Discriminator: single-arg URI overload must not be called (only title+artist overload is used)
         _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ) ), Times.Never );
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state => state.IsSuccess ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once );
@@ -806,23 +1095,26 @@ public class QueueProcessorBackgroundServiceTests {
         // Act
         using CancellationTokenSource cts = new( );
         Task serviceTask = service.StartAsync( cts.Token );
-        await Task.Delay( 200, TestContext.CancellationToken );
+        await Task.Delay( 2500, TestContext.CancellationToken );
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
         // Assert: falls through to error handling — IsSuccess == false, ErrorMessage != null
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state =>
                     !state.IsSuccess &&
                     state.ErrorMessage != null
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once );
         // The lookup service is never called
         _lookupServiceMock.Verify( l => l.GetInfoAsync( It.IsAny<string>( ), It.IsAny<string>( ) ), Times.Never );
+        _queueMock.Verify( q => q.MoveToDlqAsync( message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -849,18 +1141,19 @@ public class QueueProcessorBackgroundServiceTests {
         // Act
         using CancellationTokenSource cts = new( );
         Task serviceTask = service.StartAsync( cts.Token );
-        await Task.Delay( 200, TestContext.CancellationToken );
+        await Task.Delay( 2500, TestContext.CancellationToken );
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
         // Assert: falls through to error handling
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state =>
                     !state.IsSuccess &&
                     state.ErrorMessage != null
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once );
@@ -885,6 +1178,7 @@ public class QueueProcessorBackgroundServiceTests {
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -931,6 +1225,7 @@ public class QueueProcessorBackgroundServiceTests {
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -983,6 +1278,7 @@ public class QueueProcessorBackgroundServiceTests {
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -1004,7 +1300,7 @@ public class QueueProcessorBackgroundServiceTests {
 
         // Assert - Should mark the saga as partial
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( request.SagaId, true, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetIsPartialAsync( request.SagaId, true, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }
@@ -1023,6 +1319,7 @@ public class QueueProcessorBackgroundServiceTests {
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -1044,13 +1341,14 @@ public class QueueProcessorBackgroundServiceTests {
 
         // Assert - Should record rate limit info with correct provider
         _sagaManagerMock.Verify(
-            s => s.SetRateLimitInfoAsync(
+            s => s.TrySetRateLimitInfoAsync(
                 request.SagaId,
                 It.Is<List<ProviderRateLimitInfo>>( info =>
                     info.Count == 1 &&
                     info[0].Provider == TestProvider &&
                     !string.IsNullOrEmpty( info[0].Endpoint )
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -1079,9 +1377,10 @@ public class QueueProcessorBackgroundServiceTests {
         );
         LookupSagaState saga = new( ) {
             SagaId = request.SagaId,
-            LookupKey = "test-key",
+            LookupKey = $"{request.LookupType}:{request.LookupValue}",
             LookupType = LookupRequestType.IsrcLookup,
             LookupValue = "US1234567890",
+            InstanceToken = "test-instance",
             ProviderStates = [],
             RateLimitInfo = [existingInfo]
         };
@@ -1110,13 +1409,14 @@ public class QueueProcessorBackgroundServiceTests {
 
         // Assert - Both the existing AppleMusic entry and the new Spotify entry are present
         _sagaManagerMock.Verify(
-            s => s.SetRateLimitInfoAsync(
+            s => s.TrySetRateLimitInfoAsync(
                 request.SagaId,
                 It.Is<List<ProviderRateLimitInfo>>( info =>
                     info.Count == 2 &&
                     info.Any( r => r.Provider == SupportedProviders.AppleMusic ) &&
                     info.Any( r => r.Provider == TestProvider )
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -1179,7 +1479,7 @@ public class QueueProcessorBackgroundServiceTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task ProcessMessage_WhenRateLimitAndInteractiveOrigin_ShouldStillRequeueAtBackground( ) {
+    public async Task ProcessMessage_WhenRateLimitAndInteractiveOrigin_PreservesInteractiveLane( ) {
         // Arrange
         // [LoggerMessage] source-generated code gates every call with IsEnabled().
         // Without this setup Moq returns false and Log() is never invoked, making
@@ -1190,10 +1490,11 @@ public class QueueProcessorBackgroundServiceTests {
         QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" ) with {
             OriginPriority = QueuePriority.Interactive
         };
-        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request ) with { Priority = QueuePriority.Interactive };
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -1206,6 +1507,18 @@ public class QueueProcessorBackgroundServiceTests {
         _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( ( ) => callCount++ == 0 ? message : null );
 
+        long interactiveDeferredMeasurements = 0;
+        using MeterListener interactiveMeterListener = new( );
+        interactiveMeterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && instrument.Name == "bridgebeats.ratelimit.interactive_retry.total") {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        interactiveMeterListener.SetMeasurementEventCallback<long>(
+            ( _, measurement, _, _ ) => Interlocked.Add( ref interactiveDeferredMeasurements, measurement ) );
+        interactiveMeterListener.Start( );
+
         // Act
         using CancellationTokenSource cts = new( );
         Task serviceTask = service.StartAsync( cts.Token );
@@ -1213,7 +1526,7 @@ public class QueueProcessorBackgroundServiceTests {
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
-        // Assert — acknowledge then requeue at Background (routing unchanged by the observability gate)
+        // Assert — enqueue precedes acknowledgement at Background priority.
         _queueMock.Verify(
             q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ),
             Times.Once
@@ -1224,7 +1537,7 @@ public class QueueProcessorBackgroundServiceTests {
                     r.LookupType == request.LookupType &&
                     r.AttemptCount == request.AttemptCount + 1
                 ),
-                QueuePriority.Background,
+                QueuePriority.Interactive,
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -1240,8 +1553,55 @@ public class QueueProcessorBackgroundServiceTests {
                 It.IsAny<It.IsAnyType>( ),
                 It.IsAny<Exception?>( ),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ),
-            Times.Once,
-            "LogInteractiveDeferredToBackground (Warning, EventId 3018) must fire once for an Interactive-origin rate-limited request" );
+            Times.Never );
+        Assert.AreEqual( 1L, interactiveDeferredMeasurements );
+    }
+
+    /// <summary>A caught rate-limit replacement failure leaves the original delivery pending.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_WhenRateLimitReplacementEnqueueFails_DoesNotAcknowledge( ) {
+        _ = _loggerMock.Setup( l => l.IsEnabled( It.IsAny<LogLevel>( ) ) ).Returns( true );
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US429-ENQUEUE-FAIL" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request ) with { Priority = QueuePriority.Interactive };
+        SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new RetryAfterExceededException(
+                TimeSpan.FromSeconds( 60 ), TimeSpan.FromSeconds( 30 ),
+                new Uri( "https://api.spotify.com/v1/tracks" ), SupportedProviders.Spotify ) );
+        _ = _queueMock.Setup( q => q.EnqueueAsync(
+                It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XADD failed" ) );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        long deferredMeasurements = 0;
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && instrument.Name == "bridgebeats.ratelimit.interactive_retry.total") {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>( ( _, measurement, _, _ ) => Interlocked.Add( ref deferredMeasurements, measurement ) );
+        meterListener.Start( );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 300, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _loggerMock.Verify( l => l.Log(
+            LogLevel.Warning,
+            new EventId( LogEventIds.Services.Queue.InteractiveDeferredToBackground ),
+            It.IsAny<It.IsAnyType>( ), It.IsAny<Exception?>( ), It.IsAny<Func<It.IsAnyType, Exception?, string>>( ) ), Times.Never );
+        Assert.AreEqual( 0L, deferredMeasurements );
     }
 
     /// <summary>
@@ -1267,6 +1627,7 @@ public class QueueProcessorBackgroundServiceTests {
         TimeSpan retryAfter = TimeSpan.FromSeconds( 60 );
 
         SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
         _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
             .ThrowsAsync( new RetryAfterExceededException(
                 retryAfter,
@@ -1321,8 +1682,186 @@ public class QueueProcessorBackgroundServiceTests {
 
     #region General Exception Handling Tests
 
+    /// <summary>HTTP 500 remains incomplete and durably enqueues replacement before acknowledgement.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Http500_RequeuesTransientFailure( ) {
+        QueueProcessorBackgroundService service = CreateService();
+        QueuedLookupRequest request = CreateRequest(LookupRequestType.IsrcLookup, "US500") with { AttemptCount = 1 };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage(request);
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "server", null, System.Net.HttpStatusCode.InternalServerError ) );
+        SetupSagaNotComplete( request.SagaId );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        using CancellationTokenSource cts = new();
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 2500, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync( request.SagaId, It.Is<ProviderLookupState>( state => !state.IsComplete ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>HTTP 404 is a permanent refusal: fail the leg and move the delivery to the DLQ immediately.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Http404_CompletesFailedAndMovesToDlqWithoutRequeue( ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US404" ) with { AttemptCount = 0 };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "not found", null, System.Net.HttpStatusCode.NotFound ) );
+        SetupSagaNotComplete( request.SagaId );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            request.SagaId,
+            It.Is<ProviderLookupState>( state => state.IsComplete && !state.IsSuccess && state.ErrorMessage != null ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.MoveToDlqAsync( message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>Ordinary transient retries preserve the delivered interactive or bulk lane.</summary>
+    [TestMethod]
+    [DataRow( QueuePriority.Interactive )]
+    [DataRow( QueuePriority.Bulk )]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Http500_PreservesInteractiveAndBulkLane( QueuePriority priority ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, $"US500-{priority}" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request ) with { Priority = priority };
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "server", null, System.Net.HttpStatusCode.InternalServerError ) );
+        SetupSagaNotComplete( request.SagaId );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 2500, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>A transient retry is scheduled for later delivery without sleeping in the consumer loop.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Http500_SchedulesReplacementAndAcknowledgesOriginal( ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US500-CANCEL" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "server", null, System.Net.HttpStatusCode.InternalServerError ) );
+        SetupSagaNotComplete( request.SagaId );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>Transient replacement failure leaves the original delivery pending.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Http500_WhenReplacementEnqueueFails_DoesNotAcknowledge( ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US500-ENQUEUE-FAIL" ) with { AttemptCount = 1 };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "server", null, System.Net.HttpStatusCode.InternalServerError ) );
+        SetupSagaNotComplete( request.SagaId );
+        _ = _queueMock.Setup( q => q.RequeueAsync(
+                message.MessageId, null, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XADD failed" ) );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 2500, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>Timeouts are transient and are requeued below the retry ceiling.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_Timeout_RequeuesTransientFailure( ) {
+        QueueProcessorBackgroundService service = CreateService();
+        QueuedLookupRequest request = CreateRequest(LookupRequestType.IsrcLookup, "USTIMEOUT") with { AttemptCount = 1 };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage(request);
+        SetupNotRateLimited( );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) ).ThrowsAsync( new TimeoutException( "timeout" ) );
+        SetupSagaNotComplete( request.SagaId );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        using CancellationTokenSource cts = new();
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 2500, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync( request.SagaId, It.Is<ProviderLookupState>( state => !state.IsComplete ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>Provider task cancellation without host cancellation is treated as transient.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_TaskCanceledWithoutHostCancellation_RequeuesTransientFailure( ) {
+        QueueProcessorBackgroundService service = CreateService( );
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "TASKCANCEL001" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        SetupSagaNotComplete( request.SagaId );
+        _ = _lookupServiceMock.Setup( l => l.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .ThrowsAsync( new TaskCanceledException( "provider timeout" ) );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 2500, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
     /// <summary>
-    /// A non-rate-limit exception below the retry ceiling marks the provider state complete-and-failed
+    /// A statusless transport exception below the retry ceiling leaves the provider leg incomplete
     /// with an error message via <c>UpdateProviderStateAsync</c>.
     /// </summary>
     [TestMethod]
@@ -1347,20 +1886,21 @@ public class QueueProcessorBackgroundServiceTests {
         // Act
         using CancellationTokenSource cts = new( );
         Task serviceTask = service.StartAsync( cts.Token );
-        await Task.Delay( 200, TestContext.CancellationToken );
+        await Task.Delay( 2500, TestContext.CancellationToken );
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
         // Assert
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 request.SagaId,
                 It.Is<ProviderLookupState>( state =>
                     state.Provider == TestProvider &&
-                    state.IsComplete &&
+                    !state.IsComplete &&
                     !state.IsSuccess &&
                     state.ErrorMessage != null
                 ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -1368,11 +1908,11 @@ public class QueueProcessorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// A non-rate-limit exception below the retry ceiling acknowledges the message (no requeue, no DLQ).
+    /// A non-rate-limit transient exception below the retry ceiling re-enqueues the replacement before acknowledging the message.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task ProcessMessage_WhenExceptionThrown_BelowMaxRetries_ShouldAcknowledgeMessage( ) {
+    public async Task ProcessMessage_WhenExceptionThrown_BelowMaxRetries_ShouldRequeueThenAcknowledgeMessage( ) {
         // Arrange
         QueueProcessorBackgroundService service = CreateService( );
         QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" ) with {
@@ -1392,15 +1932,13 @@ public class QueueProcessorBackgroundServiceTests {
         // Act
         using CancellationTokenSource cts = new( );
         Task serviceTask = service.StartAsync( cts.Token );
-        await Task.Delay( 200, TestContext.CancellationToken );
+        await Task.Delay( 2500, TestContext.CancellationToken );
         await cts.CancelAsync( );
         await service.StopAsync( CancellationToken.None );
 
         // Assert
-        _queueMock.Verify(
-            q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ),
-            Times.Once
-        );
+        _queueMock.Verify( q => q.RequeueAsync(
+            message.MessageId, null, It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>
@@ -1412,7 +1950,7 @@ public class QueueProcessorBackgroundServiceTests {
         // Arrange
         QueueProcessorBackgroundService service = CreateService( );
         QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" ) with {
-            AttemptCount = 5 // At max retries
+            AttemptCount = 4 // Fifth and terminal execution (initial attempt is zero)
         };
         QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
 
@@ -1449,7 +1987,7 @@ public class QueueProcessorBackgroundServiceTests {
         // Arrange
         QueueProcessorBackgroundService service = CreateService( );
         QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "US1234567890" ) with {
-            AttemptCount = 5
+            AttemptCount = 4
         };
         QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
 
@@ -1509,7 +2047,307 @@ public class QueueProcessorBackgroundServiceTests {
         Assert.IsTrue( reachedTarget, "Service did not poll at least 2 times within timeout" );
     }
 
+    /// <summary>Generic NOGROUP repair failure is delayed and retried without stopping the host.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ExecuteAsync_WhenGroupRepairFails_RetriesAndSurvives( ) {
+        int dequeueCalls = 0;
+        int ensureCalls = 0;
+        TaskCompletionSource<bool> resumed = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        AssuringQueue queue = new( ) {
+            DequeueRate = ct => {
+                int call = Interlocked.Increment( ref dequeueCalls );
+                if (call <= 2) return Task.FromException<QueuedMessage<QueuedLookupRequest>?>( new RedisServerException( "NOGROUP" ) );
+                _ = resumed.TrySetResult( true );
+                return Task.FromResult<QueuedMessage<QueuedLookupRequest>?>( null );
+            },
+            Ensure = _ => {
+                if (Interlocked.Increment( ref ensureCalls ) == 1) return Task.FromException( new InvalidOperationException( "repair failed" ) );
+                return Task.CompletedTask;
+            }
+        };
+        QueueProcessorBackgroundService service = new(
+            _redisMock.Object, queue, _rateLimitTrackerMock.Object, _sagaManagerMock.Object,
+            _lookupServiceMock.Object, TestProvider, _loggerMock.Object );
+
+        await service.StartAsync( TestContext.CancellationToken );
+        Task completed = await Task.WhenAny( resumed.Task, Task.Delay( TimeSpan.FromSeconds( 5 ), TestContext.CancellationToken ) );
+        await service.StopAsync( TestContext.CancellationToken );
+
+        Assert.AreSame( resumed.Task, completed );
+        Assert.IsGreaterThanOrEqualTo( 2, ensureCalls );
+    }
+
+    /// <summary>Provider calls overlap up to the configured bound while dequeue remains serialized.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ExecuteAsync_WithConcurrencyTwo_ProcessesTwoProviderCallsInParallel( ) {
+        QueuedMessage<QueuedLookupRequest>[] messages = [
+            CreateMessage( CreateRequest( LookupRequestType.IsrcLookup, "CONCURRENT-1" ) ),
+            CreateMessage( CreateRequest( LookupRequestType.IsrcLookup, "CONCURRENT-2" ) )
+        ];
+        SetupNotRateLimited( );
+        int nextMessage = -1;
+        _ = _queueMock.Setup( queue => queue.DequeueAsync(
+                It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                int index = Interlocked.Increment( ref nextMessage );
+                return index < messages.Length ? messages[index] : null;
+            } );
+
+        int activeCalls = 0;
+        int maximumActiveCalls = 0;
+        TaskCompletionSource<bool> bothStarted = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        TaskCompletionSource<bool> releaseCalls = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        _ = _lookupServiceMock.Setup( lookup => lookup.GetInfoByISRCAsync( It.IsAny<string>( ) ) )
+            .Returns( async ( string isrc ) => {
+                int active = Interlocked.Increment( ref activeCalls );
+                _ = Interlocked.Exchange( ref maximumActiveCalls, Math.Max( maximumActiveCalls, active ) );
+                if (active == 2) _ = bothStarted.TrySetResult( true );
+                _ = await releaseCalls.Task;
+                _ = Interlocked.Decrement( ref activeCalls );
+                return null;
+            } );
+
+        QueueProcessorBackgroundService service = CreateService( concurrency: 2 );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        Task observed = await Task.WhenAny(
+            bothStarted.Task,
+            Task.Delay( TimeSpan.FromSeconds( 5 ), TestContext.CancellationToken ) );
+        Assert.AreSame( bothStarted.Task, observed, "The second provider call did not start while the first was in flight." );
+        _ = releaseCalls.TrySetResult( true );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        Assert.AreEqual( 2, maximumActiveCalls );
+        _queueMock.Verify( queue => queue.AcknowledgeAsync(
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Exactly( 2 ) );
+    }
+
     #endregion
+
+    /// <summary>An absent saga is acknowledged as stale without worker-side recreation.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_AbsentSagaIdentityMismatch_AcknowledgesStaleWithoutProviderMutation( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "MISMATCH" ) with { SagaId = "not-the-canonical-saga" };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( (LookupSagaState?)null );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => {
+                _ = Interlocked.Increment( ref calls );
+                return calls == 1 ? message : null;
+            } );
+
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( q => q.MoveToDlqAsync( message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( s => s.GetOrCreateAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+            It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>An existing saga with an initialized incomplete provider leg is accepted as a legitimate child.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ProcessMessage_ExistingInitializedChild_AllowsProviderUpdate( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "CHILD" ) with {
+            SagaInstanceToken = "child-instance"
+        };
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        LookupSagaState child = new( ) {
+            SagaId = request.SagaId,
+            LookupKey = "different-root",
+            LookupType = LookupRequestType.UpcLookup,
+            LookupValue = "OTHER",
+            InstanceToken = "child-instance",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [TestProvider] = new( TestProvider, false, false, null, null, null )
+            }
+        };
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( child );
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 250, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            request.SagaId, It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            "child-instance", It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.MoveToDlqAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A delivery fenced to a replaced saga generation is acknowledged as stale.</summary>
+    [TestMethod]
+    public async Task ProcessMessage_ExistingMismatchedUninitializedSaga_AcknowledgesStale( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "MISMATCHED" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( new LookupSagaState {
+                SagaId = request.SagaId,
+                LookupKey = "other-root",
+                LookupType = LookupRequestType.UpcLookup,
+                LookupValue = "OTHER",
+                InstanceToken = "other-instance",
+                ProviderStates = []
+            } );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.MoveToDlqAsync( message.MessageId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>An absent canonical saga is not recreated by a worker delivery.</summary>
+    [TestMethod]
+    public async Task ProcessMessage_AbsentCanonicalSaga_AcknowledgesStale( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "ABSENT-CANONICAL" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( (LookupSagaState?)null );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _sagaManagerMock.Verify( s => s.GetOrCreateAsync(
+            request.SagaId, It.IsAny<string>( ), request.LookupType, request.LookupValue,
+            It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( s => s.TryInitializeProviderStatesAsync(
+            request.SagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), "test-instance", It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.MoveToDlqAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A matching deterministic delivery whose persisted saga is unreadable is quarantined once.</summary>
+    [TestMethod]
+    public async Task ProcessMessage_MatchingUnreadableSaga_MovesDeliveryToDlq( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "CORRUPT-MATCHING" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync(
+                request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new UnreadableSagaStateException( request.SagaId ) );
+        int calls = 0;
+        _ = _queueMock.Setup( queue => queue.DequeueAsync(
+                It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+
+        _queueMock.Verify( queue => queue.MoveToDlqAsync(
+            message.MessageId,
+            It.Is<string>( reason => reason.Contains( "unreadable", StringComparison.OrdinalIgnoreCase ) ),
+            It.IsAny<CancellationToken>( ) ), Times.Once );
+        _lookupServiceMock.VerifyNoOtherCalls( );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ),
+            It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A provider update that loses the instance CAS acknowledges the stale delivery without retry.</summary>
+    [TestMethod]
+    public async Task ProcessMessage_WhenInstanceReplacedDuringProviderUpdate_AcknowledgesAndDrops( ) {
+        QueuedLookupRequest request = CreateRequest( LookupRequestType.IsrcLookup, "REPLACED" );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage( request );
+        SetupNotRateLimited( );
+        SetupLookupSuccess( );
+        SetupSagaNotComplete( request.SagaId );
+        _ = _sagaManagerMock.Setup( s => s.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+        int calls = 0;
+        _ = _queueMock.Setup( q => q.DequeueAsync( It.IsAny<IRateLimitTracker>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => calls++ == 0 ? message : null );
+        List<string> processingStatuses = [];
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Name == "bridgebeats.queue.processing.duration") listener.EnableMeasurementEvents( instrument );
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( _, _, tags, _ ) => {
+            foreach (KeyValuePair<string, object?> tag in tags) {
+                if (tag.Key == "status") processingStatuses.Add( tag.Value?.ToString( ) ?? string.Empty );
+            }
+        } );
+        meterListener.Start( );
+        QueueProcessorBackgroundService service = CreateService( );
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 200, TestContext.CancellationToken );
+        await cts.CancelAsync( );
+        await service.StopAsync( CancellationToken.None );
+        _queueMock.Verify( q => q.AcknowledgeAsync( message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _queueMock.Verify( q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _subscriberMock.Verify( s => s.PublishAsync( It.IsAny<RedisChannel>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        Assert.Contains( "stale", processingStatuses, "A provider-state CAS loss must not be reported as processing success." );
+    }
+
+    /// <summary>Post-commit acknowledgement recovery is capped and releases the local delivery fence.</summary>
+    [TestMethod]
+    public async Task RecoverCommittedAcknowledgement_WhenBrokerStaysUnavailable_IsBounded( ) {
+        Mock<IQueueDeliveryTracker> tracker = _queueMock.As<IQueueDeliveryTracker>( );
+        QueuedMessage<QueuedLookupRequest> message = CreateMessage(
+            CreateRequest( LookupRequestType.IsrcLookup, "USRC12345678" ) );
+        _ = _queueMock.Setup( queue => queue.AcknowledgeAsync(
+                message.MessageId, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect,
+                "ack unavailable" ) );
+        List<TimeSpan> delays = [];
+        QueueProcessorBackgroundService service = CreateService( );
+
+        await service.RecoverCommittedAcknowledgementAsync(
+            message,
+            TestContext.CancellationToken,
+            ( delay, _ ) => {
+                delays.Add( delay );
+                return Task.CompletedTask;
+            } );
+
+        CollectionAssert.AreEqual(
+            new[] { TimeSpan.FromSeconds( 1 ), TimeSpan.FromSeconds( 2 ),
+                TimeSpan.FromSeconds( 4 ), TimeSpan.FromSeconds( 8 ) },
+            delays );
+        _queueMock.Verify( queue => queue.AcknowledgeAsync(
+            message.MessageId, It.IsAny<CancellationToken>( ) ), Times.Exactly( 4 ) );
+        tracker.Verify( queue => queue.ReleaseDelivery( message.MessageId ), Times.Once );
+    }
 
     #region Helper Methods
 
@@ -1517,7 +2355,7 @@ public class QueueProcessorBackgroundServiceTests {
     /// Builds a <see cref="QueueProcessorBackgroundService"/> bound to <see cref="TestProvider"/> from
     /// the current dependency mocks.
     /// </summary>
-    private QueueProcessorBackgroundService CreateService( IMusicLookupService? lookupService = null ) =>
+    private QueueProcessorBackgroundService CreateService( IMusicLookupService? lookupService = null, int concurrency = 1 ) =>
         new(
             _redisMock.Object,
             _queueMock.Object,
@@ -1525,22 +2363,49 @@ public class QueueProcessorBackgroundServiceTests {
             _sagaManagerMock.Object,
             lookupService ?? _lookupServiceMock.Object,
             TestProvider,
-            _loggerMock.Object
+            _loggerMock.Object,
+            new QueueSettings { DefaultProviderConcurrency = concurrency }
         );
+
+    /// <summary>Queue seam exposing consumer-group assurance for hosted-loop recovery tests.</summary>
+    private sealed class AssuringQueue : IRequestQueue<QueuedLookupRequest>, IConsumerGroupAssurance {
+        public Func<CancellationToken, Task<QueuedMessage<QueuedLookupRequest>?>> DequeueRate { get; init; } = _ => Task.FromResult<QueuedMessage<QueuedLookupRequest>?>( null );
+        public Func<CancellationToken, Task> Ensure { get; init; } = _ => Task.CompletedTask;
+        public Task EnsureConsumerGroupsAsync( CancellationToken cancellationToken = default ) => Ensure( cancellationToken );
+        public Task EnqueueAsync( QueuedLookupRequest request, QueuePriority priority, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<QueuedMessage<QueuedLookupRequest>?> DequeueAsync( CancellationToken cancellationToken = default ) => DequeueRate( cancellationToken );
+        public Task<QueuedMessage<QueuedLookupRequest>?> DequeueAsync( IRateLimitTracker tracker, CancellationToken cancellationToken = default ) => DequeueRate( cancellationToken );
+        public Task AcknowledgeAsync( string messageId, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task RequeueAsync( string messageId, TimeSpan? delay = null, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<QueueDepth> GetDepthAsync( CancellationToken cancellationToken = default ) => Task.FromResult( new QueueDepth( 0, 0, 0, 0 ) );
+        public Task<IReadOnlyList<QueuedMessage<QueuedLookupRequest>>> GetDlqMessagesAsync( int limit, CancellationToken cancellationToken = default ) => Task.FromResult<IReadOnlyList<QueuedMessage<QueuedLookupRequest>>>( [] );
+        public Task RequeueFromDlqAsync( string messageId, QueuePriority priority, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task MoveToDlqAsync( string messageId, string reason, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<bool> DeleteFromDlqAsync( string messageId, CancellationToken cancellationToken = default ) => Task.FromResult( false );
+    }
 
     /// <summary>
     /// Builds a <see cref="QueuedLookupRequest"/> for <see cref="TestProvider"/> with fresh request
     /// and saga ids, the given lookup type, and lookup value.
     /// </summary>
-    private static QueuedLookupRequest CreateRequest( LookupRequestType lookupType, string lookupValue ) =>
-        new( ) {
+    private static QueuedLookupRequest CreateRequest( LookupRequestType lookupType, string lookupValue ) {
+        string lookupKey = lookupType switch {
+            LookupRequestType.SongIdLookup or LookupRequestType.AlbumIdLookup => LookupKeyBuilder.TypedKey( lookupType, TestProvider, lookupValue ),
+            LookupRequestType.UriLookup => LookupKeyBuilder.UrlKey( lookupValue ),
+            _ => $"{lookupType}:{lookupValue}"
+        };
+        string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+        s_requestIdentities[sagaId] = (lookupKey, lookupType, lookupValue);
+        return new( ) {
             RequestId = $"req-{Guid.NewGuid( ):N}",
             Provider = TestProvider,
             LookupType = lookupType,
             LookupValue = lookupValue,
-            SagaId = $"saga-{Guid.NewGuid( ):N}",
+            SagaId = sagaId,
+            SagaInstanceToken = "test-instance",
             CreatedAt = DateTimeOffset.UtcNow
         };
+    }
 
     /// <summary>
     /// Wraps a request in a <see cref="QueuedMessage{T}"/> with a fresh message id and the current
@@ -1606,19 +2471,22 @@ public class QueueProcessorBackgroundServiceTests {
     /// yet whole (no <c>saga:completed</c> publication is expected).
     /// </summary>
     private void SetupSagaNotComplete( string sagaId ) {
+        (string lookupKey, LookupRequestType lookupType, string lookupValue) = s_requestIdentities.GetValueOrDefault(
+            sagaId, ($"{LookupRequestType.IsrcLookup}:test-value", LookupRequestType.IsrcLookup, "test-value") );
         LookupSagaState saga = new( ) {
             SagaId = sagaId,
-            LookupKey = "test-key",
-            LookupType = LookupRequestType.IsrcLookup,
-            LookupValue = "test-value",
+            LookupKey = lookupKey,
+            LookupType = lookupType,
+            LookupValue = lookupValue,
+            InstanceToken = "test-instance",
             ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
-                // Only one provider complete, saga is not complete
+                // The provider leg is pending; the worker owns this delivery.
                 [SupportedProviders.Spotify] = new(
                     SupportedProviders.Spotify,
-                    IsComplete: true,
-                    IsSuccess: true,
-                    ResultJson: JsonSerializer.Serialize( CreateLookupResult( ), s_jsonOptions ),
-                    CompletedAt: DateTimeOffset.UtcNow,
+                    IsComplete: false,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: null,
                     ErrorMessage: null
                 )
             }
@@ -1632,11 +2500,14 @@ public class QueueProcessorBackgroundServiceTests {
     /// so the saga is whole (a <c>saga:completed</c> publication is expected).
     /// </summary>
     private void SetupSagaComplete( string sagaId ) {
+        (string lookupKey, LookupRequestType lookupType, string lookupValue) = s_requestIdentities.GetValueOrDefault(
+            sagaId, ($"{LookupRequestType.IsrcLookup}:test-value", LookupRequestType.IsrcLookup, "test-value") );
         LookupSagaState saga = new( ) {
             SagaId = sagaId,
-            LookupKey = "test-key",
-            LookupType = LookupRequestType.IsrcLookup,
-            LookupValue = "test-value",
+            LookupKey = lookupKey,
+            LookupType = lookupType,
+            LookupValue = lookupValue,
+            InstanceToken = "test-instance",
             ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
                 [SupportedProviders.Spotify] = new(
                     SupportedProviders.Spotify,

--- a/Tests/Unit/RedisRefreshReviewStoreTests.cs
+++ b/Tests/Unit/RedisRefreshReviewStoreTests.cs
@@ -17,75 +17,24 @@ public class RedisRefreshReviewStoreTests {
     /// <summary>MSTest cancellation token for asynchronous store operations.</summary>
     public TestContext TestContext { get; set; } = null!;
 
-    /// <summary>Promotion writes the durable review entry before deleting pending saga context.</summary>
+    /// <summary>Sweep attempts increment atomically and are deleted by the success reset.</summary>
     [TestMethod]
-    public async Task MarkUnresolved_PendingEntry_WritesReviewThenDeletesPending( ) {
+    public async Task SweepAttempts_IncrementThenClear( ) {
         Mock<IConnectionMultiplexer> redis = new( );
         Mock<IDatabase> database = new( );
-        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
-            .Returns( database.Object );
-
-        RefreshReviewEntry pending = CreateEntry( );
-        _ = database.Setup( db => db.StringGetAsync(
-                "cache:refresh:pending:refresh-saga", It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( JsonSerializer.Serialize( pending, s_jsonOptions ) );
-
-        int sequence = 0;
-        int reviewWriteOrder = 0;
-        int pendingDeleteOrder = 0;
-        RedisValue reviewJson = RedisValue.Null;
-        _ = database.Setup( db => db.HashSetAsync(
-                "cache:refresh:unresolved",
-                pending.SourceRecordUri,
-                It.IsAny<RedisValue>( ),
-                It.IsAny<When>( ),
-                It.IsAny<CommandFlags>( ) ) )
-            .Callback<RedisKey, RedisValue, RedisValue, When, CommandFlags>( ( _, _, value, _, _ ) => {
-                reviewJson = value;
-                reviewWriteOrder = Interlocked.Increment( ref sequence );
-            } )
-            .ReturnsAsync( true );
-        _ = database.Setup( db => db.KeyDeleteAsync(
-                "cache:refresh:pending:refresh-saga", It.IsAny<CommandFlags>( ) ) )
-            .Callback( ( ) => pendingDeleteOrder = Interlocked.Increment( ref sequence ) )
-            .ReturnsAsync( true );
-
-        RedisRefreshReviewStore store = new(
-            redis.Object,
-            Options.Create( new QueueSettings { JobExpirationMinutes = 60 } ),
-            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
-        await store.MarkUnresolvedAsync(
-            "refresh-saga", "No provider result.", TestContext.CancellationToken );
-
-        RefreshReviewEntry? unresolved = JsonSerializer.Deserialize<RefreshReviewEntry>(
-            reviewJson.ToString( ), s_jsonOptions );
-        Assert.IsNotNull( unresolved );
-        Assert.IsNotNull( unresolved.FailedAt );
-        Assert.AreEqual( "No provider result.", unresolved.FailureReason );
-        Assert.IsLessThan( pendingDeleteOrder, reviewWriteOrder );
-    }
-
-    /// <summary>An ordinary interactive miss has no pending refresh context and is never reviewed.</summary>
-    [TestMethod]
-    public async Task MarkUnresolved_WithoutPendingContext_DoesNotCreateReviewEntry( ) {
-        Mock<IConnectionMultiplexer> redis = new( );
-        Mock<IDatabase> database = new( );
-        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
-            .Returns( database.Object );
-        _ = database.Setup( db => db.StringGetAsync(
-                "cache:refresh:pending:interactive-saga", It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( RedisValue.Null );
-
-        RedisRefreshReviewStore store = new(
-            redis.Object,
-            Options.Create( new QueueSettings( ) ),
-            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
-        await store.MarkUnresolvedAsync(
-            "interactive-saga", "No provider result.", TestContext.CancellationToken );
-
-        database.Verify( db => db.HashSetAsync(
-            "cache:refresh:unresolved", It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
-            It.IsAny<When>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        _ = redis.Setup( c => c.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( database.Object );
+        _ = database.SetupSequence( db => db.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]>( ), It.IsAny<RedisValue[]>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)1 ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)2 ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)3 ) );
+        _ = database.Setup( db => db.KeyDeleteAsync( "cache:refresh:attempts:saga", It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( true );
+        RedisRefreshReviewStore store = new(redis.Object, Options.Create(new QueueSettings { JobExpirationMinutes = 60 }), Mock.Of<ILogger<RedisRefreshReviewStore>>());
+        Assert.AreEqual( 1, await store.IncrementSweepAttemptAsync( "saga", TestContext.CancellationToken ) );
+        Assert.AreEqual( 2, await store.IncrementSweepAttemptAsync( "saga", TestContext.CancellationToken ) );
+        Assert.AreEqual( 3, await store.IncrementSweepAttemptAsync( "saga", TestContext.CancellationToken ) );
+        await store.ClearSweepAttemptsAsync( "saga", TestContext.CancellationToken );
+        database.Verify( db => db.KeyDeleteAsync( "cache:refresh:attempts:saga", It.IsAny<CommandFlags>( ) ), Times.Once );
     }
 
     /// <summary>The review list deserializes entries and returns newest failures first.</summary>
@@ -116,90 +65,6 @@ public class RedisRefreshReviewStoreTests {
 
         Assert.HasCount( 2, entries );
         Assert.AreEqual( newer.SourceRecordUri, entries[0].SourceRecordUri );
-    }
-
-    /// <summary>A successful completion removes the unresolved entry indexed by that same saga.</summary>
-    [TestMethod]
-    public async Task Complete_UnresolvedSaga_RemovesReviewEntry( ) {
-        Mock<IConnectionMultiplexer> redis = new( );
-        Mock<IDatabase> database = new( );
-        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
-            .Returns( database.Object );
-        _ = database.Setup( db => db.HashGetAsync(
-                "cache:refresh:unresolved:sagas", "refresh-saga", It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( CreateEntry( ).SourceRecordUri );
-        _ = database.Setup( db => db.HashGetAsync(
-                "cache:refresh:unresolved", CreateEntry( ).SourceRecordUri, It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( JsonSerializer.Serialize( CreateEntry( ), s_jsonOptions ) );
-
-        RedisRefreshReviewStore store = new(
-            redis.Object,
-            Options.Create( new QueueSettings( ) ),
-            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
-
-        await store.CompleteAsync( "refresh-saga", TestContext.CancellationToken );
-
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved", CreateEntry( ).SourceRecordUri, It.IsAny<CommandFlags>( ) ), Times.Once );
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved:sagas", "refresh-saga", It.IsAny<CommandFlags>( ) ), Times.Once );
-    }
-
-    /// <summary>A successful replacement refresh clears an older review for the same source URI.</summary>
-    [TestMethod]
-    public async Task Complete_LaterPendingSaga_RemovesOlderReviewEntry( ) {
-        Mock<IConnectionMultiplexer> redis = new( );
-        Mock<IDatabase> database = new( );
-        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
-            .Returns( database.Object );
-        RefreshReviewEntry older = CreateEntry( ) with { SagaId = "older-saga" };
-        RefreshReviewEntry replacement = CreateEntry( ) with { SagaId = "replacement-saga" };
-        _ = database.Setup( db => db.StringGetAsync(
-                "cache:refresh:pending:replacement-saga", It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( JsonSerializer.Serialize( replacement, s_jsonOptions ) );
-        _ = database.Setup( db => db.HashGetAsync(
-                "cache:refresh:unresolved", older.SourceRecordUri, It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( JsonSerializer.Serialize( older, s_jsonOptions ) );
-
-        RedisRefreshReviewStore store = new(
-            redis.Object,
-            Options.Create( new QueueSettings( ) ),
-            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
-
-        await store.CompleteAsync( "replacement-saga", TestContext.CancellationToken );
-
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved", older.SourceRecordUri, It.IsAny<CommandFlags>( ) ), Times.Once );
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved:sagas", "older-saga", It.IsAny<CommandFlags>( ) ), Times.Once );
-    }
-
-    /// <summary>A stale saga index cannot remove a newer unresolved review for the same source URI.</summary>
-    [TestMethod]
-    public async Task Complete_StaleSagaIndex_PreservesNewerReviewEntry( ) {
-        Mock<IConnectionMultiplexer> redis = new( );
-        Mock<IDatabase> database = new( );
-        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
-            .Returns( database.Object );
-        RefreshReviewEntry newer = CreateEntry( ) with { SagaId = "newer-saga" };
-        _ = database.Setup( db => db.HashGetAsync(
-                "cache:refresh:unresolved:sagas", "older-saga", It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( newer.SourceRecordUri );
-        _ = database.Setup( db => db.HashGetAsync(
-                "cache:refresh:unresolved", newer.SourceRecordUri, It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( JsonSerializer.Serialize( newer, s_jsonOptions ) );
-
-        RedisRefreshReviewStore store = new(
-            redis.Object,
-            Options.Create( new QueueSettings( ) ),
-            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
-
-        await store.CompleteAsync( "older-saga", TestContext.CancellationToken );
-
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved", newer.SourceRecordUri, It.IsAny<CommandFlags>( ) ), Times.Never );
-        database.Verify( db => db.HashDeleteAsync(
-            "cache:refresh:unresolved:sagas", "older-saga", It.IsAny<CommandFlags>( ) ), Times.Once );
     }
 
     /// <summary>A corrupt hash value is quarantined without hiding healthy review entries.</summary>
@@ -288,6 +153,37 @@ public class RedisRefreshReviewStoreTests {
             TestContext.CancellationToken );
 
         Assert.IsFalse( deleted );
+    }
+
+    /// <summary>
+    /// Entry-scoped review mutations use one Redis script each, rather than a client-side read,
+    /// compare, and write sequence that could interleave with a replacement refresh.
+    /// </summary>
+    [TestMethod]
+    public async Task EntryScopedReviewMutations_UseAtomicScriptsWithoutClientSideReadModifyWrite( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> database = new( );
+        _ = redis.Setup( connection => connection.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
+            .Returns( database.Object );
+        _ = database.Setup( db => db.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)0 ) );
+
+        RefreshReviewEntry entry = CreateEntry( ) with { InstanceToken = "instance-x" };
+        RedisRefreshReviewStore store = new(
+            redis.Object,
+            Options.Create( new QueueSettings { JobExpirationMinutes = 60 } ),
+            Mock.Of<ILogger<RedisRefreshReviewStore>>( ) );
+
+        await store.MarkUnresolvedAsync( entry, "No provider result.", TestContext.CancellationToken );
+        await store.CompleteAsync( entry, TestContext.CancellationToken );
+
+        database.Verify( db => db.ScriptEvaluateAsync(
+            It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ), It.IsAny<CommandFlags>( ) ),
+            Times.Exactly( 2 ) );
+        database.Verify( db => db.StringGetAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        database.Verify( db => db.HashGetAsync( It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        database.Verify( db => db.HashDeleteAsync( It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
     }
 
     private static RefreshReviewEntry CreateEntry( ) => new( ) {

--- a/Tests/Unit/RedisRequestQueueFailureTests.cs
+++ b/Tests/Unit/RedisRequestQueueFailureTests.cs
@@ -1,0 +1,287 @@
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Queue;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>Failure-boundary tests for loss-safe Redis queue replacement.</summary>
+[TestClass]
+[DoNotParallelize]
+public sealed class RedisRequestQueueFailureTests {
+    /// <summary>An atomic replacement failure leaves the source pending and records no enqueue.</summary>
+    [TestMethod]
+    public async Task RequeueAsync_WhenAtomicMoveFails_RecordsNoAcceptedEnqueue( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        QueuedLookupRequest request = new( ) {
+            RequestId = "request",
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-FAIL",
+            SagaId = "saga"
+        };
+        StreamEntry original = new( (RedisValue)"1-0", [
+            new NameValueEntry( QueueStreamFieldNames.Payload, JsonSerializer.Serialize( request ) ),
+            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ] );
+        _ = db.Setup( d => d.StreamRangeAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ), It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [original] );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "atomic move failed" ) );
+
+        long accepted = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, consumer ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") {
+                consumer.EnableMeasurementEvents( instrument );
+            }
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, measurement, _, _ ) => Interlocked.Add( ref accepted, measurement ) );
+        listener.Start( );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        _ = await Assert.ThrowsExactlyAsync<RedisServerException>(
+            ( ) => queue.RequeueAsync( "queue:spotify:interactive:1-0", cancellationToken: CancellationToken.None ) );
+        listener.RecordObservableInstruments( );
+        Assert.AreEqual( 0, accepted );
+    }
+
+    /// <summary>An XADD failure leaves the original stream delivery untouched.</summary>
+    [TestMethod]
+    public async Task RequeueAsync_WhenReplacementAddFails_LeavesOriginalPending( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        QueuedLookupRequest request = new( ) {
+            RequestId = "request",
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-FAIL",
+            SagaId = "saga"
+        };
+        NameValueEntry[] fields = [
+            new( QueueStreamFieldNames.Payload, JsonSerializer.Serialize( request ) ),
+            new( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ];
+        StreamEntry original = new( (RedisValue)"1-0", fields );
+        _ = db.Setup( d => d.StreamRangeAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ), It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [original] );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XADD failed" ) );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        long accepted = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, consumer ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") consumer.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, measurement, _, _ ) => Interlocked.Add( ref accepted, measurement ) );
+        listener.Start( );
+
+        _ = await Assert.ThrowsExactlyAsync<RedisServerException>(
+            ( ) => queue.RequeueAsync( "queue:spotify:interactive:1-0", cancellationToken: CancellationToken.None ) );
+
+        listener.RecordObservableInstruments( );
+        Assert.AreEqual( 0, accepted, "A failed XADD is not an accepted enqueue" );
+
+        db.Verify( d => d.StreamAcknowledgeAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        db.Verify( d => d.StreamDeleteAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue[]>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>An accepted ordinary enqueue records exactly one enqueue metric after XADD succeeds.</summary>
+    [TestMethod]
+    public async Task EnqueueAsync_WhenStreamAddReturnsId_RecordsAcceptedEnqueue( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"3-0" ) );
+
+        long accepted = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, consumer ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") consumer.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, measurement, _, _ ) => Interlocked.Add( ref accepted, measurement ) );
+        listener.Start( );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+        await queue.EnqueueAsync( new QueuedLookupRequest {
+            RequestId = "request",
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-ACCEPTED",
+            SagaId = "saga"
+        }, QueuePriority.Interactive, CancellationToken.None );
+
+        listener.RecordObservableInstruments( );
+        Assert.AreEqual( 1, accepted, "A non-null XADD id must count exactly one accepted enqueue" );
+    }
+
+    /// <summary>A value-less XADD result is reported as an enqueue failure.</summary>
+    [TestMethod]
+    public async Task EnqueueAsync_WhenStreamAddReturnsNoId_ThrowsAndRecordsNoMetric( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( RedisValue.Null ) );
+
+        long accepted = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, consumer ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") consumer.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, measurement, _, _ ) => Interlocked.Add( ref accepted, measurement ) );
+        listener.Start( );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        _ = await Assert.ThrowsExactlyAsync<InvalidOperationException>( ( ) => queue.EnqueueAsync(
+            new QueuedLookupRequest {
+                RequestId = "request",
+                Provider = SupportedProviders.Spotify,
+                LookupType = LookupRequestType.IsrcLookup,
+                LookupValue = "US-NOT-ACCEPTED",
+                SagaId = "saga"
+            }, QueuePriority.Interactive, CancellationToken.None ) );
+
+        listener.RecordObservableInstruments( );
+        Assert.AreEqual( 0, accepted );
+    }
+
+    /// <summary>A value-less DLQ replacement leaves the only source copy intact.</summary>
+    [TestMethod]
+    public async Task RequeueFromDlqAsync_WhenReplacementReturnsNoId_DoesNotDeleteSource( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        QueuedLookupRequest request = new( ) {
+            RequestId = "request",
+            Provider = SupportedProviders.Spotify,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "US-DLQ",
+            SagaId = "saga"
+        };
+        StreamEntry original = new( (RedisValue)"1-0", [
+            new NameValueEntry( QueueStreamFieldNames.Payload, JsonSerializer.Serialize( request ) ),
+            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
+        ] );
+        _ = db.Setup( d => d.StreamRangeAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ), It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [original] );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( RedisValue.Null ) );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        _ = await Assert.ThrowsExactlyAsync<InvalidOperationException>( ( ) => queue.RequeueFromDlqAsync(
+            "queue:spotify:dlq:1-0", QueuePriority.Background, CancellationToken.None ) );
+
+        db.Verify( d => d.StreamDeleteAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue[]>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>Unknown-command XAUTOCLAIM errors fall back to own-PEL/new scanning.</summary>
+    [TestMethod]
+    public async Task DequeueAsync_WhenAutoClaimIsUnsupported_FallsBackToOtherStages( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        Mock<IRateLimitTracker> tracker = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( SupportedProviders.Spotify, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( Array.Empty<RateLimitedEndpoint>( ) );
+        _ = db.Setup( d => d.StreamLengthAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( 0 );
+        _ = db.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<long>( ),
+                It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "ERR unknown command 'XAUTOCLAIM'" ) );
+        _ = db.Setup( d => d.StreamPendingMessagesAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<int>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( Array.Empty<StreamPendingMessageInfo>( ) );
+        _ = db.Setup( d => d.StreamReadGroupAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue?>( ),
+                It.IsAny<int?>( ), It.IsAny<bool>( ), It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( Array.Empty<StreamEntry>( ) );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        Assert.IsNull( await queue.DequeueAsync( tracker.Object, CancellationToken.None ) );
+    }
+
+    /// <summary>Permission errors from XAUTOCLAIM propagate instead of being treated as unsupported.</summary>
+    [TestMethod]
+    public async Task DequeueAsync_WhenAutoClaimIsForbidden_PropagatesRedisError( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        Mock<IRateLimitTracker> tracker = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = tracker.Setup( t => t.GetAllRateLimitedAsync( SupportedProviders.Spotify, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( Array.Empty<RateLimitedEndpoint>( ) );
+        _ = db.Setup( d => d.StreamLengthAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( 0 );
+        _ = db.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<long>( ),
+                It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "NOPERM this user has no permissions" ) );
+
+        RedisRequestQueue<QueuedLookupRequest> queue = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisRequestQueue<QueuedLookupRequest>>>( ),
+            Options.Create( new QueueSettings( ) ),
+            SupportedProviders.Spotify );
+
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => queue.DequeueAsync( tracker.Object, CancellationToken.None ) );
+    }
+}

--- a/Tests/Unit/RedisSagaStateManagerHotReadTests.cs
+++ b/Tests/Unit/RedisSagaStateManagerHotReadTests.cs
@@ -1,0 +1,86 @@
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
+using BridgeBeats.Contracts.Records;
+using BridgeBeats.Core.Infrastructure.Queue;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>Guards the hot saga-read path against accidental token-adoption writes.</summary>
+[TestClass]
+public sealed class RedisSagaStateManagerHotReadTests {
+    /// <summary>Existing token reads use hash reads only; listener-on/off operation count is stable.</summary>
+    [TestMethod]
+    public async Task GetAsync_WithExistingInstanceToken_DoesNotEvaluateAdoptionScriptOrWrite( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = db.Setup( d => d.HashGetAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisValue)"stable-token" );
+        _ = db.Setup( d => d.HashGetAllAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( ( RedisKey key, CommandFlags _ ) => key.ToString( ).StartsWith( "saga:" ) && !key.ToString( ).Contains( ":provider:" )
+                ? [
+                    new HashEntry( "lookupKey", "isrc:HOT" ),
+                    new HashEntry( "lookupType", "IsrcLookup" ),
+                    new HashEntry( "lookupValue", "HOT" ),
+                    new HashEntry( "instanceToken", "stable-token" ) ]
+                : [] );
+
+        RedisSagaStateManager manager = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisSagaStateManager>>( ),
+            Options.Create( new QueueSettings { JobExpirationMinutes = 60 } ) );
+
+        LookupSagaState? result = await manager.GetAsync( "hot-saga", TestContext.CancellationToken );
+
+        Assert.IsNotNull( result );
+        db.Verify( d => d.ScriptEvaluateAsync(
+            It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        db.Verify( d => d.HashSetAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<HashEntry[]>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>A deletion after the create script cannot be followed by an origin-only zombie write.</summary>
+    [TestMethod]
+    public async Task GetOrCreate_WhenExistingSagaDisappearsAfterScript_DoesNotWriteAfterDeletion( ) {
+        Mock<IConnectionMultiplexer> redis = new( );
+        Mock<IDatabase> db = new( );
+        _ = redis.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) ).Returns( db.Object );
+        _ = db.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)0 ) );
+        _ = db.Setup( d => d.HashGetAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisValue)"deleted-token" );
+        _ = db.Setup( d => d.HashGetAllAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [] );
+
+        RedisSagaStateManager manager = new(
+            redis.Object,
+            Mock.Of<ILogger<RedisSagaStateManager>>( ),
+            Options.Create( new QueueSettings { JobExpirationMinutes = 60 } ) );
+
+        _ = await Assert.ThrowsExactlyAsync<UnreadableSagaStateException>( async ( ) => await manager.GetOrCreateAsync(
+            "disappeared-saga",
+            "isrc:DISAPPEARED",
+            LookupRequestType.IsrcLookup,
+            "DISAPPEARED",
+            QueuePriority.Interactive,
+            TestContext.CancellationToken ) );
+
+        db.Verify( d => d.KeyExpireAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+        db.Verify( d => d.HashSetAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+            It.IsAny<When>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>MSTest context used for cancellation-aware read verification.</summary>
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/Tests/Unit/RefreshReviewControllerTests.cs
+++ b/Tests/Unit/RefreshReviewControllerTests.cs
@@ -1,9 +1,9 @@
+using System.Security.Claims;
+using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
-using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Web.Controllers;
 using BridgeBeats.Web.Services;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
@@ -48,7 +48,7 @@ public class RefreshReviewControllerTests {
         IActionResult result = await controller.Delete(
             SourceUri, string.Empty, string.Empty, CancellationToken.None );
 
-        Assert.IsInstanceOfType<BadRequestResult>( result );
+        _ = Assert.IsInstanceOfType<BadRequestResult>( result );
         disposition.Verify( service => service.DeleteAsync(
             It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<string>( ),
             It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
@@ -78,7 +78,7 @@ public class RefreshReviewControllerTests {
         IActionResult result = await controller.Delete(
             SourceUri, "refresh-saga", "bafyreihash", CancellationToken.None );
 
-        Assert.IsInstanceOfType<RedirectToActionResult>( result );
+        _ = Assert.IsInstanceOfType<RedirectToActionResult>( result );
         disposition.Verify( service => service.DeleteAsync(
             SourceUri, "refresh-saga", "bafyreihash", "admin-123", It.IsAny<CancellationToken>( ) ), Times.Once );
     }
@@ -100,7 +100,7 @@ public class RefreshReviewControllerTests {
         IActionResult result = await controller.Delete(
             SourceUri, "refresh-saga", "bafyreihash", CancellationToken.None );
 
-        Assert.IsInstanceOfType<NotFoundResult>( result );
+        _ = Assert.IsInstanceOfType<NotFoundResult>( result );
     }
 
     /// <summary>A replacement review entry is surfaced as a conflict so the operator must reload.</summary>
@@ -121,6 +121,6 @@ public class RefreshReviewControllerTests {
         IActionResult result = await controller.Delete(
             SourceUri, "refresh-saga", "bafyreihash", CancellationToken.None );
 
-        Assert.IsInstanceOfType<ConflictObjectResult>( result );
+        _ = Assert.IsInstanceOfType<ConflictObjectResult>( result );
     }
 }

--- a/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
+++ b/Tests/Unit/SagaCoordinatorBackgroundServiceTests.cs
@@ -76,28 +76,60 @@ public class SagaCoordinatorBackgroundServiceTests {
         _enabledProviders = [SupportedProviders.Spotify, SupportedProviders.AppleMusic, SupportedProviders.Tidal];
         _loggerMock = new Mock<ILogger<SagaCoordinatorBackgroundService>>( );
         _refreshReviewStoreMock = new Mock<IRefreshReviewStore>( );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( CreateCompleteSaga( ) );
         _ = _refreshReviewStoreMock.Setup( store => store.MarkUnresolvedAsync(
-                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );
         _ = _refreshReviewStoreMock.Setup( store => store.CompleteAsync(
-                It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Returns( Task.CompletedTask );
 
         _ = _redisMock.Setup( r => r.GetSubscriber( It.IsAny<object>( ) ) ).Returns( _subscriberMock.Object );
 
         // By default the coordinator wins the secondaries-queued marker (no concurrent handler)
         _ = _sagaManagerMock
-            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
 
         // By default the coordinator wins the finalize claim (no concurrent handler)
         _ = _sagaManagerMock
-            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
 
         // By default the write-generation CAS advances (first call wins per generation)
         _ = _sagaManagerMock
-            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        // Token-fenced coordinator mutations succeed by default. Individual tests override these
+        // setups when exercising a lost instance race or a failed durable write.
+        _ = _sagaManagerMock
+            .Setup( s => s.TryUpdateProviderStateAsync( It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
+        _ = _sagaManagerMock
+            .Setup( s => s.TrySetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TryInitializeProviderStatesAsync( It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
     }
 
@@ -303,7 +335,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -330,7 +362,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Should have queried for unfinalized sagas
         _sagaManagerMock.Verify(
-            s => s.GetCompletedButUnfinalizedAsync(
+            s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -348,7 +380,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -386,7 +418,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -419,7 +451,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Should have set final result URI
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( completeSaga.SagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( completeSaga.SagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -436,7 +468,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         );
 
         _refreshReviewStoreMock.Verify(
-            store => store.CompleteAsync( completeSaga.SagaId, It.IsAny<CancellationToken>( ) ),
+            store => store.CompleteAsync( completeSaga.SagaId, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }
@@ -456,7 +488,7 @@ public class SagaCoordinatorBackgroundServiceTests {
             PartialResultUri = null
         };
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -483,13 +515,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Should have written partial result first
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( partialSaga.SagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( partialSaga.SagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
         // Assert - Should also have written final result
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( partialSaga.SagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( partialSaga.SagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }
@@ -505,8 +537,10 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState saga1 = CreateCompleteSaga( ) with { SagaId = "saga-1" };
         LookupSagaState saga2 = CreateCompleteSaga( ) with { SagaId = "saga-2" };
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( "saga-1", It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( saga1 );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( "saga-2", It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( saga2 );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -566,14 +600,14 @@ public class SagaCoordinatorBackgroundServiceTests {
             }
         };
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
             ) )
             .ReturnsAsync( [failedSaga] );
 
-        _ = _sagaManagerMock.Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+        _ = _sagaManagerMock.Setup( s => s.TryDeleteAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
 
         // Act
@@ -596,9 +630,70 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Should delete the saga
         _sagaManagerMock.Verify(
-            s => s.DeleteAsync( failedSaga.SagaId, It.IsAny<CancellationToken>( ) ),
+            s => s.TryDeleteAsync( failedSaga.SagaId, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
+    }
+
+    /// <summary>A failed provider leg does not discard a successful sibling refresh result.</summary>
+    [TestMethod]
+    [DataRow( false )]
+    [DataRow( true )]
+    public async Task WriteFinalResult_RefreshFailure_PreservesSuccessfulSibling( bool includeSuccessfulProvider ) {
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState saga = CreateCompleteSaga( ) with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new( SupportedProviders.Spotify, true, false, null, DateTimeOffset.UtcNow, "worker unavailable" )
+            }
+        };
+        if (includeSuccessfulProvider) {
+            saga = saga with {
+                ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState>( saga.ProviderStates ) {
+                    [SupportedProviders.AppleMusic] = new( SupportedProviders.AppleMusic, true, true,
+                        "{\"isrc\":\"USRC12345678\",\"trackName\":\"Track\",\"artistName\":\"Artist\",\"url\":\"https://example.test\"}",
+                        DateTimeOffset.UtcNow, null )
+                }
+            };
+        }
+        RefreshReviewEntry context = new( ) {
+            SourceRecordUri = "at://refresh/outage",
+            SagaId = saga.SagaId,
+            InstanceToken = saga.InstanceToken,
+            LookupType = saga.LookupType,
+            LookupValue = saga.LookupValue
+        };
+        _ = _refreshReviewStoreMock.Setup( store => store.GetPendingForSagaAsync( saga.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [context] );
+        _ = _sagaManagerMock.Setup( manager => manager.TryDeleteAsync( saga.SagaId, saga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _atProtoStorageMock.Setup( storage => storage.StoreMediaLinkResultAsync(
+                It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( "at://did:plc:test/link/result" );
+
+        await service.InvokeFinalizeForTestAsync( saga, TestContext.CancellationToken );
+
+        if (includeSuccessfulProvider) {
+            _atProtoStorageMock.Verify( storage => storage.StoreMediaLinkResultAsync(
+                It.Is<MediaLinkResult>( result => result.Results.Count == 1 ),
+                It.IsAny<CancellationToken>( ) ), Times.Once );
+            _refreshReviewStoreMock.Verify( store => store.MarkUnresolvedAsync(
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+            _refreshReviewStoreMock.Verify( store => store.CompleteAsync(
+                saga.SagaId, saga.InstanceToken!, It.IsAny<CancellationToken>( ) ), Times.Once );
+            _deduplicatorMock.Verify( dedup => dedup.ReleaseAsync(
+                saga.LookupKey, "at://did:plc:test/link/result", It.IsAny<CancellationToken>( ) ), Times.Once );
+            _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+                saga.SagaId, saga.InstanceToken!, It.IsAny<CancellationToken>( ) ), Times.Never );
+        } else {
+            _atProtoStorageMock.Verify( storage => storage.StoreMediaLinkResultAsync(
+                It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+            _refreshReviewStoreMock.Verify( store => store.MarkUnresolvedAsync(
+                context, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+            _deduplicatorMock.Verify( dedup => dedup.ReleaseAsync(
+                saga.LookupKey, null, It.IsAny<CancellationToken>( ) ), Times.Once );
+            _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+                saga.SagaId, saga.InstanceToken!, It.IsAny<CancellationToken>( ) ), Times.Once );
+        }
     }
 
     /// <summary>A zero-result stale refresh is persisted for review before its saga is deleted.</summary>
@@ -608,12 +703,21 @@ public class SagaCoordinatorBackgroundServiceTests {
         int sequence = 0;
         int reviewOrder = 0;
         int deleteOrder = 0;
+        RefreshReviewEntry refreshEntry = new( ) {
+            SourceRecordUri = "at://record/refresh-context",
+            SagaId = TestSagaId,
+            InstanceToken = "instance-current",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678"
+        };
+        _ = reviewStore.Setup( store => store.GetPendingForSagaAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [refreshEntry] );
         _ = reviewStore.Setup( store => store.MarkUnresolvedAsync(
-                TestSagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .Callback( ( ) => reviewOrder = Interlocked.Increment( ref sequence ) )
             .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( manager => manager.DeleteAsync(
-                TestSagaId, It.IsAny<CancellationToken>( ) ) )
+        _ = _sagaManagerMock.Setup( manager => manager.TryDeleteAsync(
+                TestSagaId, "instance-current", It.IsAny<CancellationToken>( ) ) )
             .Callback( ( ) => deleteOrder = Interlocked.Increment( ref sequence ) )
             .ReturnsAsync( true );
 
@@ -625,7 +729,7 @@ public class SagaCoordinatorBackgroundServiceTests {
                     IsSuccess: false,
                     ResultJson: null,
                     CompletedAt: DateTimeOffset.UtcNow,
-                    ErrorMessage: "Not found" )
+                    ErrorMessage: null )
             }
         };
 
@@ -633,10 +737,140 @@ public class SagaCoordinatorBackgroundServiceTests {
             failedSaga, TestContext.CancellationToken );
 
         reviewStore.Verify( store => store.MarkUnresolvedAsync(
-            TestSagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+            It.Is<RefreshReviewEntry>( entry => entry.InstanceToken == "instance-current" ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
         Assert.IsGreaterThan( 0, reviewOrder );
         Assert.IsLessThan( deleteOrder, reviewOrder,
             "The review entry must be durable before the saga is deleted." );
+    }
+
+    /// <summary>Stale X zero-result handling cannot mutate replacement Y's review context or lock.</summary>
+    [TestMethod]
+    public async Task WriteFinalResult_ZeroResult_StaleXContextDoesNotFallbackToSagaId( ) {
+        Mock<IRefreshReviewStore> reviewStore = new( );
+        LookupSagaState staleX = CreateCompleteSaga( ) with { InstanceToken = "instance-x" };
+        LookupSagaState replacementYSaga = staleX with { InstanceToken = "instance-y" };
+        RefreshReviewEntry replacementYEntry = new( ) {
+            SourceRecordUri = "at://record-y",
+            SagaId = staleX.SagaId,
+            InstanceToken = "instance-y",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "Y"
+        };
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync(
+                staleX.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( replacementYSaga );
+        _ = reviewStore.Setup( store => store.GetPendingForSagaAsync( staleX.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [replacementYEntry] );
+
+        LookupSagaState failedSaga = staleX with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    SupportedProviders.Spotify, true, false, null, DateTimeOffset.UtcNow, null )
+            }
+        };
+
+        await CreateService( reviewStore.Object ).InvokeFinalizeForTestAsync(
+            failedSaga, TestContext.CancellationToken );
+
+        reviewStore.Verify( store => store.MarkUnresolvedAsync(
+            It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        reviewStore.Verify( store => store.GetPendingForSagaAsync(
+            staleX.SagaId, It.IsAny<CancellationToken>( ) ), Times.Never );
+        _deduplicatorMock.Verify( deduplicator => deduplicator.ReleaseAsync(
+            It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+            staleX.SagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryClaimFinalizeAsync(
+            staleX.SagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>Current X that loses the finalize claim cannot mutate review, completion, or saga state.</summary>
+    [TestMethod]
+    public async Task WriteFinalResult_ZeroResult_CurrentXClaimLoserIsCompletelySilent( ) {
+        Mock<IRefreshReviewStore> reviewStore = new( );
+        LookupSagaState failedX = CreateCompleteSaga( ) with {
+            InstanceToken = "instance-x",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    SupportedProviders.Spotify, true, false, null, DateTimeOffset.UtcNow, null )
+            }
+        };
+        RefreshReviewEntry reviewEntry = new( ) {
+            SourceRecordUri = "at://record-x",
+            SagaId = failedX.SagaId,
+            InstanceToken = failedX.InstanceToken,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "X"
+        };
+
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync(
+                failedX.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( failedX );
+        _ = _sagaManagerMock.Setup( manager => manager.TryClaimFinalizeAsync(
+                failedX.SagaId, failedX.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+        _ = reviewStore.Setup( store => store.GetPendingForSagaAsync(
+                failedX.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [reviewEntry] );
+
+        await CreateService( reviewStore.Object ).InvokeFinalizeForTestAsync(
+            failedX, TestContext.CancellationToken );
+
+        reviewStore.Verify( store => store.GetPendingForSagaAsync(
+            failedX.SagaId, It.IsAny<CancellationToken>( ) ), Times.Never );
+        reviewStore.Verify( store => store.MarkUnresolvedAsync(
+            It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _deduplicatorMock.Verify( deduplicator => deduplicator.ReleaseAsync(
+            It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+            failedX.SagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryReleaseFinalizeClaimAsync(
+            failedX.SagaId, failedX.InstanceToken!, It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TrySetFinalResultUriAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _atProtoStorageMock.Verify( storage => storage.StoreMediaLinkResultAsync(
+            It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>Current Y zero-result cleanup promotes its own matching review context.</summary>
+    [TestMethod]
+    public async Task WriteFinalResult_ZeroResult_CurrentYContextIsPromotedAndDeleted( ) {
+        Mock<IRefreshReviewStore> reviewStore = new( );
+        LookupSagaState currentY = CreateCompleteSaga( ) with { InstanceToken = "instance-y" };
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( currentY.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( currentY );
+        RefreshReviewEntry context = new( ) {
+            SourceRecordUri = "at://record-y",
+            SagaId = currentY.SagaId,
+            InstanceToken = currentY.InstanceToken,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "Y"
+        };
+        _ = reviewStore.Setup( store => store.GetPendingForSagaAsync(
+                currentY.SagaId, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( [context] );
+        _ = reviewStore.Setup( store => store.MarkUnresolvedAsync(
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock.Setup( manager => manager.TryDeleteAsync(
+                currentY.SagaId, currentY.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        LookupSagaState failedSaga = currentY with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new(
+                    SupportedProviders.Spotify, true, false, null, DateTimeOffset.UtcNow, null )
+            }
+        };
+        await CreateService( reviewStore.Object ).InvokeFinalizeForTestAsync(
+            failedSaga, TestContext.CancellationToken );
+
+        reviewStore.Verify( store => store.MarkUnresolvedAsync(
+            It.Is<RefreshReviewEntry>( entry => entry.SourceRecordUri == context.SourceRecordUri
+                && entry.InstanceToken == currentY.InstanceToken ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+            currentY.SagaId, currentY.InstanceToken!, It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>A review-store outage does not strand a terminal saga or its deduplication waiters.</summary>
@@ -644,10 +878,9 @@ public class SagaCoordinatorBackgroundServiceTests {
     public async Task WriteFinalResult_ReviewStoreFailure_ReleasesAndDeletesSaga( ) {
         Mock<IRefreshReviewStore> reviewStore = new( );
         _ = reviewStore.Setup( store => store.MarkUnresolvedAsync(
-                TestSagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ThrowsAsync( new InvalidOperationException( "Redis unavailable" ) );
-        _ = _sagaManagerMock.Setup( manager => manager.DeleteAsync(
-                TestSagaId, It.IsAny<CancellationToken>( ) ) )
+        _ = _sagaManagerMock.Setup( manager => manager.TryDeleteAsync( TestSagaId, "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
 
         LookupSagaState failedSaga = CreateCompleteSaga( ) with {
@@ -667,22 +900,22 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         _deduplicatorMock.Verify( deduplicator => deduplicator.ReleaseAsync(
             failedSaga.LookupKey, null, It.IsAny<CancellationToken>( ) ), Times.Once );
-        _sagaManagerMock.Verify( manager => manager.DeleteAsync(
-            TestSagaId, It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+            TestSagaId, "instance-current", It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>
-    /// Verifies that finalizing a saga clears its partial flag (sets <c>IsPartial</c> false), so a
-    /// finalized saga is no longer treated as partial.
+    /// Verifies that finalizing a saga does not issue a second state mutation after the final URI
+    /// operation atomically clears the partial flag.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task WriteFinalResult_WhenSagaIsFinalized_ShouldClearIsPartialFlag( ) {
+    public async Task WriteFinalResult_WhenSagaIsFinalized_DoesNotIssueSeparatePartialMutation( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -707,10 +940,10 @@ public class SagaCoordinatorBackgroundServiceTests {
             // Expected
         }
 
-        // Assert - Should have cleared the partial flag after setting the final result URI
+        // Assert - The final-URI Lua operation clears the partial flag atomically.
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( completeSaga.SagaId, false, It.IsAny<CancellationToken>( ) ),
-            Times.Once
+            s => s.TrySetIsPartialAsync( completeSaga.SagaId, false, "instance-current", It.IsAny<CancellationToken>( ) ),
+            Times.Never
         );
     }
 
@@ -741,7 +974,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -782,7 +1015,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Saga should be marked partial when secondaries are queued
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetIsPartialAsync( TestSagaId, true, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -798,7 +1031,7 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -832,7 +1065,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -869,7 +1102,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Cached provider results materialized into the saga as completed states
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 TestSagaId,
                 It.Is<ProviderLookupState>( p =>
                     p.Provider == SupportedProviders.AppleMusic &&
@@ -878,12 +1111,13 @@ public class SagaCoordinatorBackgroundServiceTests {
                     p.ResultJson != null &&
                     p.CompletedAt != null
                 ),
+                "instance-current",
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
+            s => s.TryUpdateProviderStateAsync(
                 TestSagaId,
                 It.Is<ProviderLookupState>( p =>
                     p.Provider == SupportedProviders.Tidal &&
@@ -891,6 +1125,7 @@ public class SagaCoordinatorBackgroundServiceTests {
                     p.IsSuccess &&
                     p.ResultJson != null
                 ),
+                "instance-current",
                 It.IsAny<CancellationToken>( )
             ),
             Times.Once
@@ -910,9 +1145,67 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Saga finalized
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
+    }
+
+    /// <summary>
+    /// Verifies a stale coordinator cannot materialize cached secondary providers after a replacement
+    /// saga instance wins the race. The stale X token is fenced before any queue or result write, and
+    /// the replacement Y instance receives no provider, core, or review mutations.
+    /// </summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task SagaCompletion_WhenCachedSecondaryRaceLosesInstanceFence_DoesNotQueueOrMutateReplacement( ) {
+        Dictionary<string, Action<RedisChannel, RedisValue>> handlers = [];
+        _ = _subscriberMock
+            .Setup( s => s.SubscribeAsync( It.IsAny<RedisChannel>( ), It.IsAny<Action<RedisChannel, RedisValue>>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisChannel, Action<RedisChannel, RedisValue>, CommandFlags>(
+                ( channel, handler, _ ) => handlers[channel.ToString( )] = handler )
+            .Returns( Task.CompletedTask );
+
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState staleX = CreateUriLookupSaga( ) with { InstanceToken = "instance-x" };
+        LookupSagaState replacementY = staleX with {
+            InstanceToken = "instance-y",
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState>( staleX.ProviderStates )
+        };
+        LookupSagaState current = staleX;
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => current );
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
+                It.IsAny<TimeSpan>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
+
+        MediaLinkResult cachedResult = CreateCachedExternalIdResult( SupportedProviders.AppleMusic, SupportedProviders.Tidal );
+        _ = _cacheRepositoryMock.Setup( c => c.TryGetCachedResultByISRCAsync( It.IsAny<string>( ) ) )
+            .ReturnsAsync( ( ) => {
+                // Replacement Y wins immediately after X reads the cache and before its fenced write.
+                current = replacementY;
+                return (cachedResult, TestRecordUri, false);
+            } );
+        _ = _sagaManagerMock.Setup( s => s.TryUpdateProviderStateAsync(
+                TestSagaId, It.IsAny<ProviderLookupState>( ), "instance-x", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        using CancellationTokenSource cts = new( );
+        _ = service.StartAsync( cts.Token );
+        await Task.Delay( 100, TestContext.CancellationToken );
+        Assert.IsTrue( handlers.ContainsKey( "saga:completed" ) );
+        handlers["saga:completed"]( RedisChannel.Literal( "saga:completed" ), TestSagaId );
+        await Task.Delay( 250, TestContext.CancellationToken );
+
+        await cts.CancelAsync( );
+        try { await service.StopAsync( CancellationToken.None ); } catch (OperationCanceledException) { }
+
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            TestSagaId, It.IsAny<ProviderLookupState>( ), "instance-x", It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( s => s.TryUpdateProviderStateAsync(
+            TestSagaId, It.IsAny<ProviderLookupState>( ), "instance-y", It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueResolverMock.Verify( r => r.GetQueue( It.IsAny<SupportedProviders>( ) ), Times.Never );
+        _atProtoStorageMock.Verify( a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _refreshReviewStoreMock.Verify( r => r.MarkUnresolvedAsync( It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -937,7 +1230,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -979,16 +1272,12 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Cached AppleMusic result materialized into the saga
         _sagaManagerMock.Verify(
-            s => s.UpdateProviderStateAsync(
-                TestSagaId,
-                It.Is<ProviderLookupState>( p =>
+            s => s.TryUpdateProviderStateAsync( TestSagaId, It.Is<ProviderLookupState>( p =>
                     p.Provider == SupportedProviders.AppleMusic &&
                     p.IsComplete &&
                     p.IsSuccess &&
                     p.ResultJson != null
-                ),
-                It.IsAny<CancellationToken>( )
-            ),
+                ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -1015,13 +1304,13 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
         // Assert - Saga not finalized while the secondary lookup is pending
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -1048,7 +1337,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( bulkSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1126,7 +1415,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1139,7 +1428,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Another handler already won the race to queue secondaries
         _ = _sagaManagerMock
-            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( false );
 
         Mock<IRequestQueue<QueuedLookupRequest>> queueMock = new( );
@@ -1178,17 +1467,17 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - The idempotent state/partial writes still run (they happen before the
         // marker claim so a published partial can never be mistaken for a final result)
         _sagaManagerMock.Verify(
-            s => s.InitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryInitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetIsPartialAsync( TestSagaId, true, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
         // Assert - It still defers finalization (secondaries pending elsewhere)
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
@@ -1198,7 +1487,7 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
     }
@@ -1225,7 +1514,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1239,15 +1528,15 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Record the order of the saga-manager calls that close the partial-vs-final race
         List<string> callOrder = [];
         _ = _sagaManagerMock
-            .Setup( s => s.InitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryInitializeProviderStatesAsync( TestSagaId, It.IsAny<IEnumerable<SupportedProviders>>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .Callback( ( ) => callOrder.Add( "InitializeProviderStates" ) )
-            .Returns( Task.CompletedTask );
+            .ReturnsAsync( true );
         _ = _sagaManagerMock
-            .Setup( s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TrySetIsPartialAsync( TestSagaId, true, "instance-current", It.IsAny<CancellationToken>( ) ) )
             .Callback( ( ) => callOrder.Add( "SetIsPartial" ) )
-            .Returns( Task.CompletedTask );
+            .ReturnsAsync( true );
         _ = _sagaManagerMock
-            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryMarkSecondariesQueuedAsync( TestSagaId, "instance-current", It.IsAny<CancellationToken>( ) ) )
             .Callback( ( ) => callOrder.Add( "TryMarkSecondariesQueued" ) )
             .ReturnsAsync( true );
 
@@ -1286,10 +1575,8 @@ public class SagaCoordinatorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// Verifies the terminal-state contract when every secondary enqueue throws: both enqueues are
-    /// attempted, the saga is not finalized (the one-provider result is not promoted to final), the
-    /// partial result is written for waiting callers, and the saga is immediately removed from the
-    /// reconciliation pending index so it does not strand to TTL expiry.
+    /// Verifies that every failed secondary enqueue is converted into a terminal provider leg and
+    /// publishes progress, so the one-time fan-out marker cannot strand the saga.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
@@ -1308,7 +1595,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1356,28 +1643,44 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Exactly( 2 )
         );
 
-        // Assert - The saga is NOT finalized: the one-provider result must not be promoted to
-        // final while secondary providers are still unresolved
+        // No providers remain unresolved: both failed enqueues were durably converted into
+        // terminal failed legs, so this invocation finalizes immediately.
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
-            Times.Never
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
+            Times.Once
         );
 
-        // Assert - The partial result is written for waiting callers instead (non-terminal write path)
         _atProtoStorageMock.Verify(
             a => a.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
-            Times.Once
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
+            Times.Never
         );
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( TestSagaId, true, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetIsPartialAsync( TestSagaId, true, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
-        // Assert - The saga is removed from the pending index so it does not strand to TTL expiry
+        _sagaManagerMock.Verify(
+            s => s.TryUpdateProviderStateAsync(
+                TestSagaId,
+                It.Is<ProviderLookupState>( state =>
+                    state.IsComplete && !state.IsSuccess && state.ErrorMessage != null ),
+                "instance-current",
+                It.IsAny<CancellationToken>( ) ),
+            Times.Exactly( 2 )
+        );
+        _subscriberMock.Verify(
+            s => s.PublishAsync(
+                RedisChannel.Literal( "saga:completed" ),
+                TestSagaId,
+                It.IsAny<CommandFlags>( ) ),
+            Times.AtLeastOnce( )
+        );
+
+        // Successful terminal release clears the reconciliation entry.
         _sagaManagerMock.Verify(
             s => s.RemoveFromPendingIndexAsync( TestSagaId, It.IsAny<CancellationToken>( ) ),
             Times.Once
@@ -1406,7 +1709,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( uriSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1460,7 +1763,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Not finalized: secondaries are still pending
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
@@ -1470,8 +1773,28 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
+        );
+
+        _sagaManagerMock.Verify(
+            s => s.TryUpdateProviderStateAsync(
+                TestSagaId,
+                It.Is<ProviderLookupState>( state =>
+                    state.Provider == SupportedProviders.Tidal
+                    && state.IsComplete
+                    && !state.IsSuccess
+                    && state.ErrorMessage != null ),
+                "instance-current",
+                It.IsAny<CancellationToken>( ) ),
+            Times.Once
+        );
+        _subscriberMock.Verify(
+            s => s.PublishAsync(
+                RedisChannel.Literal( "saga:completed" ),
+                TestSagaId,
+                It.IsAny<CommandFlags>( ) ),
+            Times.AtLeastOnce( )
         );
 
         // Assert - The pending index is NOT cleared: at least one provider is in flight
@@ -1493,7 +1816,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState uriSaga = CreateUriLookupSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1540,11 +1863,11 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -1565,7 +1888,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1574,7 +1897,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Finalize claim is already held by a concurrent handler
         _ = _sagaManagerMock
-            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( false );
 
         // Act
@@ -1597,7 +1920,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - No final URI recorded
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
@@ -1610,7 +1933,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - No generation reset: the terminal path does not advance the generation, so
         // there is nothing to roll back when the claim is lost.
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -1645,12 +1968,13 @@ public class SagaCoordinatorBackgroundServiceTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = "instance-current"
         };
 
         // The generation was already advanced by a concurrent handler
         _ = _sagaManagerMock
-            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( false );
 
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
@@ -1666,13 +1990,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - No partial URI recorded
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
         // Assert - Finalize claim never acquired on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -1688,7 +2012,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1721,13 +2045,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Final URI recorded
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( completeSaga.SagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( completeSaga.SagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
         // Assert - The claim is NOT released on the success path
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -1744,7 +2068,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1771,13 +2095,13 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - Generation NOT reset: the terminal path never advances the generation,
         // so there is nothing to roll back after a PDS write failure.
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
         // Assert - Claim released so the next poll can re-finalize
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( completeSaga.SagaId, It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( completeSaga.SagaId, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -1813,7 +2137,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( alreadyFinalizedSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1845,7 +2169,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - No second final URI write
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
@@ -1877,7 +2201,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         _ = _sagaManagerMock.Setup( s => s.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( completeSaga );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1914,20 +2238,17 @@ public class SagaCoordinatorBackgroundServiceTests {
     }
 
     /// <summary>
-    /// Verifies that a failure occurring after the final result URI has been durably recorded does
-    /// NOT reset the write generation or release the finalize claim. Retaining both prevents a
-    /// re-entrant PDS write against a URI that was already written. Pairs with
-    /// <see cref="Finalize_WhenPdsWriteFails_ReleasesClaimAndDedup"/> (pre-URI failure) as a
-    /// discriminator: together they prove the release is conditioned on the durability line.
+    /// Verifies refresh cleanup failure after the final URI is durable cannot block dedup waiters
+    /// or release the finalize claim for a re-entrant PDS write.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task Finalize_WhenFailureAfterUriRecorded_DoesNotResetGenerationOrReleaseClaim( ) {
+    public async Task Finalize_WhenRefreshCleanupFailsAfterDurability_ReleasesDedupAndKeepsClaim( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -1941,13 +2262,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // SetFinalResultUriAsync succeeds (URI is now durably recorded)
         _ = _sagaManagerMock
-            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
 
-        // The first post-URI step throws — simulates a failure after the durability line
-        _ = _sagaManagerMock
-            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
-            .ThrowsAsync( new InvalidOperationException( "post-URI step failed" ) );
+        _ = _refreshReviewStoreMock
+            .Setup( store => store.CompleteAsync(
+                completeSaga.SagaId, completeSaga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "refresh cleanup failed" ) );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -1963,15 +2284,20 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - No generation reset after the durability line
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
         // Assert - A failure after the URI is recorded must retain the claim (no release)
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
+
+        _deduplicatorMock.Verify(
+            deduplicator => deduplicator.ReleaseAsync(
+                completeSaga.LookupKey, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Once );
 
         // Assert - dedup must never be released with null on this path; releasing null would hand
         // waiters an empty completion for a saga whose result was already recorded
@@ -1980,6 +2306,28 @@ public class SagaCoordinatorBackgroundServiceTests {
             Times.Never,
             "Post-URI failure must not release the dedup lock with null"
         );
+    }
+
+    /// <summary>A lost final-URI fence never publishes the stale instance's PDS URI.</summary>
+    [TestMethod]
+    public async Task Finalize_WhenFinalUriFenceIsLostAfterPdsWrite_DoesNotReleaseStaleResult( ) {
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState saga = CreateCompleteSaga( );
+        _ = _atProtoStorageMock.Setup( storage => storage.StoreMediaLinkResultAsync(
+                It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( TestRecordUri );
+        _ = _sagaManagerMock.Setup( manager => manager.TrySetFinalResultUriAsync(
+                saga.SagaId, TestRecordUri, saga.InstanceToken!, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.InstanceMismatch );
+
+        await service.InvokeFinalizeForTestAsync( saga, TestContext.CancellationToken );
+
+        _deduplicatorMock.Verify( deduplicator => deduplicator.ReleaseAsync(
+            It.IsAny<string>( ), It.IsAny<string?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.RemoveFromPendingIndexAsync(
+            saga.SagaId, It.IsAny<CancellationToken>( ) ), Times.Never );
+        _atProtoStorageMock.Verify( storage => storage.StoreMediaLinkResultAsync(
+            It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>
@@ -1996,7 +2344,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -2009,8 +2357,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             .ThrowsAsync( new OperationCanceledException( ) );
 
         _ = _sagaManagerMock
-            .Setup( s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         // Act
         using CancellationTokenSource cts = new( );
@@ -2026,13 +2374,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Generation NOT reset: the terminal path never advances the generation.
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
         // Assert - Claim must be released so the next host can re-finalize
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
@@ -2044,7 +2392,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Saga must not be deleted
         _sagaManagerMock.Verify(
-            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryDeleteAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -2063,7 +2411,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -2077,12 +2425,12 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // SetFinalResultUriAsync completes — durability line crossed
         _ = _sagaManagerMock
-            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
 
         // The first post-URI step throws OperationCanceledException — cancellation after the durability line
         _ = _sagaManagerMock
-            .Setup( s => s.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TrySetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ThrowsAsync( new OperationCanceledException( ) );
 
         // Act
@@ -2099,14 +2447,14 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - No generation reset after the durability line
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
         // Assert - Claim must NOT be released; releasing would allow a re-entrant PDS write against
         // a URI that is already recorded
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
 
@@ -2118,7 +2466,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - Saga must not be deleted
         _sagaManagerMock.Verify(
-            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryDeleteAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
     }
@@ -2146,8 +2494,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Set up mock to advance generation monotonically using a local counter
         int storedGeneration = 0;
         _ = _sagaManagerMock
-            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ) )
-            .ReturnsAsync( ( string _, int gen, CancellationToken _ ) => {
+            .Setup( s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string _, int gen, string _, CancellationToken _ ) => {
                 if (gen > storedGeneration) {
                     storedGeneration = gen;
                     return true;
@@ -2172,7 +2520,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                     ResultJson: spotifyJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null )
             },
             FinalResultUri = null,
-            IsPartial = false
+            IsPartial = false,
+            InstanceToken = "instance-current"
         };
 
         LookupSagaState sagaGen2 = sagaGen1 with {
@@ -2185,6 +2534,10 @@ public class SagaCoordinatorBackgroundServiceTests {
                     ResultJson: appleMusicJson, CompletedAt: DateTimeOffset.UtcNow, ErrorMessage: null )
             }
         };
+
+        _ = _sagaManagerMock
+            .Setup( s => s.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( sagaGen1 );
 
         LookupSagaState sagaGen3 = sagaGen1 with {
             ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
@@ -2203,8 +2556,8 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Also set up the claim mock to only allow the first terminal winner through
         bool claimHeld = false;
         _ = _sagaManagerMock
-            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( ( string _, CancellationToken _ ) => {
+            .Setup( s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( string _, string _, CancellationToken _ ) => {
                 bool won = !claimHeld;
                 claimHeld = true;
                 return Task.FromResult( won );
@@ -2261,7 +2614,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = "instance-current"
         };
 
         _ = _atProtoStorageMock
@@ -2289,38 +2643,37 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - partial URI stored, not final URI
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not set the final result URI"
         );
 
         // Assert - the finalize claim is never acquired on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not call TryClaimFinalizeAsync"
         );
 
         // Assert - IsPartial flag is never cleared on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( It.IsAny<string>( ), false, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetIsPartialAsync( It.IsAny<string>( ), false, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not clear the IsPartial flag"
         );
     }
 
     /// <summary>
-    /// Verifies the terminal write path: <c>terminal=true</c> clears <c>IsPartial</c> (calls
-    /// <c>SetIsPartialAsync(false)</c>) exactly once after recording the final URI. This is the
-    /// positive control that distinguishes the two write paths.
+    /// Verifies the terminal write path relies on the final-URI Lua operation to clear
+    /// <c>IsPartial</c> atomically rather than issuing a second fenced mutation.
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task WriteResult_Terminal_ClearsIsPartialAfterFinalUri( ) {
+    public async Task WriteResult_Terminal_ClearsIsPartialAtomicallyWithFinalUri( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
         LookupSagaState completeSaga = CreateCompleteSaga( );
@@ -2338,20 +2691,20 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Act - terminal write
         await service.InvokeWriteForTestAsync( completeSaga, terminal: true, cts.Token );
 
-        // Assert - IsPartial cleared exactly once after the final URI
+        // Assert - no separate post-durability partial-state mutation is issued.
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( TestSagaId, false, It.IsAny<CancellationToken>( ) ),
-            Times.Once,
-            "Terminal write must clear the IsPartial flag once"
+            s => s.TrySetIsPartialAsync( TestSagaId, false, "instance-current", It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "Final URI storage clears IsPartial in the same Lua operation"
         );
 
         // Assert - final URI recorded (not partial)
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
         _sagaManagerMock.Verify(
-            s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Terminal write must not call SetPartialResultUriAsync"
         );
@@ -2386,7 +2739,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = "instance-current"
         };
 
         // PDS write fails before the durability line
@@ -2401,22 +2755,53 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - generation conditionally reset so the next trigger can re-advance and retry
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( TestSagaId, It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "Non-terminal pre-durability failure must reset the write generation"
         );
 
         // Assert - finalize claim NEVER acquired or released on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not call TryClaimFinalizeAsync"
         );
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not release a finalize claim it never held"
         );
+        _refreshReviewStoreMock.Verify(
+            store => store.ClearSweepAttemptsAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "A failed PDS write must not clear sweep attempts before the partial URI is durable"
+        );
+    }
+
+    /// <summary>Matching current-instance refresh context suppresses non-terminal PDS materialization.</summary>
+    [TestMethod]
+    public async Task WriteResult_NonTerminal_MatchingRefreshContext_SuppressesPdsAndBookkeeping( ) {
+        SagaCoordinatorBackgroundService service = CreateService( );
+        LookupSagaState refreshSaga = CreateUriLookupSaga( QueuePriority.Bulk ) with {
+            SagaId = TestSagaId,
+            InstanceToken = "instance-current"
+        };
+        RefreshReviewEntry context = new( ) {
+            SourceRecordUri = "at://record/refresh-live",
+            SagaId = TestSagaId,
+            InstanceToken = "instance-current",
+            LookupType = refreshSaga.LookupType,
+            LookupValue = refreshSaga.LookupValue
+        };
+        _ = _refreshReviewStoreMock.Setup( store => store.GetPendingForSagaAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [context] );
+
+        await service.InvokeWriteForTestAsync( refreshSaga, terminal: false, TestContext.CancellationToken );
+
+        _atProtoStorageMock.Verify( storage => storage.StoreMediaLinkResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryAdvanceWriteGenerationAsync(
+            It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _refreshReviewStoreMock.Verify( store => store.ClearSweepAttemptsAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -2429,7 +2814,7 @@ public class SagaCoordinatorBackgroundServiceTests {
     /// </summary>
     [TestMethod]
     [Timeout( 30000, CooperativeCancellation = true )]
-    public async Task WriteResult_NonTerminal_WhenFailureAfterPartialUriRecorded_DoesNotResetGeneration( ) {
+    public async Task WriteResult_NonTerminal_WhenFailureAfterPartialUriRecorded_ClearsRefreshAttemptsWithoutResettingGeneration( ) {
         // Arrange
         SagaCoordinatorBackgroundService service = CreateService( );
 
@@ -2451,7 +2836,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = "instance-current"
         };
 
         // PDS write succeeds and returns a URI
@@ -2461,8 +2847,24 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // SetPartialResultUriAsync succeeds — partial URI durably recorded (uriRecorded = true)
         _ = _sagaManagerMock
-            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TryAdvanceWriteGenerationAsync(
+                It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock
+            .Setup( s => s.TrySetPartialResultUriAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+
+        RefreshReviewEntry refreshContext = new( ) {
+            SourceRecordUri = "at://record/refresh-context",
+            SagaId = TestSagaId,
+            InstanceToken = "instance-current",
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = "USRC12345678"
+        };
+        _ = _refreshReviewStoreMock
+            .Setup( store => store.GetPendingForSagaAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( [] );
 
         // The first post-durability step throws — simulates a failure after the durability line
         _ = _cacheRepositoryMock
@@ -2477,19 +2879,24 @@ public class SagaCoordinatorBackgroundServiceTests {
         // Assert - generation must NOT be reset after the durability line; retaining it prevents
         // a re-entrant duplicate partial write
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal post-durability failure must not reset the write generation"
+        );
+        _refreshReviewStoreMock.Verify(
+            store => store.ClearSweepAttemptsAsync( refreshContext.SourceRecordUri, It.IsAny<CancellationToken>( ) ),
+            Times.Never,
+            "A background refresh with no matching pending context does not clear refresh bookkeeping"
         );
 
         // Assert - finalize claim NEVER acquired or released on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not call TryClaimFinalizeAsync"
         );
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not release a finalize claim it never held"
         );
@@ -2517,8 +2924,10 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         LookupSagaState saga1 = CreateCompleteSaga( );
         LookupSagaState saga2 = CreateCompleteSaga( ) with { SagaId = SagaId2 };
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( saga1.SagaId, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( saga1 );
+        _ = _sagaManagerMock.Setup( s => s.GetAsync( saga2.SagaId, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( saga2 );
 
-        _ = _sagaManagerMock.Setup( s => s.GetCompletedButUnfinalizedAsync(
+        _ = _sagaManagerMock.Setup( s => s.GetPendingReconciliationAsync(
                 It.IsAny<TimeSpan>( ),
                 It.IsAny<int>( ),
                 It.IsAny<CancellationToken>( )
@@ -2589,7 +2998,8 @@ public class SagaCoordinatorBackgroundServiceTests {
                 )
             },
             FinalResultUri = null,
-            IsPartial = true
+            IsPartial = true,
+            InstanceToken = "instance-current"
         };
 
         _ = _atProtoStorageMock
@@ -2607,20 +3017,20 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert — final URI recorded (saga finalized despite unchanged generation)
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "Terminal write must call SetFinalResultUriAsync even when the generation did not grow"
         );
 
-        // Assert — partial flag cleared
+        // Assert — the final-URI Lua operation clears the partial flag atomically.
         _sagaManagerMock.Verify(
-            s => s.SetIsPartialAsync( TestSagaId, false, It.IsAny<CancellationToken>( ) ),
-            Times.Once
+            s => s.TrySetIsPartialAsync( TestSagaId, false, "instance-current", It.IsAny<CancellationToken>( ) ),
+            Times.Never
         );
 
         // Assert — generation CAS was never consulted on the terminal path
         _sagaManagerMock.Verify(
-            s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryAdvanceWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Terminal write must not call TryAdvanceWriteGenerationAsync"
         );
@@ -2667,7 +3077,7 @@ public class SagaCoordinatorBackgroundServiceTests {
         };
 
         _ = _sagaManagerMock
-            .Setup( s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Setup( s => s.TryDeleteAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( true );
 
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource( TestContext.CancellationToken );
@@ -2677,7 +3087,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert — saga must NOT be deleted: more providers are still in flight
         _sagaManagerMock.Verify(
-            s => s.DeleteAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryDeleteAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal null combine must not delete the saga"
         );
@@ -2714,8 +3124,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             .ReturnsAsync( TestRecordUri );
 
         _ = _sagaManagerMock
-            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
 
         _ = _cacheRepositoryMock
             .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
@@ -2735,13 +3145,13 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - URI was durably stored before the release
         _sagaManagerMock.Verify(
-            s => s.SetFinalResultUriAsync( TestSagaId, TestRecordUri, It.IsAny<CancellationToken>( ) ),
+            s => s.TrySetFinalResultUriAsync( TestSagaId, TestRecordUri, "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Once
         );
 
         // Assert - finalize claim was never returned; it is retained to prevent re-entrant writes
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Post-release index failure must not release the finalize claim"
         );
@@ -2765,8 +3175,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             .ReturnsAsync( TestRecordUri );
 
         _ = _sagaManagerMock
-            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         _ = _cacheRepositoryMock
             .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
@@ -2786,14 +3196,14 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - write generation was not reset; the durability line was crossed
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Post-release index failure must not reset the write generation"
         );
 
         // Assert - finalize claim was never acquired or released on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not call TryClaimFinalizeAsync"
         );
@@ -2818,8 +3228,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             .ReturnsAsync( TestRecordUri );
 
         _ = _sagaManagerMock
-            .Setup( s => s.SetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetFinalResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( SagaFinalResultWriteOutcome.Stored );
 
         _ = _cacheRepositoryMock
             .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
@@ -2839,7 +3249,7 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - finalize claim was never returned; it is retained to prevent re-entrant writes
         _sagaManagerMock.Verify(
-            s => s.ReleaseFinalizeClaimAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryReleaseFinalizeClaimAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Post-release OCE from indexing must not release the finalize claim"
         );
@@ -2863,8 +3273,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             .ReturnsAsync( TestRecordUri );
 
         _ = _sagaManagerMock
-            .Setup( s => s.SetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .Setup( s => s.TrySetPartialResultUriAsync( It.IsAny<string>( ), It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
 
         _ = _cacheRepositoryMock
             .Setup( c => c.IndexResultAsync( It.IsAny<MediaLinkResult>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
@@ -2884,14 +3294,14 @@ public class SagaCoordinatorBackgroundServiceTests {
 
         // Assert - write generation was not reset; the durability line was crossed
         _sagaManagerMock.Verify(
-            s => s.ResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryResetWriteGenerationAsync( It.IsAny<string>( ), It.IsAny<int>( ), It.IsAny<int>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Post-release OCE from indexing must not reset the write generation"
         );
 
         // Assert - finalize claim was never acquired or released on the non-terminal path
         _sagaManagerMock.Verify(
-            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
+            s => s.TryClaimFinalizeAsync( It.IsAny<string>( ), "instance-current", It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Non-terminal write must not call TryClaimFinalizeAsync"
         );
@@ -2959,6 +3369,7 @@ public class SagaCoordinatorBackgroundServiceTests {
             IsPartial = false,
             InitialProvider = SupportedProviders.Spotify,
             RateLimitInfo = null,
+            InstanceToken = "instance-current",
             OriginPriority = originPriority
         };
     }
@@ -3023,7 +3434,8 @@ public class SagaCoordinatorBackgroundServiceTests {
             FinalResultUri = null,
             IsPartial = false,
             InitialProvider = SupportedProviders.Spotify,
-            RateLimitInfo = null
+            RateLimitInfo = null,
+            InstanceToken = "instance-current"
         };
     }
 

--- a/Tests/Unit/SpotifyBulkDispatchContractTests.cs
+++ b/Tests/Unit/SpotifyBulkDispatchContractTests.cs
@@ -44,7 +44,7 @@ public class SpotifyBulkDispatchContractTests {
     private Mock<ISagaStateManager> _sagaManagerMock = null!;
     /// <summary>Mock bulk lookup service supplying batch track/album results.</summary>
     private Mock<ISpotifyBulkLookupService> _lookupServiceMock = null!;
-    /// <summary>Mock request queue used to verify Interactive re-enqueues on the 4xx rejection path.</summary>
+    /// <summary>Mock request queue used by unrelated generic queue paths.</summary>
     private Mock<IRequestQueue<QueuedLookupRequest>> _requestQueueMock = null!;
     /// <summary>Mock logger for the batch queue helper.</summary>
     private Mock<ILogger<SpotifyBatchQueueHelper>> _helperLoggerMock = null!;
@@ -68,6 +68,42 @@ public class SpotifyBulkDispatchContractTests {
 
     /// <summary>MSTest-injected context; its cancellation token bounds the async operations under test.</summary>
     public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>Two helper instances retain independent full GUID suffixes, even on a long host name.</summary>
+    [TestMethod]
+    public void Helpers_UseDistinctUntruncatedConsumerIds( ) {
+        SpotifyBatchQueueHelper first = new( _redisMock.Object, _helperLoggerMock.Object );
+        SpotifyBatchQueueHelper second = new( _redisMock.Object, _helperLoggerMock.Object );
+
+        Assert.AreNotEqual( first.ConsumerId, second.ConsumerId );
+        Assert.IsGreaterThan( 32, first.ConsumerId.Length );
+        Assert.IsGreaterThan( 32, second.ConsumerId.Length );
+    }
+
+    /// <summary>The bulk consumer honors the same isolated key prefix as its producer.</summary>
+    [TestMethod]
+    public async Task Helper_WithKeyPrefix_RepairsOnlyPrefixedBulkStreams( ) {
+        SpotifyBatchQueueHelper helper = new(
+            _redisMock.Object,
+            _helperLoggerMock.Object,
+            keyPrefix: "isolated" );
+
+        await helper.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+
+        _dbMock.Verify( database => database.StreamCreateConsumerGroupAsync(
+            It.Is<RedisKey>( key => key == "queue:isolated:spotify:bulk:track-id"
+                || key == "queue:isolated:spotify:bulk:album-id" ),
+            It.IsAny<RedisValue>( ),
+            It.IsAny<RedisValue>( ),
+            true,
+            It.IsAny<CommandFlags>( ) ), Times.Exactly( 2 ) );
+        _dbMock.Verify( database => database.StreamCreateConsumerGroupAsync(
+            It.Is<RedisKey>( key => key == TrackStream || key == AlbumStream ),
+            It.IsAny<RedisValue>( ),
+            It.IsAny<RedisValue>( ),
+            It.IsAny<bool>( ),
+            It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
 
     /// <summary>
     /// Creates fresh mocks before each test and wires their defaults: Redis database and subscriber
@@ -200,6 +236,12 @@ public class SpotifyBulkDispatchContractTests {
                 It.IsAny<CommandFlags>( ) ) )
             .ReturnsAsync( (RedisValue)"9999999999-0" );
 
+        // Atomic bulk-rejection transfer returns the interactive replacement id.
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"9999999999-1" ) );
+
         // Subscriber PublishAsync succeeds
         _ = _subscriberMock.Setup( s => s.PublishAsync(
                 It.IsAny<RedisChannel>( ),
@@ -219,35 +261,29 @@ public class SpotifyBulkDispatchContractTests {
                 SagaId = TestSagaId,
                 LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
                 LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance"
             } );
         _ = _sagaManagerMock.Setup( m => m.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( new LookupSagaState {
                 SagaId = TestSagaId,
                 LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
                 LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance"
             } );
-        _ = _sagaManagerMock.Setup( m => m.InitializeProviderStatesAsync(
-                It.IsAny<string>( ),
-                It.IsAny<IEnumerable<SupportedProviders>>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.UpdateProviderStateAsync(
-                It.IsAny<string>( ),
-                It.IsAny<ProviderLookupState>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.SetIsPartialAsync(
-                It.IsAny<string>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.SetRateLimitInfoAsync(
-                It.IsAny<string>( ),
-                It.IsAny<List<ProviderRateLimitInfo>>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock.Setup( m => m.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TrySetIsPartialAsync(
+                It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TrySetRateLimitInfoAsync(
+                It.IsAny<string>( ), It.IsAny<List<ProviderRateLimitInfo>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
     }
 
     /// <summary>
@@ -266,33 +302,13 @@ public class SpotifyBulkDispatchContractTests {
         // Act — call the internal method directly (InternalsVisibleTo in Worker.Spotify.csproj)
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — RequeueAsync path: XACK + XDEL of original + XADD (re-add with attempt+1)
-        // XACK: original entry must be acknowledged before re-adding
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Original message must be ACKed as part of RequeueAsync" );
-
-        // XADD: message must be re-added to the stream with incremented AttemptCount
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Message must be re-added to the stream (requeue)" );
+        VerifyAtomicRequeue( TrackStream, Times.AtLeastOnce( ) );
 
         // Assert — no saga state was written (no UpdateProviderStateAsync calls)
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
             It.IsAny<string>( ),
             It.IsAny<ProviderLookupState>( ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Empty-dict (request failure) must not write saga state for any message" );
@@ -325,19 +341,13 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — message for TestTrackId was requeued (XACK + XADD)
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Message with absent key must be ACKed as part of individual RequeueAsync" );
+        VerifyAtomicRequeue( TrackStream, Times.AtLeastOnce( ) );
 
         // Assert — no saga update for the absent-key message
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
             It.IsAny<string>( ),
             It.IsAny<ProviderLookupState>( ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Never,
             "Absent-key message must not write saga state" );
@@ -363,24 +373,18 @@ public class SpotifyBulkDispatchContractTests {
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
         // Assert — saga was written with IsSuccess=false (not-found)
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
             TestSagaId,
             It.Is<ProviderLookupState>( s =>
                 s.Provider == SupportedProviders.Spotify &&
                 s.IsComplete &&
                 !s.IsSuccess ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "Genuine not-found (key present, null value) must write IsSuccess=false saga state" );
 
-        // Assert — message was ACKed (XACK) as part of AcknowledgeAsync, NOT requeued
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "Not-found message must be ACKed once (AcknowledgeAsync)" );
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
 
         // Assert — no XADD (not requeued)
         _dbMock.Verify( d => d.StreamAddAsync(
@@ -394,6 +398,159 @@ public class SpotifyBulkDispatchContractTests {
             It.IsAny<CommandFlags>( ) ),
             Times.Never,
             "Genuine not-found must not be requeued" );
+    }
+
+    /// <summary>Bulk admission drops a delivery fenced to a replaced saga instance.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_ReplacedSaga_AcknowledgesStaleDeliveryWithoutMutation( ) {
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = null } );
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( new LookupSagaState {
+                SagaId = TestSagaId,
+                LookupKey = "other-root",
+                LookupType = LookupRequestType.UpcLookup,
+                LookupValue = "OTHER",
+                InstanceToken = "replacement-instance",
+                ProviderStates = []
+            } );
+        _ = _requestQueueMock.Setup( queue => queue.MoveToDlqAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
+        _requestQueueMock.Verify( queue => queue.MoveToDlqAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A lost saga-instance CAS acknowledges and drops the bulk message without retry or publication.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_WhenProviderStateCasIsLost_AcknowledgesAndDrops( ) {
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = null } );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
+        _requestQueueMock.Verify( queue => queue.MoveToDlqAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _requestQueueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _subscriberMock.Verify( subscriber => subscriber.PublishAsync(
+            It.IsAny<RedisChannel>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>A lost saga-instance CAS whose stale-delivery ACK also fails escapes retry mutation.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_WhenProviderStateCasIsLostAndAckFails_DoesNotRequeue( ) {
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = null } );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+        _ = _dbMock.Setup( database => database.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == TrackStream ),
+                It.Is<RedisValue[]?>( arguments => arguments != null && arguments.Length == 2 ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "atomic acknowledgement unavailable" ) );
+
+        Exception failure = await Assert.ThrowsAsync<Exception>(
+            ( ) => CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+        StringAssert.Contains( failure.Message, "Acknowledgement failed after provider state commit" );
+
+        _requestQueueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _requestQueueMock.Verify( queue => queue.MoveToDlqAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>Initial and completed-leg recovery ACK failures propagate without cap mutation.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_WhenInitialAndRecoveryAckFail_DoesNotRequeueCompletedLeg( ) {
+        bool committed = false;
+        LookupSagaState activeSaga = new( ) {
+            SagaId = TestSagaId,
+            LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
+            LookupType = LookupRequestType.SongIdLookup,
+            LookupValue = TestTrackId,
+            InstanceToken = "test-instance"
+        };
+        LookupSagaState completedSaga = activeSaga with {
+            ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                [SupportedProviders.Spotify] = new( SupportedProviders.Spotify, true, true, "{}", DateTimeOffset.UtcNow, null )
+            }
+        };
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => committed ? completedSaga : activeSaga );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = null } );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => committed = true )
+            .ReturnsAsync( true );
+        _ = _dbMock.Setup( database => database.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == TrackStream ),
+                It.Is<RedisValue[]?>( arguments => arguments != null && arguments.Length == 2 ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "atomic acknowledgement unavailable" ) );
+
+        SpotifyBulkProcessorService service = CreateService( );
+        Exception firstFailure = await Assert.ThrowsAsync<Exception>(
+            ( ) => service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+        StringAssert.Contains( firstFailure.Message, "Acknowledgement failed after provider state commit" );
+        Exception recoveryFailure = await Assert.ThrowsAsync<Exception>(
+            ( ) => service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+        StringAssert.Contains( recoveryFailure.Message, "Acknowledgement failed after provider state commit" );
+
+        // The batch API is requested again on redelivery; the completed-leg guard must prevent
+        // that result from mutating saga state or entering the retry path.
+        _lookupServiceMock.Verify( lookup => lookup.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ), Times.Exactly( 2 ) );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _requestQueueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _requestQueueMock.Verify( queue => queue.MoveToDlqAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A progress-publish failure after a successful saga write never enters retry/cap mutation.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_WhenProgressPublishFails_DoesNotOverwriteCommittedSuccess( ) {
+        MusicLookupResult result = new( ) { ExternalId = TestTrackId, IsAlbum = false };
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = result } );
+        _ = _subscriberMock.Setup( subscriber => subscriber.PublishAsync(
+                RedisChannel.Literal( "saga:completed" ),
+                TestSagaId,
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisConnectionException( ConnectionFailureType.UnableToResolvePhysicalConnection, "publish unavailable" ) );
+
+        _ = await Assert.ThrowsExactlyAsync<PostCommitAcknowledgementException>(
+            ( ) => CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            TestSagaId,
+            It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            "test-instance",
+            It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ),
+            It.Is<ProviderLookupState>( state => state.IsComplete && !state.IsSuccess && state.ErrorMessage != null ),
+            It.IsAny<string>( ),
+            It.IsAny<CancellationToken>( ) ), Times.Never );
+        VerifyAtomicRequeue( TrackStream, Times.Never( ) );
+        VerifyAtomicRemoval( TrackStream, Times.Never( ) );
     }
 
     /// <summary>A refresh-native miss resolves its ISRC fallback inside the original work item.</summary>
@@ -424,15 +581,12 @@ public class SpotifyBulkDispatchContractTests {
         _lookupServiceMock.Verify( service => service.GetInfoByISRCAsync( "USRC12345678" ), Times.Once );
         _requestQueueMock.Verify( queue => queue.EnqueueAsync(
             It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
-        _sagaManagerMock.Verify( manager => manager.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
             TestSagaId,
             It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ), Times.Once );
-        _dbMock.Verify( database => database.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ), Times.Once );
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
     }
 
     /// <summary>
@@ -484,19 +638,12 @@ public class SpotifyBulkDispatchContractTests {
                 It.IsAny<CommandFlags>( ) ) )
             .ReturnsAsync( [entry] );
 
-        NameValueEntry[]? capturedFields = null;
-        _ = _dbMock.Setup( d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+        RedisValue[]? capturedArguments = null;
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .Callback( ( RedisKey _, NameValueEntry[] f, RedisValue? _, long? _, bool _, long? _, StreamTrimMode _, CommandFlags _ ) =>
-                capturedFields = f )
-            .ReturnsAsync( (RedisValue)"9999-0" );
+            .Callback( ( string _, RedisKey[]? _, RedisValue[]? arguments, CommandFlags _ ) => capturedArguments = arguments )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"9999-0" ) );
 
         SpotifyBatchQueueHelper helper = CreateHelper( );
         string compositeId = $"{TrackStream}:1234567890-0";
@@ -507,36 +654,42 @@ public class SpotifyBulkDispatchContractTests {
         // Assert — method signals "requeued"
         Assert.AreEqual( RequeueOutcome.Requeued, outcome, "Return value must be Requeued (message re-added, not capped)" );
 
-        // Assert — XADD was called (message re-added)
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once, "Message must be re-added after first failure" );
+        VerifyAtomicRequeue( TrackStream, Times.Once( ) );
 
         // Assert — re-serialized payload has AttemptCount=1
-        Assert.IsNotNull( capturedFields, "StreamAddAsync must have been called with fields" );
-        string? payloadJson = (string?)capturedFields.FirstOrDefault( f => f.Name == QueueStreamFieldNames.Payload ).Value;
+        Assert.IsNotNull( capturedArguments, "The atomic requeue script must receive the replacement payload" );
+        string? payloadJson = capturedArguments[3];
         Assert.IsNotNull( payloadJson );
         QueuedLookupRequest? requeuedPayload = JsonSerializer.Deserialize<QueuedLookupRequest>( payloadJson, s_jsonOptions );
         Assert.IsNotNull( requeuedPayload );
         Assert.AreEqual( 1, requeuedPayload.AttemptCount, "AttemptCount must be incremented to 1 on first requeue" );
     }
 
+    /// <summary>A failed replacement XADD leaves the original Spotify delivery pending.</summary>
+    [TestMethod]
+    public async Task RequeueAsync_WhenReplacementAddFails_DoesNotAcknowledgeOriginal( ) {
+        QueuedLookupRequest request = CreateRequest( TestTrackId, attemptCount: 0 );
+        StreamEntry entry = BuildStreamEntryFromRequest( request );
+        _ = _dbMock.Setup( d => d.StreamRangeAsync(
+                TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ),
+                It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [entry] );
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) ).ThrowsAsync( new RedisServerException( "atomic move failed" ) );
+
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => CreateHelper( ).RequeueAsync( $"{TrackStream}:1234567890-0", TestSagaId, TestContext.CancellationToken ) );
+
+    }
+
     /// <summary>
-    /// Verifies that requeuing a message already at the retry cap returns <c>CapReached</c>,
-    /// acknowledges the message to clear it from the pending list, and does not re-add it to the
-    /// stream (complete-failed semantics).
+    /// Verifies that requeuing a message already at the retry cap returns <c>CapReached</c> without
+    /// removing its last recovery delivery; the caller must first record terminal saga state.
     /// </summary>
     [TestMethod]
-    public async Task RequeueAsync_WhenAttemptCountAtCap_ShouldAckAndNotRequeue( ) {
-        // Arrange — message already at MaxRetryAttempts (5)
-        QueuedLookupRequest request = CreateRequest( TestTrackId, attemptCount: 5 );
+    public async Task RequeueAsync_WhenAttemptCountAtCap_ShouldLeaveDeliveryPending( ) {
+        // Arrange — the fifth and final execution carries AttemptCount=4 (attempts 0..4).
+        QueuedLookupRequest request = CreateRequest( TestTrackId, attemptCount: LookupConstants.MaxQueueRetryAttempts - 1 );
         StreamEntry entry = BuildStreamEntryFromRequest( request );
 
         _ = _dbMock.Setup( d => d.StreamRangeAsync(
@@ -557,25 +710,74 @@ public class SpotifyBulkDispatchContractTests {
         // Assert — method signals "gave up"
         Assert.AreEqual( RequeueOutcome.CapReached, outcome, "Return value must be CapReached when the retry cap is reached" );
 
-        // Assert — ACK + delete (message cleared from PEL) — single-ID overload
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once, "Message at cap must still be ACKed to clear it from PEL" );
+        _dbMock.Verify( d => d.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == TrackStream ),
+            It.Is<RedisValue[]?>( args => args != null && args.Length == 2 ),
+            It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
 
-        // Assert — XADD must NOT be called (not requeued)
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Never, "Message at cap must not be re-added (complete-failed semantics)" );
+    /// <summary>The fourth execution (AttemptCount=3) is still replaceable and produces AttemptCount=4.</summary>
+    [TestMethod]
+    public async Task RequeueAsync_WhenAttemptCountIsThree_ShouldRequeueWithAttemptCountFour( ) {
+        QueuedLookupRequest request = CreateRequest( TestTrackId, attemptCount: LookupConstants.MaxQueueRetryAttempts - 2 );
+        StreamEntry entry = BuildStreamEntryFromRequest( request );
+        _ = _dbMock.Setup( d => d.StreamRangeAsync(
+                TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ),
+                It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [entry] );
+        RedisValue[]? capturedArguments = null;
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback( ( string _, RedisKey[]? _, RedisValue[]? arguments, CommandFlags _ ) => capturedArguments = arguments )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"9999-0" ) );
+
+        RequeueOutcome outcome = await CreateHelper( ).RequeueAsync(
+            $"{TrackStream}:1234567890-0", TestSagaId, TestContext.CancellationToken );
+
+        Assert.AreEqual( RequeueOutcome.Requeued, outcome );
+        VerifyAtomicRequeue( TrackStream, Times.Once( ) );
+        string payload = (string)capturedArguments![3]!;
+        QueuedLookupRequest requeued = JsonSerializer.Deserialize<QueuedLookupRequest>( payload, s_jsonOptions )!;
+        Assert.AreEqual( LookupConstants.MaxQueueRetryAttempts - 1, requeued.AttemptCount );
+    }
+
+    /// <summary>A failed terminal saga write leaves the retry-cap delivery available for recovery.</summary>
+    [TestMethod]
+    public async Task ProcessBulkTracks_WhenTerminalStateWriteFails_ShouldLeaveCapDeliveryPending( ) {
+        QueuedLookupRequest request = CreateRequest(
+            TestTrackId,
+            attemptCount: LookupConstants.MaxQueueRetryAttempts - 1 );
+        StreamEntry entry = BuildStreamEntryFromRequest( request );
+        _ = _dbMock.Setup( database => database.StreamReadGroupAsync(
+                TrackStream,
+                It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ),
+                It.IsAny<int?>( ),
+                It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _dbMock.Setup( database => database.StreamRangeAsync(
+                TrackStream,
+                It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ),
+                It.IsAny<Order>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( [] );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new RedisConnectionException( ConnectionFailureType.UnableToResolvePhysicalConnection, "state unavailable" ) );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        VerifyAtomicRemoval( TrackStream, Times.Never( ) );
+        _requestQueueMock.Verify( queue => queue.MoveToDlqAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -631,6 +833,7 @@ public class SpotifyBulkDispatchContractTests {
             LookupKey = expectedLookupKey,
             LookupType = LookupRequestType.SongIdLookup,
             LookupValue = TestTrackId,
+            InstanceToken = "test-instance",
             ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
                 [SupportedProviders.Spotify] = new ProviderLookupState(
                     Provider: SupportedProviders.Spotify,
@@ -652,12 +855,13 @@ public class SpotifyBulkDispatchContractTests {
 
         // Assert (a): UpdateProviderStateAsync called with IsSuccess=false and the cap error message.
         // This is the service-level write that marks the saga provider as permanently failed.
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
             TestSagaId,
             It.Is<ProviderLookupState>( s =>
                 !s.IsSuccess &&
                 s.ErrorMessage != null &&
                 s.ErrorMessage.Contains( "Bulk lookup failed after" ) ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "RequeueSingleAsync cap path must write IsSuccess=false with 'Bulk lookup failed after' error" );
@@ -671,14 +875,12 @@ public class SpotifyBulkDispatchContractTests {
             Times.Once,
             "saga:completed must be published when the retry cap is reached (F2)" );
 
-        // Assert (b2): lookup-completion channel publish fires (PublishLookupCompletionAsync).
-        // This unblocks interactive waiters subscribed to the per-lookup-key channel.
+        // The coordinator consumes the saga progress event and owns waiter publication after
+        // authoritative finalization; the provider worker does not publish a speculative URI.
         _subscriberMock.Verify( s => s.PublishAsync(
             It.Is<RedisChannel>( ch => ch == RedisChannel.Literal( $"complete:{expectedLookupKey}" ) ),
             It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "complete:{lookupKey} must be published when the retry cap is reached (F2)" );
+            It.IsAny<CommandFlags>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -716,18 +918,20 @@ public class SpotifyBulkDispatchContractTests {
         await service.HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkTracksEndpoint, ex, TestContext.CancellationToken );
 
         // Assert — SetIsPartialAsync called for the saga
-        _sagaManagerMock.Verify( m => m.SetIsPartialAsync(
+        _sagaManagerMock.Verify( m => m.TrySetIsPartialAsync(
             TestSagaId,
             true,
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "Each rate-limited saga must be marked partial (parity with QueueProcessorBackgroundService rate-limit handling)" );
 
         // Assert — SetRateLimitInfoAsync called to merge rate-limit info into saga
-        _sagaManagerMock.Verify( m => m.SetRateLimitInfoAsync(
+        _sagaManagerMock.Verify( m => m.TrySetRateLimitInfoAsync(
             TestSagaId,
             It.Is<List<ProviderRateLimitInfo>>( list =>
                 list.Any( r => r.Provider == SupportedProviders.Spotify ) ),
+            It.IsAny<string>( ),
             It.IsAny<CancellationToken>( ) ),
             Times.Once,
             "Rate-limit info must be merged into the saga with Spotify provider entry" );
@@ -847,22 +1051,7 @@ public class SpotifyBulkDispatchContractTests {
         // Assert — no messages returned (poison was discarded)
         Assert.HasCount( 0, messages, "Poison entry must be discarded, not returned" );
 
-        // Assert — XACK must have been called to remove from PEL
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "Poison entry must be ACKed to remove it from the PEL (prevent eternal re-claim)" );
-
-        // Assert — XDEL must have been called
-        _dbMock.Verify( d => d.StreamDeleteAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<RedisValue[]>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "Poison entry must be XDELed so it cannot re-appear via XAUTOCLAIM" );
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
     }
 
     /// <summary>
@@ -900,22 +1089,7 @@ public class SpotifyBulkDispatchContractTests {
         // Assert — no messages returned (poison was discarded)
         Assert.HasCount( 0, messages, "Null-JSON-payload poison entry must be discarded, not returned" );
 
-        // Assert — XACK must have been called to remove from PEL
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "Null-JSON-payload poison entry must be ACKed to remove it from the PEL (prevent eternal re-claim)" );
-
-        // Assert — XDEL must have been called
-        _dbMock.Verify( d => d.StreamDeleteAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<RedisValue[]>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.Once,
-            "Null-JSON-payload poison entry must be XDELed so it cannot re-appear via XAUTOCLAIM" );
+        VerifyAtomicRemoval( TrackStream, Times.Once( ) );
     }
 
     /// <summary>
@@ -995,12 +1169,8 @@ public class SpotifyBulkDispatchContractTests {
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
         // Assert — saga state must NOT be written when entry is not found
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
-            It.IsAny<string>( ),
-            It.IsAny<ProviderLookupState>( ),
-            It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "NotFound requeue outcome must not trigger saga state write" );
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -1079,6 +1249,7 @@ public class SpotifyBulkDispatchContractTests {
             LookupType = LookupRequestType.SongIdLookup,
             LookupValue = trackId,
             SagaId = TestSagaId,
+            SagaInstanceToken = "test-instance",
             IsAlbum = false,
             OriginPriority = QueuePriority.Bulk,
             AttemptCount = attemptCount
@@ -1164,8 +1335,8 @@ public class SpotifyBulkDispatchContractTests {
 
     /// <summary>
     /// Verifies that when reclaimed entries already fill the requested count budget,
-    /// <c>XREADGROUP</c> is skipped entirely: a budget of one satisfied by a single claimed entry
-    /// means no fresh read is issued.
+    /// the fresh <c>XREADGROUP &gt;</c> read is skipped; the own-consumer PEL probe remains bounded
+    /// and is allowed before the aged reclaim pass.
     /// </summary>
     [TestMethod]
     public async Task DequeueTrackIdBatch_WhenAutoClaimFillsBudget_ShouldSkipXReadGroup( ) {
@@ -1198,18 +1369,50 @@ public class SpotifyBulkDispatchContractTests {
         // Assert — exactly one message from the claimed entry
         Assert.HasCount( 1, messages, "Budget of 1 must be filled by the claimed entry alone" );
 
-        // Assert — XREADGROUP was NOT called (budget exhausted by claimed entries)
+        // Assert — the fresh XREADGROUP > read was NOT called (budget exhausted by claimed entries)
         _dbMock.Verify( d => d.StreamReadGroupAsync(
             TrackStream,
             It.IsAny<RedisValue>( ),
             It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue?>( ),
+            It.Is<RedisValue?>( position => position == null ),
             It.IsAny<int?>( ),
             It.IsAny<bool>( ),
             It.IsAny<TimeSpan?>( ),
             It.IsAny<CommandFlags>( ) ),
             Times.Never,
             "XREADGROUP must not be called when the count budget is already filled by claimed entries" );
+    }
+
+    /// <summary>Spotify bulk XAUTOCLAIM advances its cursor so a later batch reaches the tail.</summary>
+    [TestMethod]
+    public async Task DequeueTrackIdBatch_WhenAutoClaimHasTail_AdvancesCursorAcrossCalls( ) {
+        StreamEntry first = BuildStreamEntryFromRequest( CreateRequest( "spotify-young-prefix", attemptCount: 1 ) );
+        StreamEntry tail = BuildStreamEntryFromRequest( CreateRequest( "spotify-aged-tail", attemptCount: 2 ) );
+        ConstructorInfo ctor = typeof( StreamAutoClaimResult ).GetConstructors( BindingFlags.NonPublic | BindingFlags.Instance )[0];
+        StreamAutoClaimResult firstPage = (StreamAutoClaimResult)ctor.Invoke( [(RedisValue)"100-0", new[] { first }, Array.Empty<RedisValue>( )] );
+        StreamAutoClaimResult tailPage = (StreamAutoClaimResult)ctor.Invoke( [(RedisValue)"0-0", new[] { tail }, Array.Empty<RedisValue>( )] );
+        List<RedisValue> starts = [];
+        int calls = 0;
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<long>( ),
+                It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .Callback<RedisKey, RedisValue, RedisValue, long, RedisValue, int?, CommandFlags>(
+                ( _, _, _, _, start, _, _ ) => starts.Add( start ) )
+            .ReturnsAsync( ( ) => Interlocked.Increment( ref calls ) == 1 ? firstPage : tailPage );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue?>( ),
+                It.IsAny<int?>( ), It.IsAny<bool>( ), It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [] );
+
+        SpotifyBatchQueueHelper helper = CreateHelper( );
+        IReadOnlyList<QueuedMessage<QueuedLookupRequest>> firstBatch = await helper.DequeueTrackIdBatchAsync( 1, TestContext.CancellationToken );
+        IReadOnlyList<QueuedMessage<QueuedLookupRequest>> tailBatch = await helper.DequeueTrackIdBatchAsync( 1, TestContext.CancellationToken );
+
+        Assert.AreEqual( "spotify-young-prefix", firstBatch[0].Payload.LookupValue );
+        Assert.AreEqual( "spotify-aged-tail", tailBatch[0].Payload.LookupValue );
+        Assert.HasCount( 2, starts );
+        Assert.AreEqual( (RedisValue)"0-0", starts[0] );
+        Assert.AreEqual( (RedisValue)"100-0", starts[1] );
     }
 
     /// <summary>
@@ -1318,35 +1521,11 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkAlbumLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — XACK fired (original entry acknowledged before re-add)
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            AlbumStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Original album message must be ACKed as part of RequeueAsync" );
-
-        // Assert — XADD fired (message re-added to the album stream)
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)AlbumStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Album message must be re-added to the album stream (requeue)" );
+        VerifyAtomicRequeue( AlbumStream, Times.AtLeastOnce( ) );
 
         // Assert — no saga state written (empty-dict = request failure, not not-found)
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
-            It.IsAny<string>( ),
-            It.IsAny<ProviderLookupState>( ),
-            It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "Empty-dict (request failure) on the album path must not write saga state" );
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
 
         // Negative control: the empty-dict path must NOT re-enqueue via the Interactive queue
         _requestQueueMock.Verify( q => q.EnqueueAsync(
@@ -1386,18 +1565,7 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — rebatch path fires (XADD)
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Auth failure (empty dict) must take the cooldown+rebatch path (XADD)" );
+        VerifyAtomicRequeue( TrackStream, Times.AtLeastOnce( ) );
 
         // Negative control: Interactive re-enqueue must NOT fire for an auth failure
         _requestQueueMock.Verify( q => q.EnqueueAsync(
@@ -1434,18 +1602,7 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — rebatch path fires (XADD)
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Authorization failure (empty dict) must take the cooldown+rebatch path (XADD)" );
+        VerifyAtomicRequeue( TrackStream, Times.AtLeastOnce( ) );
 
         // Negative control: Interactive re-enqueue must NOT fire for an authorization failure
         _requestQueueMock.Verify( q => q.EnqueueAsync(
@@ -1459,62 +1616,57 @@ public class SpotifyBulkDispatchContractTests {
     /// <summary>
     /// Verifies the 4xx track batch rejection contract: when the lookup service throws
     /// <see cref="SpotifyBulkRejectedException"/> (deterministic 4xx), every message is
-    /// re-enqueued individually at Interactive priority and the original bulk-stream messages
-    /// are acknowledged. No saga state is written and no cooldown is armed.
+    /// transferred individually to the Interactive stream in one Redis script. No saga state is
+    /// written and no cooldown is armed.
     /// </summary>
     /// <remarks>Test was red before HandleBulkRejectionAsync existed; green after.</remarks>
     [TestMethod]
-    public async Task ProcessBulkTracks_WhenBulkRejected4xx_ShouldReenqueueAllAtInteractiveAndAck( ) {
+    public async Task ProcessBulkTracks_WhenBulkRejected4xx_ShouldAtomicallyTransferAllToInteractive( ) {
         const int ExpectedCount = 1; // one message from default XREADGROUP setup
 
         // Arrange — lookup service throws the 4xx rejection exception
         _ = _lookupServiceMock.Setup( s => s.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
             .ThrowsAsync( new SpotifyBulkRejectedException( 400, null, SupportedProviders.Spotify ) );
 
-        List<QueuedLookupRequest> capturedRequests = [];
-        List<QueuePriority> capturedPriorities = [];
-        _ = _requestQueueMock.Setup( q => q.EnqueueAsync(
-                It.IsAny<QueuedLookupRequest>( ),
-                It.IsAny<QueuePriority>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( QueuedLookupRequest r, QueuePriority p, CancellationToken _ ) => {
-                capturedRequests.Add( r );
-                capturedPriorities.Add( p );
+        List<RedisKey[]?> capturedKeys = [];
+        List<RedisValue[]?> capturedValues = [];
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback( ( string _, RedisKey[]? keys, RedisValue[]? values, CommandFlags _ ) => {
+                capturedKeys.Add( keys );
+                capturedValues.Add( values );
             } )
-            .Returns( Task.CompletedTask );
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"9999999999-1" ) );
 
         SpotifyBulkProcessorService service = CreateService( );
 
         // Act
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — each message is re-enqueued at Interactive priority
-        _requestQueueMock.Verify( q => q.EnqueueAsync(
-            It.IsAny<QueuedLookupRequest>( ),
-            QueuePriority.Interactive,
-            It.IsAny<CancellationToken>( ) ),
-            Times.Exactly( ExpectedCount ),
-            "Every message in the rejected batch must be re-enqueued at Interactive priority" );
-
-        Assert.HasCount( ExpectedCount, capturedRequests, "Re-enqueue count must match message count" );
-        Assert.AreEqual( QueuePriority.Interactive, capturedPriorities[0], "Re-enqueue priority must be Interactive" );
-
-        // Assert — original bulk-stream messages are acknowledged (XACK + XDEL)
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            TrackStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
+        // Assert — each source is transferred to the generic background stream atomically.
+        _dbMock.Verify( d => d.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null
+                && keys[0] == TrackStream
+                && keys[1] == SpotifyConstants.BackgroundStream ),
+            It.IsAny<RedisValue[]?>( ),
             It.IsAny<CommandFlags>( ) ),
             Times.Exactly( ExpectedCount ),
-            "Each original bulk-stream message must be ACKed after re-enqueueing" );
+            "Every message in the rejected batch must use the atomic transfer script" );
+        Assert.HasCount( ExpectedCount, capturedKeys );
+        Assert.HasCount( ExpectedCount, capturedValues );
+        QueuedLookupRequest? forwarded = JsonSerializer.Deserialize<QueuedLookupRequest>(
+            capturedValues[0]![2].ToString( ), s_jsonOptions );
+        Assert.AreEqual( QueueEnqueueOrigin.Requeue, forwarded!.EnqueueOrigin );
+        Assert.IsTrue( forwarded.BypassBulkRouting );
+        _requestQueueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
 
         // Assert — no saga state written on the 4xx path
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
-            It.IsAny<string>( ),
-            It.IsAny<ProviderLookupState>( ),
-            It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "4xx rejection must not write saga state" );
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
 
         // Assert — cooldown not armed: no stream re-add (RequeueAllAsync not called)
         _dbMock.Verify( d => d.StreamAddAsync(
@@ -1533,11 +1685,11 @@ public class SpotifyBulkDispatchContractTests {
     /// <summary>
     /// Verifies the album-path parity for 4xx rejection: when the album lookup service throws
     /// <see cref="SpotifyBulkRejectedException"/>, every album message is re-enqueued at
-    /// Interactive and acknowledged, and no saga state is written.
+    /// Interactive atomically, and no saga state is written.
     /// </summary>
     /// <remarks>Test was red before HandleBulkRejectionAsync existed; green after.</remarks>
     [TestMethod]
-    public async Task ProcessBulkAlbums_WhenBulkRejected4xx_ShouldReenqueueAllAtInteractiveAndAck( ) {
+    public async Task ProcessBulkAlbums_WhenBulkRejected4xx_ShouldAtomicallyTransferAllToInteractive( ) {
         const string TestAlbumId = "6WdSsBrH5QtofaTTqgwxOV";
         const int ExpectedCount = 1;
 
@@ -1578,30 +1730,23 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkAlbumLookupsAsync( TestContext.CancellationToken );
 
-        // Assert — re-enqueued at Interactive
-        _requestQueueMock.Verify( q => q.EnqueueAsync(
-            It.IsAny<QueuedLookupRequest>( ),
-            QueuePriority.Interactive,
-            It.IsAny<CancellationToken>( ) ),
-            Times.Exactly( ExpectedCount ),
-            "Every album message in the rejected batch must be re-enqueued at Interactive priority" );
-
-        // Assert — original album-stream message acknowledged
-        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
-            AlbumStream,
-            It.IsAny<RedisValue>( ),
-            It.IsAny<RedisValue>( ),
+        // Assert — atomically transferred to the single-item background stream.
+        _dbMock.Verify( d => d.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null
+                && keys[0] == AlbumStream
+                && keys[1] == SpotifyConstants.BackgroundStream ),
+            It.IsAny<RedisValue[]?>( ),
             It.IsAny<CommandFlags>( ) ),
             Times.Exactly( ExpectedCount ),
-            "Each original album bulk-stream message must be ACKed after re-enqueueing" );
+            "Every album message in the rejected batch must use the atomic transfer script" );
+        _requestQueueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
+            Times.Never );
 
         // Assert — no saga state written
-        _sagaManagerMock.Verify( m => m.UpdateProviderStateAsync(
-            It.IsAny<string>( ),
-            It.IsAny<ProviderLookupState>( ),
-            It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "4xx album rejection must not write saga state" );
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
+            It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -1636,13 +1781,12 @@ public class SpotifyBulkDispatchContractTests {
         _ = _lookupServiceMock.Setup( s => s.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
             .ThrowsAsync( new SpotifyBulkRejectedException( 400, null, SupportedProviders.Spotify ) );
 
-        QueuedLookupRequest? capturedRequest = null;
-        _ = _requestQueueMock.Setup( q => q.EnqueueAsync(
-                It.IsAny<QueuedLookupRequest>( ),
-                It.IsAny<QueuePriority>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( QueuedLookupRequest r, QueuePriority _, CancellationToken _ ) => capturedRequest = r )
-            .Returns( Task.CompletedTask );
+        RedisValue[]? capturedValues = null;
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .Callback( ( string _, RedisKey[]? _, RedisValue[]? values, CommandFlags _ ) => capturedValues = values )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"9999999999-1" ) );
 
         SpotifyBulkProcessorService service = CreateService( );
 
@@ -1650,7 +1794,10 @@ public class SpotifyBulkDispatchContractTests {
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
         // Assert — AttemptCount carried unchanged
-        Assert.IsNotNull( capturedRequest, "EnqueueAsync must have been called with the re-enqueued request" );
+        Assert.IsNotNull( capturedValues, "The atomic transfer script must receive the re-enqueued payload" );
+        QueuedLookupRequest? capturedRequest = JsonSerializer.Deserialize<QueuedLookupRequest>(
+            capturedValues[2].ToString( ), s_jsonOptions );
+        Assert.IsNotNull( capturedRequest );
         Assert.AreEqual(
             OriginalAttemptCount,
             capturedRequest.AttemptCount,
@@ -1674,18 +1821,7 @@ public class SpotifyBulkDispatchContractTests {
         // Act
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Characterize: takes the rebatch (XADD) path, not the Interactive re-enqueue path
-        _dbMock.Verify( d => d.StreamAddAsync(
-            (RedisKey)TrackStream,
-            It.IsAny<NameValueEntry[]>( ),
-            It.IsAny<RedisValue?>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<bool>( ),
-            It.IsAny<long?>( ),
-            It.IsAny<StreamTrimMode>( ),
-            It.IsAny<CommandFlags>( ) ),
-            Times.AtLeastOnce,
-            "Empty-dict takes the cooldown+rebatch path (current behavior characterization)" );
+        VerifyAtomicRequeue( TrackStream, Times.AtLeastOnce( ) );
 
         _requestQueueMock.Verify( q => q.EnqueueAsync(
             It.IsAny<QueuedLookupRequest>( ),
@@ -1694,4 +1830,18 @@ public class SpotifyBulkDispatchContractTests {
             Times.Never,
             "Empty-dict must not trigger Interactive re-enqueue (current behavior characterization)" );
     }
+
+    private void VerifyAtomicRequeue( string stream, Times times ) =>
+        _dbMock.Verify( database => database.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == stream ),
+            It.Is<RedisValue[]?>( arguments => arguments != null && arguments.Length == 7 ),
+            It.IsAny<CommandFlags>( ) ), times );
+
+    private void VerifyAtomicRemoval( string stream, Times times ) =>
+        _dbMock.Verify( database => database.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == stream ),
+            It.Is<RedisValue[]?>( arguments => arguments != null && arguments.Length == 2 ),
+            It.IsAny<CommandFlags>( ) ), times );
 }

--- a/Tests/Unit/SpotifyBulkFlushTests.cs
+++ b/Tests/Unit/SpotifyBulkFlushTests.cs
@@ -1,11 +1,16 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Globalization;
+using System.Reflection;
 using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Domain.Providers.Spotify;
 using BridgeBeats.Core.Infrastructure.Queue;
+using BridgeBeats.Core.Infrastructure.Utilities;
 using BridgeBeats.Worker.Spotify;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -25,6 +30,7 @@ namespace BridgeBeats.Tests.Unit;
 /// as approved bulk callers.
 /// </summary>
 [TestClass]
+[DoNotParallelize]
 public class SpotifyBulkFlushTests {
 
     /// <summary>Mock Redis multiplexer supplying the database and subscriber to the service under test.</summary>
@@ -100,6 +106,10 @@ public class SpotifyBulkFlushTests {
                 It.IsAny<StreamTrimMode>( ),
                 It.IsAny<CommandFlags>( ) ) )
             .ReturnsAsync( (RedisValue)"1234567890-0" );
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"1234567890-1" ) );
 
         // StreamLength returns 0 by default
         _ = _dbMock.Setup( d => d.StreamLengthAsync( It.IsAny<RedisKey>( ), It.IsAny<CommandFlags>( ) ) )
@@ -192,35 +202,29 @@ public class SpotifyBulkFlushTests {
                 SagaId = TestSagaId,
                 LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
                 LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance"
             } );
         _ = _sagaManagerMock.Setup( m => m.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( new LookupSagaState {
                 SagaId = TestSagaId,
                 LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
                 LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance"
             } );
-        _ = _sagaManagerMock.Setup( m => m.InitializeProviderStatesAsync(
-                It.IsAny<string>( ),
-                It.IsAny<IEnumerable<SupportedProviders>>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.UpdateProviderStateAsync(
-                It.IsAny<string>( ),
-                It.IsAny<ProviderLookupState>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.SetIsPartialAsync(
-                It.IsAny<string>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
-        _ = _sagaManagerMock.Setup( m => m.SetRateLimitInfoAsync(
-                It.IsAny<string>( ),
-                It.IsAny<List<ProviderRateLimitInfo>>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock.Setup( m => m.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TrySetIsPartialAsync(
+                It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TrySetRateLimitInfoAsync(
+                It.IsAny<string>( ), It.IsAny<List<ProviderRateLimitInfo>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( true );
     }
 
     /// <summary>
@@ -228,11 +232,7 @@ public class SpotifyBulkFlushTests {
     /// never written to a bulk stream.
     /// </summary>
     /// <remarks>
-    /// This passthrough is load-bearing for the 4xx bulk-rejection fallback. When
-    /// <see cref="SpotifyBulkProcessorService"/> handles a <c>SpotifyBulkRejectedException</c>, it
-    /// re-enqueues each item at Interactive priority through the decorator. If the decorator were ever
-    /// changed to batch Interactive SongIdLookup requests into the bulk stream, the fallback would
-    /// silently loop instead of resolving items individually.
+    /// Interactive requests stay on the generic single-item path and are never batch-routed.
     /// </remarks>
     [TestMethod]
     public async Task Decorator_SongIdLookup_WithInteractivePriority_DelegatesToInnerQueue( ) {
@@ -269,15 +269,91 @@ public class SpotifyBulkFlushTests {
     }
 
     /// <summary>
+    /// Verifies that a missing Redis consumer group is repaired and that the bulk worker continues
+    /// into a subsequent polling cycle instead of remaining in the error path.
+    /// </summary>
+    [TestMethod]
+    public async Task ExecuteAsync_WhenNoGroupError_RecreatesGroupsAndContinuesLoop( ) {
+        // Arrange — the first flush-decision read simulates Redis returning NOGROUP. The third
+        // read is the album check in the next polling cycle (the second read is the first cycle's
+        // album check), proving the loop resumed after EnsureConsumerGroupsAsync completed.
+        TaskCompletionSource<bool> resumed = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        int stateCalls = 0;
+        _ = _rateLimitTrackerMock.Setup( t => t.GetStateAsync(
+                It.IsAny<SupportedProviders>( ),
+                It.IsAny<string>( ),
+                It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( SupportedProviders _, string _, CancellationToken _ ) => {
+                int call = Interlocked.Increment( ref stateCalls );
+                if (call == 1) {
+                    return Task.FromException<RateLimitState>(
+                        new RedisServerException( "NOGROUP No such key 'spotify:bulk:tracks'" ) );
+                }
+
+                if (call >= 3) {
+                    _ = resumed.TrySetResult( true );
+                }
+
+                return Task.FromResult( new RateLimitState( false, null, null ) );
+            } );
+
+        SpotifyBulkProcessorService service = CreateService( );
+
+        // Act — start the hosted loop, wait until it reaches the next cycle, then stop it cleanly.
+        await service.StartAsync( TestContext.CancellationToken );
+        Task completed = await Task.WhenAny( resumed.Task, Task.Delay( TimeSpan.FromSeconds( 5 ), TestContext.CancellationToken ) );
+        await service.StopAsync( TestContext.CancellationToken );
+
+        // Assert — startup and the NOGROUP recovery each ensure both bulk consumer groups.
+        Assert.AreSame( resumed.Task, completed, "The worker did not resume polling after NOGROUP recovery." );
+        Assert.IsGreaterThanOrEqualTo( 3, stateCalls, "The worker did not enter a subsequent polling cycle." );
+        _dbMock.Verify( d => d.StreamCreateConsumerGroupAsync(
+                It.IsAny<RedisKey>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue>( ),
+                It.IsAny<bool>( ),
+                It.IsAny<CommandFlags>( ) ), Times.Exactly( 4 ) );
+    }
+
+    /// <summary>Failed Spotify group repair is delayed and retried without terminating the loop.</summary>
+    [TestMethod]
+    [Timeout( 30000, CooperativeCancellation = true )]
+    public async Task ExecuteAsync_WhenGroupRepairFails_RetriesOnLaterNoGroup( ) {
+        TaskCompletionSource<bool> resumed = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        int stateCalls = 0;
+        _ = _rateLimitTrackerMock.Setup( t => t.GetStateAsync(
+                It.IsAny<SupportedProviders>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( ( SupportedProviders _, string _, CancellationToken _ ) => {
+                int call = Interlocked.Increment( ref stateCalls );
+                if (call <= 2) return Task.FromException<RateLimitState>( new RedisServerException( "NOGROUP" ) );
+                _ = resumed.TrySetResult( true );
+                return Task.FromResult( new RateLimitState( false, null, null ) );
+            } );
+        int groupCalls = 0;
+        _ = _dbMock.Setup( d => d.StreamCreateConsumerGroupAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<bool>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( ( RedisKey _, RedisValue _, RedisValue _, bool _, CommandFlags _ ) => {
+                int call = Interlocked.Increment( ref groupCalls );
+                if (call == 3) throw new RedisServerException( "repair failed" );
+                return true;
+            } );
+
+        SpotifyBulkProcessorService service = CreateService( );
+        await service.StartAsync( TestContext.CancellationToken );
+        Task completed = await Task.WhenAny( resumed.Task, Task.Delay( TimeSpan.FromSeconds( 12 ), TestContext.CancellationToken ) );
+        await service.StopAsync( TestContext.CancellationToken );
+
+        Assert.AreSame( resumed.Task, completed );
+        Assert.IsGreaterThanOrEqualTo( 5, groupCalls );
+    }
+
+    /// <summary>
     /// Verifies that an album-id lookup at interactive priority is delegated to the inner queue and
     /// is never written to a bulk stream.
     /// </summary>
     /// <remarks>
-    /// This passthrough is load-bearing for the 4xx bulk-rejection fallback. When
-    /// <see cref="SpotifyBulkProcessorService"/> handles a <c>SpotifyBulkRejectedException</c>, it
-    /// re-enqueues each item at Interactive priority through the decorator. If the decorator were ever
-    /// changed to batch Interactive AlbumIdLookup requests into the bulk stream, the fallback would
-    /// silently loop instead of resolving items individually.
+    /// Interactive requests stay on the generic single-item path and are never batch-routed.
     /// </remarks>
     [TestMethod]
     public async Task Decorator_AlbumIdLookup_WithInteractivePriority_DelegatesToInnerQueue( ) {
@@ -336,7 +412,21 @@ public class SpotifyBulkFlushTests {
                 It.IsAny<QueuePriority>( ),
                 It.IsAny<CancellationToken>( ) ),
             Times.Never,
-            "Decorator must not materialize a saga at enqueue time — sagas are created at flush in ProcessBulkResultAsync" );
+            "Decorator must not materialize a saga; the upstream producer owns saga creation" );
+    }
+
+    /// <summary>A bulk-routed enqueue fails when Redis does not return an accepted entry id.</summary>
+    [TestMethod]
+    public async Task Decorator_BulkEnqueueWithoutMessageId_Throws( ) {
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( (RedisResult)RedisResult.Create( RedisValue.Null ) );
+
+        SpotifyBulkQueueDecorator decorator = CreateDecorator( );
+
+        _ = await Assert.ThrowsExactlyAsync<InvalidOperationException>( ( ) => decorator.EnqueueAsync(
+            MakeTrackRequest( TestTrackId ), QueuePriority.Bulk, TestContext.CancellationToken ) );
     }
 
     /// <summary>
@@ -514,14 +604,15 @@ public class SpotifyBulkFlushTests {
     }
 
     /// <summary>
-    /// Verifies the ordering guarantee in rate-limit handling: <c>HandleBulkRateLimitAsync</c> calls
-    /// <c>GetOrCreateAsync</c> to ensure the saga core hash exists before <c>SetIsPartialAsync</c>
-    /// writes provider state, so partial state is never written against a missing saga.
+    /// A rate-limited delivery whose producer saga is gone is acknowledged as stale and never
+    /// recreates state from an old delivery.
     /// </summary>
     [TestMethod]
-    public async Task HandleBulkRateLimitAsync_CallsGetOrCreateAsync_BeforeWritingProviderState( ) {
-        // Arrange — a JetStream-style fire-and-forget message (saga not pre-created)
-        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+    public async Task HandleBulkRateLimitAsync_MissingSaga_AcknowledgesStaleWithoutMutation( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk ) with {
+            SagaId = ISagaStateManager.GenerateSagaId( LookupKeyBuilder.TypedKey(
+                LookupRequestType.SongIdLookup, SupportedProviders.Spotify, TestTrackId ) )
+        };
         List<QueuedMessage<QueuedLookupRequest>> messages = [
             new QueuedMessage<QueuedLookupRequest>(
                 $"{TrackStream}:1234567890-0",
@@ -535,53 +626,78 @@ public class SpotifyBulkFlushTests {
             requestUri: null,
             provider: SupportedProviders.Spotify );
 
-        bool getOrCreateCalledBeforeSetPartial = false;
-        bool setPartialCalled = false;
-
-        _ = _sagaManagerMock.Setup( m => m.GetOrCreateAsync(
-                It.IsAny<string>( ),
-                It.IsAny<string>( ),
-                It.IsAny<LookupRequestType>( ),
-                It.IsAny<string>( ),
-                It.IsAny<QueuePriority?>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( string _, string _, LookupRequestType _, string _, QueuePriority? _, CancellationToken _ ) => {
-                getOrCreateCalledBeforeSetPartial = !setPartialCalled;
-            } )
-            .ReturnsAsync( new LookupSagaState {
-                SagaId = TestSagaId,
-                LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
-                LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
-            } );
-
-        _ = _sagaManagerMock.Setup( m => m.SetIsPartialAsync(
-                It.IsAny<string>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( string _, bool _, CancellationToken _ ) => setPartialCalled = true )
-            .Returns( Task.CompletedTask );
+        _ = _sagaManagerMock.Setup( m => m.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( (LookupSagaState?)null );
 
         SpotifyBulkProcessorService service = CreateService( );
 
         // Act
         await service.HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkTracksEndpoint, ex, TestContext.CancellationToken );
 
-        // Assert (a): GetOrCreateAsync was called
-        _sagaManagerMock.Verify(
-            m => m.GetOrCreateAsync(
-                TestSagaId,
-                It.IsAny<string>( ),
-                It.IsAny<LookupRequestType>( ),
-                It.IsAny<string>( ),
-                It.IsAny<QueuePriority?>( ),
-                It.IsAny<CancellationToken>( ) ),
-            Times.Once,
-            "HandleBulkRateLimitAsync must call GetOrCreateAsync to ensure the core hash exists before writing provider state" );
+        _sagaManagerMock.Verify( m => m.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ), Times.AtLeastOnce );
+        _sagaManagerMock.Verify( m => m.TrySetIsPartialAsync(
+            It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( m => m.GetOrCreateAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+            It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
 
-        // Assert (b): GetOrCreateAsync was called BEFORE SetIsPartialAsync
-        Assert.IsTrue( getOrCreateCalledBeforeSetPartial,
-            "GetOrCreateAsync must be called before SetIsPartialAsync so the core hash exists before provider state is written" );
+    /// <summary>
+    /// Verifies rate-limit handling emits one end-to-end wall sample and span for both an admitted
+    /// message and a stale identity that is quarantined before admission.
+    /// </summary>
+    [TestMethod]
+    public async Task HandleBulkRateLimitAsync_MixedAdmittedAndStaleMessages_RecordsWallOncePerMessage( ) {
+        QueuedMessage<QueuedLookupRequest> admitted = new(
+            $"{TrackStream}:admitted",
+            MakeTrackRequest( TestTrackId, QueuePriority.Bulk ),
+            DateTimeOffset.UtcNow );
+        QueuedMessage<QueuedLookupRequest> stale = new(
+            $"{TrackStream}:stale",
+            MakeTrackRequest( TestTrackId, QueuePriority.Bulk ),
+            DateTimeOffset.UtcNow );
+        List<QueuedMessage<QueuedLookupRequest>> messages = [admitted, stale];
+        Contracts.Exceptions.RetryAfterExceededException ex = new(
+            retryAfterValue: TimeSpan.FromSeconds( 60 ),
+            threshold: TimeSpan.FromSeconds( 120 ),
+            requestUri: null,
+            provider: SupportedProviders.Spotify );
+
+        int partialCalls = 0;
+        _ = _sagaManagerMock.Setup( m => m.TrySetIsPartialAsync(
+                It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string _, bool _, string _, CancellationToken _ ) => Interlocked.Increment( ref partialCalls ) == 1 );
+
+        int wallSamples = 0;
+        List<Activity> wallSpans = [];
+        using ActivityListener activityListener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => {
+                if (activity.OperationName == "queue.spotify.message.wall") wallSpans.Add( activity );
+            }
+        };
+        ActivitySource.AddActivityListener( activityListener );
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") listener.EnableMeasurementEvents( instrument );
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( _, _, _, _ ) => wallSamples++ );
+        meterListener.Start( );
+
+        await CreateService( ).HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkTracksEndpoint, ex, TestContext.CancellationToken );
+
+        Assert.AreEqual( 2, wallSamples );
+        Assert.HasCount( 2, wallSpans );
+        _innerQueueMock.Verify( q => q.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( m => m.TrySetIsPartialAsync(
+            admitted.Payload.SagaId, true, "test-instance", It.IsAny<CancellationToken>( ) ), Times.Exactly( 2 ) );
+        _sagaManagerMock.Verify( m => m.TrySetRateLimitInfoAsync(
+            admitted.Payload.SagaId,
+            It.IsAny<List<ProviderRateLimitInfo>>( ),
+            "test-instance",
+            It.IsAny<CancellationToken>( ) ), Times.Once );
     }
 
     /// <summary>
@@ -594,7 +710,10 @@ public class SpotifyBulkFlushTests {
     public async Task RequeueSingle_CapReached_CallsGetOrCreateAsync_BeforeUpdateProviderState( ) {
         // Arrange — message at retry cap
         QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk,
-            attemptCount: LookupConstants.MaxQueueRetryAttempts );
+            attemptCount: LookupConstants.MaxQueueRetryAttempts ) with {
+            SagaId = ISagaStateManager.GenerateSagaId( LookupKeyBuilder.TypedKey(
+                    LookupRequestType.SongIdLookup, SupportedProviders.Spotify, TestTrackId ) )
+        };
         StreamEntry capEntry = BuildStreamEntry( request );
 
         // StreamRangeAsync returns the at-cap entry so RequeueAsync sees AttemptCount == cap
@@ -627,56 +746,49 @@ public class SpotifyBulkFlushTests {
         _ = _lookupServiceMock.Setup( s => s.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
             .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { ["someOtherId"] = null } );
 
-        bool getOrCreateCalledBeforeUpdateProvider = false;
         bool updateProviderCalled = false;
 
-        _ = _sagaManagerMock.Setup( m => m.GetOrCreateAsync(
-                It.IsAny<string>( ),
-                It.IsAny<string>( ),
-                It.IsAny<LookupRequestType>( ),
-                It.IsAny<string>( ),
-                It.IsAny<QueuePriority?>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( string _, string _, LookupRequestType _, string _, QueuePriority? _, CancellationToken _ ) => {
-                // Only set the flag if this is the CapReached call (updateProvider not yet called)
-                if (!updateProviderCalled) {
-                    getOrCreateCalledBeforeUpdateProvider = true;
-                }
-            } )
+        _ = _sagaManagerMock.Setup( m => m.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( string _, ProviderLookupState _, string _, CancellationToken _ ) => updateProviderCalled = true )
+            .ReturnsAsync( true );
+        _ = _sagaManagerMock.Setup( m => m.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( new LookupSagaState {
                 SagaId = TestSagaId,
                 LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
                 LookupType = LookupRequestType.SongIdLookup,
-                LookupValue = TestTrackId
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance",
+                ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                    [SupportedProviders.Spotify] = new( SupportedProviders.Spotify, false, false, null, null, null )
+                }
             } );
 
-        _ = _sagaManagerMock.Setup( m => m.UpdateProviderStateAsync(
-                It.IsAny<string>( ),
-                It.IsAny<ProviderLookupState>( ),
-                It.IsAny<CancellationToken>( ) ) )
-            .Callback( ( string _, ProviderLookupState _, CancellationToken _ ) => updateProviderCalled = true )
-            .Returns( Task.CompletedTask );
-
         SpotifyBulkProcessorService service = CreateService( );
+        int completedLegs = 0;
+        string? completedState = null;
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.saga.leg.completed.total") sub.EnableMeasurementEvents( instrument );
+        };
+        meterListener.SetMeasurementEventCallback<long>( ( _, value, tags, _ ) => {
+            completedLegs += (int)value;
+            foreach (KeyValuePair<string, object?> tag in tags) {
+                if (tag.Key == "saga_state") completedState = tag.Value?.ToString( );
+            }
+        } );
+        meterListener.Start( );
 
         // Act — drives the absent-key → RequeueSingleAsync → CapReached path
         await service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
 
-        // Assert (a): GetOrCreateAsync was called in the CapReached branch
-        _sagaManagerMock.Verify(
-            m => m.GetOrCreateAsync(
-                TestSagaId,
-                It.IsAny<string>( ),
-                It.IsAny<LookupRequestType>( ),
-                It.IsAny<string>( ),
-                It.IsAny<QueuePriority?>( ),
-                It.IsAny<CancellationToken>( ) ),
-            Times.AtLeastOnce,
-            "RequeueSingleAsync CapReached branch must call GetOrCreateAsync to ensure the core hash exists before writing provider state" );
-
-        // Assert (b): GetOrCreateAsync preceded UpdateProviderStateAsync
-        Assert.IsTrue( getOrCreateCalledBeforeUpdateProvider,
-            "GetOrCreateAsync must be called before UpdateProviderStateAsync in the CapReached branch" );
+        // Assert: the cap path reads and fences the saga before writing terminal state.
+        _sagaManagerMock.Verify( m => m.GetAsync( request.SagaId, It.IsAny<CancellationToken>( ) ), Times.AtLeastOnce );
+        _sagaManagerMock.Verify( m => m.TryUpdateProviderStateAsync(
+            request.SagaId, It.IsAny<ProviderLookupState>( ), "test-instance", It.IsAny<CancellationToken>( ) ), Times.Once );
+        Assert.IsTrue( updateProviderCalled, "The CapReached branch must write terminal state through the token-aware CAS." );
+        Assert.AreEqual( 1, completedLegs );
+        Assert.AreEqual( "committed_failure", completedState );
     }
 
     /// <summary>
@@ -852,6 +964,621 @@ public class SpotifyBulkFlushTests {
     private SpotifyBatchQueueHelper CreateHelper( ) =>
         new( _redisMock.Object, _helperLoggerMock.Object );
 
+    /// <summary>Spotify dequeue emits scoped dequeue, PEL, and read-group spans on the real helper path.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkDequeue_EmitsScopedTelemetryForPelAndReadGroup( ) {
+        List<Activity> observed = [];
+        using ActivityListener listener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => observed.Add( activity )
+        };
+        ActivitySource.AddActivityListener( listener );
+        _ = await CreateHelper( ).DequeueTrackIdBatchAsync( 1, TestContext.CancellationToken );
+        Assert.Contains( activity => activity.OperationName == "queue.spotify.dequeue", observed );
+        Activity pel = observed.Single( activity => activity.OperationName == "queue.spotify.dequeue.pel_scan" );
+        Activity read = observed.Single( activity => activity.OperationName == "queue.spotify.dequeue.read_group" );
+        Assert.AreEqual( "spotify", pel.GetTagItem( QueueMetricTags.Provider ) );
+        Assert.AreEqual( "bulk", pel.GetTagItem( QueueMetricTags.Priority ) );
+        Assert.IsGreaterThan( TimeSpan.Zero, pel.Duration );
+        Assert.IsGreaterThan( TimeSpan.Zero, read.Duration );
+    }
+
+    /// <summary>One valid bulk message produces exactly one wall sample and one missing-state leg sample.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkResult_RecordsWallAndMissingSagaLegExactlyOnce( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> {
+                [TestTrackId] = new MusicLookupResult { Artist = "Artist", Title = "Title", ExternalId = "ISRC" }
+            } );
+
+        Dictionary<string, int> counts = [];
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && (instrument.Name == "bridgebeats.queue.message.wall.duration"
+                    || instrument.Name == "bridgebeats.queue.saga.leg.completed.total")) {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( instrument, _, _, _ ) =>
+            counts[instrument.Name] = counts.GetValueOrDefault( instrument.Name ) + 1 );
+        meterListener.SetMeasurementEventCallback<long>( ( instrument, _, _, _ ) =>
+            counts[instrument.Name] = counts.GetValueOrDefault( instrument.Name ) + 1 );
+        meterListener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 1, counts.GetValueOrDefault( "bridgebeats.queue.message.wall.duration" ) );
+        Assert.AreEqual( 1, counts.GetValueOrDefault( "bridgebeats.queue.saga.leg.completed.total" ) );
+    }
+
+    /// <summary>A two-message returned batch emits exactly one wall sample per message.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkResult_TwoReturnedMessages_EmitsExactlyTwoWallSamples( ) {
+        QueuedLookupRequest first = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        QueuedLookupRequest second = MakeTrackRequest( TestTrackId + "2", QueuePriority.Bulk );
+        StreamEntry firstEntry = BuildStreamEntry( first );
+        StreamEntry secondEntry = BuildStreamEntry( second, "1234567891-0" );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [firstEntry, secondEntry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> {
+                [TestTrackId] = new MusicLookupResult { Artist = "Artist", Title = "Title", ExternalId = "ISRC" },
+                [TestTrackId + "2"] = new MusicLookupResult { Artist = "Artist 2", Title = "Title 2", ExternalId = "ISRC2" }
+            } );
+
+        int wallSamples = 0;
+        List<double> wallDurations = [];
+        List<Activity> wallSpans = [];
+        using ActivityListener activityListener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => {
+                if (activity.OperationName == "queue.spotify.message.wall") wallSpans.Add( activity );
+            }
+        };
+        ActivitySource.AddActivityListener( activityListener );
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<double>( ( instrument, value, _, _ ) => {
+            wallSamples++;
+            wallDurations.Add( value );
+        } );
+        listener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 2, wallSamples );
+        Assert.HasCount( 2, wallSpans );
+        for (int index = 0; index < wallSpans.Count; index++) {
+            Assert.IsLessThan( 0.5, Math.Abs( wallSpans[index].Duration.TotalSeconds - wallDurations[index] ) );
+        }
+    }
+
+    /// <summary>
+    /// A bulk result whose post-commit XACK fails remains pending without entering the retry-cap
+    /// mutation path, even at the terminal attempt boundary.
+    /// </summary>
+    [TestMethod]
+    public async Task SpotifyBulkResult_AckFailureAfterCommittedSuccess_LeavesPelPendingWithoutRetryMutation( ) {
+        QueuedLookupRequest request = MakeTrackRequest(
+            TestTrackId,
+            QueuePriority.Bulk,
+            LookupConstants.MaxQueueRetryAttempts - 1 );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> {
+                [TestTrackId] = new MusicLookupResult { Artist = "Artist", Title = "Title", ExternalId = "ISRC" }
+            } );
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == TrackStream ),
+                It.Is<RedisValue[]?>( arguments => arguments != null && arguments.Length == 2 ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "atomic acknowledgement unavailable" ) );
+
+        SpotifyBulkProcessorService service = CreateService( );
+
+        _ = await Assert.ThrowsAsync<Exception>(
+            ( ) => service.ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+
+        _sagaManagerMock.Verify( manager => manager.TryUpdateProviderStateAsync(
+            request.SagaId,
+            It.Is<ProviderLookupState>( state => state.IsComplete && state.IsSuccess ),
+            "test-instance",
+            It.IsAny<CancellationToken>( ) ), Times.Once );
+        _dbMock.Verify( d => d.StreamAddAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<NameValueEntry[]>( ), It.IsAny<RedisValue?>( ),
+            It.IsAny<long?>( ), It.IsAny<bool>( ), It.IsAny<long?>( ), It.IsAny<StreamTrimMode>( ),
+            It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>Completed-leg redelivery is dropped while the first delivery emits its pending state.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkResult_RecordsPendingAndCompleteSagaStatesOncePerMessage( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> {
+                [TestTrackId] = new MusicLookupResult { Artist = "Artist", Title = "Title", ExternalId = "ISRC" }
+            } );
+        int sagaRead = 0;
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync(
+                TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => sagaRead++ switch {
+                0 => new LookupSagaState { SagaId = TestSagaId, LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}", LookupType = LookupRequestType.SongIdLookup, LookupValue = TestTrackId, InstanceToken = "test-instance" },
+                1 or 2 => new LookupSagaState {
+                    SagaId = TestSagaId,
+                    LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
+                    LookupType = LookupRequestType.SongIdLookup,
+                    LookupValue = TestTrackId,
+                    InstanceToken = "test-instance",
+                    ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                        [SupportedProviders.Spotify] = new( SupportedProviders.Spotify, false, false, null, null, "pending" )
+                    }
+                },
+                3 or 4 or 5 or 6 => new LookupSagaState {
+                    SagaId = TestSagaId,
+                    LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
+                    LookupType = LookupRequestType.SongIdLookup,
+                    LookupValue = TestTrackId,
+                    InstanceToken = "test-instance",
+                    ProviderStates = new Dictionary<SupportedProviders, ProviderLookupState> {
+                        [SupportedProviders.Spotify] = new( SupportedProviders.Spotify, true, true, "{}", DateTimeOffset.UtcNow, null )
+                    }
+                },
+                _ => null
+            } );
+
+        List<string> states = [];
+        int wallSamples = 0;
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && (instrument.Name == "bridgebeats.queue.message.wall.duration"
+                    || instrument.Name == "bridgebeats.queue.saga.leg.completed.total")) {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( instrument, _, _, _ ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") { wallSamples++; }
+        } );
+        meterListener.SetMeasurementEventCallback<long>( ( instrument, _, tags, _ ) => {
+            if (instrument.Name == "bridgebeats.queue.saga.leg.completed.total") {
+                foreach (KeyValuePair<string, object?> tag in tags) {
+                    if (tag.Key == "saga_state") { states.Add( tag.Value?.ToString( ) ?? string.Empty ); }
+                }
+            }
+        } );
+        meterListener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 3, wallSamples );
+        CollectionAssert.AreEquivalent( new[] { "committed", "committed", "committed" }, states );
+    }
+
+    /// <summary>Spotify observation listeners do not change saga, queue, or acknowledgment calls.</summary>
+    [TestMethod]
+    public async Task SpotifyLeg_MetricsListenerOnAndOff_HasIdenticalBusinessCallCounts( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> {
+                [TestTrackId] = new MusicLookupResult { Artist = "Artist", Title = "Title", ExternalId = "ISRC" }
+            } );
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( TestSagaId, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( new LookupSagaState {
+                SagaId = TestSagaId,
+                LookupKey = $"{LookupRequestType.SongIdLookup}:{SupportedProviders.Spotify}:{TestTrackId}",
+                LookupType = LookupRequestType.SongIdLookup,
+                LookupValue = TestTrackId,
+                InstanceToken = "test-instance"
+            } );
+
+        static int Count( Mock mock, string method ) => mock.Invocations.Count( invocation => invocation.Method.Name == method );
+        static int CountAtomicAcks( Mock mock ) => mock.Invocations.Count( invocation =>
+            invocation.Method.Name == nameof( IDatabase.ScriptEvaluateAsync )
+            && invocation.Arguments[2] is RedisValue[] arguments
+            && arguments.Length == 2 );
+        async Task<(int Gets, int Updates, int Acks)> RunAsync( bool listen ) {
+            using MeterListener? listener = listen ? new MeterListener( ) : null;
+            if (listener is not null) {
+                listener.InstrumentPublished = ( instrument, consumer ) => {
+                    if (instrument.Meter.Name == QueueMetrics.MeterName
+                        && instrument.Name == "bridgebeats.queue.saga.leg.completed.total") {
+                        consumer.EnableMeasurementEvents( instrument );
+                    }
+                };
+                listener.Start( );
+            }
+            int gets = Count( _sagaManagerMock, nameof( ISagaStateManager.GetAsync ) );
+            int updates = Count( _sagaManagerMock, nameof( ISagaStateManager.TryUpdateProviderStateAsync ) );
+            int acks = CountAtomicAcks( _dbMock );
+            await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+            return (Count( _sagaManagerMock, nameof( ISagaStateManager.GetAsync ) ) - gets,
+                Count( _sagaManagerMock, nameof( ISagaStateManager.TryUpdateProviderStateAsync ) ) - updates,
+                CountAtomicAcks( _dbMock ) - acks);
+        }
+
+        (int Gets, int Updates, int Acks) disabled = await RunAsync( false );
+        (int Gets, int Updates, int Acks) enabled = await RunAsync( true );
+        Assert.AreEqual( disabled, enabled );
+        Assert.AreEqual( 1, disabled.Gets );
+        Assert.AreEqual( 1, disabled.Updates );
+        Assert.AreEqual( 1, disabled.Acks );
+    }
+
+    /// <summary>Transient provider failure after dequeue requeues and produces one wall sample without a completed leg.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkTransientFailure_EmitsNoCompletedLegOrWallSample( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _dbMock.Setup( d => d.StreamRangeAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ), It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [entry] );
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XADD failed" ) );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "transient" ) );
+        int legSamples = 0;
+        int wallSamples = 0;
+        long enqueued = 0;
+        using MeterListener meterListener = new( );
+        meterListener.InstrumentPublished = ( instrument, listener ) => {
+            if (instrument.Meter.Name == QueueMetrics.MeterName
+                && (instrument.Name == "bridgebeats.queue.message.wall.duration"
+                    || instrument.Name == "bridgebeats.queue.saga.leg.completed.total"
+                    || instrument.Name == "bridgebeats.queue.enqueued.total")) {
+                listener.EnableMeasurementEvents( instrument );
+            }
+        };
+        meterListener.SetMeasurementEventCallback<double>( ( instrument, _, _, _ ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") { wallSamples++; }
+        } );
+        meterListener.SetMeasurementEventCallback<long>( ( instrument, _, _, _ ) => {
+            if (instrument.Name == "bridgebeats.queue.saga.leg.completed.total") { legSamples++; }
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") { enqueued++; }
+        } );
+        meterListener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 0, legSamples );
+        Assert.AreEqual( 1, wallSamples );
+        meterListener.RecordObservableInstruments( );
+        Assert.AreEqual( 0, enqueued, "A failed replacement XADD is not an accepted enqueue" );
+        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>An atomic replacement failure emits exactly one wall sample and no acceptance metrics.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkAtomicRequeueFailure_EmitsExactlyOneWallSample( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [entry] );
+        _ = _dbMock.Setup( d => d.StreamRangeAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<int?>( ), It.IsAny<Order>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ThrowsAsync( new HttpRequestException( "transient" ) );
+        _ = _dbMock.Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "atomic move failed" ) );
+        int wallSamples = 0;
+        long enqueued = 0;
+        long requeued = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name is "bridgebeats.queue.message.wall.duration"
+                or "bridgebeats.queue.enqueued.total"
+                or "bridgebeats.queue.requeued.total") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<double>( ( _, _, _, _ ) => wallSamples++ );
+        listener.SetMeasurementEventCallback<long>( ( instrument, measurement, _, _ ) => {
+            if (instrument.Name == "bridgebeats.queue.enqueued.total") _ = Interlocked.Add( ref enqueued, measurement );
+            if (instrument.Name == "bridgebeats.queue.requeued.total") _ = Interlocked.Add( ref requeued, measurement );
+        } );
+        listener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 1, wallSamples );
+        listener.RecordObservableInstruments( );
+        Assert.AreEqual( 0, enqueued, "A failed atomic move has no accepted replacement" );
+        Assert.AreEqual( 0, requeued, "A failed atomic move must not report successful cleanup" );
+    }
+
+    /// <summary>A replacement enqueue/XADD failure still emits exactly one wall sample.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkRejectionReplacementEnqueueFailure_EmitsExactlyOneWallSample( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk );
+        StreamEntry entry = BuildStreamEntry( request );
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) ).ReturnsAsync( [entry] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ThrowsAsync( new SpotifyBulkRejectedException( 400, null, SupportedProviders.Spotify ) );
+        _ = _dbMock.Setup( database => database.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
+                It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "XADD failed" ) );
+
+        int wallSamples = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<double>( ( _, _, _, _ ) => wallSamples++ );
+        listener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 1, wallSamples );
+        _dbMock.Verify( d => d.StreamAcknowledgeAsync(
+            It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ), It.IsAny<CommandFlags>( ) ), Times.Never );
+    }
+
+    /// <summary>A fallback single-id HTTP call emits its own provider duration in addition to the bulk call.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkFallback_EmitsIndividualProviderHttpDuration( ) {
+        QueuedLookupRequest request = MakeTrackRequest( TestTrackId, QueuePriority.Bulk ) with {
+            FallbackLookupType = LookupRequestType.IsrcLookup,
+            FallbackLookupValue = "US-FALLBACK"
+        };
+        _ = _dbMock.Setup( d => d.StreamLengthAsync( (RedisKey)TrackStream, It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( SpotifyConstants.MaxTracksPerBatchLookup );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [BuildStreamEntry( request )] );
+        _ = _lookupServiceMock.Setup( service => service.GetTracksByIdsAsync( It.IsAny<IEnumerable<string>>( ) ) )
+            .ReturnsAsync( new Dictionary<string, MusicLookupResult?> { [TestTrackId] = null } );
+        _ = _lookupServiceMock.Setup( service => service.GetInfoByISRCAsync( "US-FALLBACK" ) )
+            .ReturnsAsync( new MusicLookupResult { Artist = "Fallback", Title = "Track", ExternalId = "US-FALLBACK" } );
+
+        int providerHttpSamples = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.provider_http.duration") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<double>( ( _, _, _, _ ) => providerHttpSamples++ );
+        listener.Start( );
+
+        await CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 2, providerHttpSamples );
+    }
+
+    /// <summary>A dequeue exception before any message is returned emits no message wall sample.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkDequeueFailure_EmitsNoWallSample( ) {
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<long>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "NOGROUP No such key" ) );
+        int wallSamples = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.message.wall.duration") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<double>( ( _, _, _, _ ) => wallSamples++ );
+        listener.Start( );
+
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => CreateService( ).ProcessBulkTrackLookupsAsync( TestContext.CancellationToken ) );
+
+        Assert.AreEqual( 0, wallSamples );
+    }
+
+    /// <summary>Bulk dequeue rethrows NOGROUP from XAUTOCLAIM so the worker can repair groups.</summary>
+    [TestMethod]
+    public async Task BulkDequeue_WhenAutoClaimReportsNoGroup_RethrowsForWorkerRecovery( ) {
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<long>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "NOGROUP No such key" ) );
+        SpotifyBatchQueueHelper helper = CreateHelper( );
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => helper.DequeueTrackIdBatchAsync( 10, TestContext.CancellationToken ) );
+    }
+
+    /// <summary>Unknown-command XAUTOCLAIM errors degrade to own-PEL/new-entry recovery.</summary>
+    [TestMethod]
+    public async Task BulkDequeue_WhenAutoClaimIsUnsupported_FallsBackToOwnPelAndNewEntries( ) {
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<long>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "ERR unknown command 'XAUTOCLAIM'" ) );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( Array.Empty<StreamEntry>( ) );
+
+        IReadOnlyList<QueuedMessage<QueuedLookupRequest>> result =
+            await CreateHelper( ).DequeueTrackIdBatchAsync( 10, TestContext.CancellationToken );
+
+        Assert.IsEmpty( result );
+    }
+
+    /// <summary>Permission errors from XAUTOCLAIM propagate instead of being mislabeled unsupported.</summary>
+    [TestMethod]
+    public async Task BulkDequeue_WhenAutoClaimIsForbidden_PropagatesRedisError( ) {
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<long>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "NOPERM this user has no permissions" ) );
+
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => CreateHelper( ).DequeueTrackIdBatchAsync( 10, TestContext.CancellationToken ) );
+    }
+
+    /// <summary>XAUTOCLAIM receives only the budget left after own-consumer PEL recovery.</summary>
+    [TestMethod]
+    public async Task BulkDequeue_AutoClaimCountUsesRemainingBudget( ) {
+        StreamEntry ownPending = BuildStreamEntry( MakeTrackRequest( TestTrackId ) );
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                (RedisKey)TrackStream, It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.Is<RedisValue?>( position => position.HasValue && position.Value == "0-0" ),
+                It.IsAny<int?>( ), It.IsAny<bool>( ), It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( [ownPending] );
+
+        _ = await CreateHelper( ).DequeueTrackIdBatchAsync( 5, TestContext.CancellationToken );
+
+        _dbMock.Verify( d => d.StreamAutoClaimAsync(
+            (RedisKey)TrackStream,
+            It.IsAny<RedisValue>( ),
+            It.IsAny<RedisValue>( ),
+            It.IsAny<long>( ),
+            It.IsAny<RedisValue>( ),
+            4,
+            It.IsAny<CommandFlags>( ) ), Times.Once );
+    }
+
+    /// <summary>Redis read failures propagate while closing the specialized dequeue span.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkDequeue_ReadGroupFailure_EmitsScopedErrorTelemetry( ) {
+        _ = _dbMock.Setup( d => d.StreamReadGroupAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<RedisValue?>( ), It.IsAny<int?>( ), It.IsAny<bool>( ),
+                It.IsAny<TimeSpan?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ThrowsAsync( new RedisServerException( "READONLY" ) );
+        List<Activity> spans = [];
+        using ActivityListener listener = new( ) {
+            ShouldListenTo = source => source.Name == QueueMetrics.MeterName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => spans.Add( activity )
+        };
+        ActivitySource.AddActivityListener( listener );
+
+        _ = await Assert.ThrowsAsync<RedisServerException>(
+            ( ) => CreateHelper( ).DequeueTrackIdBatchAsync( 10, TestContext.CancellationToken ) );
+
+        Assert.Contains( activity => activity.OperationName == "queue.spotify.dequeue.pel_scan", spans );
+        Assert.IsGreaterThan( TimeSpan.Zero,
+            spans.Single( activity => activity.OperationName == "queue.spotify.dequeue.pel_scan" ).Duration );
+    }
+
+    /// <summary>XAUTOCLAIM deleted IDs are counted once as missing PEL entries.</summary>
+    [TestMethod]
+    public async Task SpotifyBulkDequeue_DeletedAutoClaimIds_EmitMissingPelCount( ) {
+        ConstructorInfo ctor = typeof( StreamAutoClaimResult )
+            .GetConstructors( BindingFlags.NonPublic | BindingFlags.Instance )[0];
+        StreamAutoClaimResult result = (StreamAutoClaimResult)ctor.Invoke(
+            [(RedisValue)"0-0", Array.Empty<StreamEntry>( ), new[] { (RedisValue)"1-0", (RedisValue)"2-0" } ] );
+        _ = _dbMock.Setup( d => d.StreamAutoClaimAsync(
+                It.IsAny<RedisKey>( ), It.IsAny<RedisValue>( ), It.IsAny<RedisValue>( ),
+                It.IsAny<long>( ), It.IsAny<RedisValue>( ), It.IsAny<int?>( ), It.IsAny<CommandFlags>( ) ) )
+            .ReturnsAsync( result );
+
+        int missing = 0;
+        using MeterListener listener = new( );
+        listener.InstrumentPublished = ( instrument, sub ) => {
+            if (instrument.Name == "bridgebeats.queue.dequeue.pel_scan.entries") sub.EnableMeasurementEvents( instrument );
+        };
+        listener.SetMeasurementEventCallback<long>( ( _, _, tags, _ ) => {
+            foreach (KeyValuePair<string, object?> tag in tags) {
+                if (tag.Key == "outcome" && tag.Value?.ToString( ) == "missing") missing++;
+            }
+        } );
+        listener.Start( );
+
+        _ = await CreateHelper( ).DequeueTrackIdBatchAsync( 10, TestContext.CancellationToken );
+
+        Assert.AreEqual( 2, missing );
+    }
+
+    /// <summary>Verifies decorated Spotify queues expose the generic consumer-group repair capability.</summary>
+    [TestMethod]
+    public async Task Decorator_EnsureConsumerGroups_DelegatesToInnerCapability( ) {
+        AssuringQueue inner = new( );
+        SpotifyBulkQueueDecorator decorator = new( inner, _redisMock.Object, _decoratorLoggerMock.Object );
+
+        await decorator.EnsureConsumerGroupsAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( 1, inner.EnsureCalls );
+    }
+
+    private sealed class AssuringQueue : IRequestQueue<QueuedLookupRequest>, IConsumerGroupAssurance {
+        public int EnsureCalls { get; private set; }
+        public Task EnsureConsumerGroupsAsync( CancellationToken cancellationToken = default ) {
+            EnsureCalls++;
+            return Task.CompletedTask;
+        }
+        public Task EnqueueAsync( QueuedLookupRequest request, QueuePriority priority, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<QueuedMessage<QueuedLookupRequest>?> DequeueAsync( CancellationToken cancellationToken = default ) => Task.FromResult<QueuedMessage<QueuedLookupRequest>?>( null );
+        public Task<QueuedMessage<QueuedLookupRequest>?> DequeueAsync( IRateLimitTracker rateLimitTracker, CancellationToken cancellationToken = default ) => Task.FromResult<QueuedMessage<QueuedLookupRequest>?>( null );
+        public Task AcknowledgeAsync( string messageId, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task RequeueAsync( string messageId, TimeSpan? delay = null, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<QueueDepth> GetDepthAsync( CancellationToken cancellationToken = default ) => Task.FromResult( new QueueDepth( 0, 0, 0, 0 ) );
+        public Task<IReadOnlyList<QueuedMessage<QueuedLookupRequest>>> GetDlqMessagesAsync( int limit, CancellationToken cancellationToken = default ) => Task.FromResult<IReadOnlyList<QueuedMessage<QueuedLookupRequest>>>( [] );
+        public Task RequeueFromDlqAsync( string messageId, QueuePriority priority, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task MoveToDlqAsync( string messageId, string reason, CancellationToken cancellationToken = default ) => Task.CompletedTask;
+        public Task<bool> DeleteFromDlqAsync( string messageId, CancellationToken cancellationToken = default ) => Task.FromResult( true );
+    }
+
     /// <summary>
     /// Builds a Spotify song-id <c>QueuedLookupRequest</c> for the given track id, priority, and
     /// attempt count, carrying the fixed test saga id.
@@ -870,6 +1597,7 @@ public class SpotifyBulkFlushTests {
         LookupType = LookupRequestType.SongIdLookup,
         LookupValue = trackId,
         SagaId = TestSagaId,
+        SagaInstanceToken = "test-instance",
         IsAlbum = false,
         OriginPriority = priority,
         AttemptCount = attemptCount
@@ -893,6 +1621,7 @@ public class SpotifyBulkFlushTests {
         LookupType = LookupRequestType.AlbumIdLookup,
         LookupValue = albumId,
         SagaId = TestSagaId,
+        SagaInstanceToken = "test-instance",
         IsAlbum = true,
         OriginPriority = priority,
         AttemptCount = attemptCount
@@ -904,13 +1633,14 @@ public class SpotifyBulkFlushTests {
     /// dequeue and requeue paths.
     /// </summary>
     /// <param name="request">The request to embed as the entry payload.</param>
+    /// <param name="id">The Redis stream entry id.</param>
     /// <returns>A stream entry carrying the serialized request and an enqueue timestamp.</returns>
-    private static StreamEntry BuildStreamEntry( QueuedLookupRequest request ) {
+    private static StreamEntry BuildStreamEntry( QueuedLookupRequest request, string id = "1234567890-0" ) {
         string payload = System.Text.Json.JsonSerializer.Serialize( request, s_jsonOptions );
         NameValueEntry[] fields = [
             new NameValueEntry( "payload", payload ),
             new NameValueEntry( "enqueuedAt", DateTimeOffset.UtcNow.ToString( "O" ) )
         ];
-        return new StreamEntry( (RedisValue)"1234567890-0", fields );
+        return new StreamEntry( (RedisValue)id, fields );
     }
 }

--- a/Tests/Unit/SpotifyBulkQueueDecoratorTests.cs
+++ b/Tests/Unit/SpotifyBulkQueueDecoratorTests.cs
@@ -63,18 +63,12 @@ public class SpotifyBulkQueueDecoratorTests {
         _ = _redisMock.Setup( r => r.GetDatabase( It.IsAny<int>( ), It.IsAny<object>( ) ) )
             .Returns( _databaseMock.Object );
 
-        // Default: any StreamAddAsync call succeeds (8-param overload used by StackExchange.Redis 2.13)
+        // Default: atomic XADD + wake publication succeeds.
         _ = _databaseMock
-            .Setup( d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            .Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .ReturnsAsync( (RedisValue)"1234567890-0" );
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"1234567890-0" ) );
 
         _decorator = new SpotifyBulkQueueDecorator( _innerQueueMock.Object, _redisMock.Object, _loggerMock.Object );
     }
@@ -136,16 +130,12 @@ public class SpotifyBulkQueueDecoratorTests {
         // Act
         await _decorator.EnqueueAsync( request, QueuePriority.Bulk, TestContext.CancellationToken );
 
-        // Assert — XADD was called exactly once, with the track-id stream key
+        // Assert — the atomic enqueue script targets the track-id stream.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                BulkTrackIdStream,
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == BulkTrackIdStream ),
+                It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Once
         );
@@ -155,6 +145,37 @@ public class SpotifyBulkQueueDecoratorTests {
             q => q.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ),
             Times.Never
         );
+    }
+
+    /// <summary>An isolated queue prefix is applied to the bulk stream and its wake channel.</summary>
+    [TestMethod]
+    public async Task EnqueueAsync_WithKeyPrefix_UsesOnlyPrefixedBulkKeyspace( ) {
+        SpotifyBulkQueueDecorator decorator = new(
+            _innerQueueMock.Object,
+            _redisMock.Object,
+            _loggerMock.Object,
+            keyPrefix: "isolated" );
+        QueuedLookupRequest request = CreateRequest(
+            LookupRequestType.SongIdLookup,
+            "3n3Ppam7vgaVa1iaRUc9Lp" );
+
+        await decorator.EnqueueAsync( request, QueuePriority.Bulk, TestContext.CancellationToken );
+
+        _databaseMock.Verify( database => database.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null
+                && keys.Length == 1
+                && keys[0] == "queue:isolated:spotify:bulk:track-id" ),
+            It.Is<RedisValue[]?>( arguments => arguments != null
+                && arguments.Length == 5
+                && arguments[4] == "queue:isolated:spotify:bulk:work" ),
+            It.IsAny<CommandFlags>( ) ), Times.Once );
+        _databaseMock.Verify( database => database.ScriptEvaluateAsync(
+            It.IsAny<string>( ),
+            It.Is<RedisKey[]?>( keys => keys != null
+                && keys.Any( key => key == BulkTrackIdStream ) ),
+            It.IsAny<RedisValue[]?>( ),
+            It.IsAny<CommandFlags>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -169,16 +190,12 @@ public class SpotifyBulkQueueDecoratorTests {
         // Act
         await _decorator.EnqueueAsync( request, QueuePriority.Bulk, TestContext.CancellationToken );
 
-        // Assert — XADD was called exactly once, with the album-id stream key
+        // Assert — the atomic enqueue script targets the album-id stream.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                BulkAlbumIdStream,
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == BulkAlbumIdStream ),
+                It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Once
         );
@@ -212,16 +229,10 @@ public class SpotifyBulkQueueDecoratorTests {
             Times.Once
         );
 
-        // Assert — no XADD to any stream
+        // Assert — no atomic bulk enqueue.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Never
         );
@@ -272,16 +283,10 @@ public class SpotifyBulkQueueDecoratorTests {
             Times.Once
         );
 
-        // Assert — no StreamAddAsync (no bulk-stream write)
+        // Assert — no bulk-stream write.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Never
         );
@@ -309,16 +314,10 @@ public class SpotifyBulkQueueDecoratorTests {
             Times.Once
         );
 
-        // Assert — no StreamAddAsync (no bulk-stream write)
+        // Assert — no bulk-stream write.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Never
         );
@@ -336,16 +335,12 @@ public class SpotifyBulkQueueDecoratorTests {
         // Act
         await _decorator.EnqueueAsync( request, QueuePriority.Background, TestContext.CancellationToken );
 
-        // Assert — XADD to the track-id stream
+        // Assert — atomic enqueue to the track-id stream.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                BulkTrackIdStream,
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == BulkTrackIdStream ),
+                It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Once
         );
@@ -369,16 +364,12 @@ public class SpotifyBulkQueueDecoratorTests {
         // Act
         await _decorator.EnqueueAsync( request, QueuePriority.Background, TestContext.CancellationToken );
 
-        // Assert — XADD to the album-id stream
+        // Assert — atomic enqueue to the album-id stream.
         _databaseMock.Verify(
-            d => d.StreamAddAsync(
-                BulkAlbumIdStream,
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ),
+                It.Is<RedisKey[]?>( keys => keys != null && keys.Length == 1 && keys[0] == BulkAlbumIdStream ),
+                It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ),
             Times.Once
         );
@@ -398,21 +389,15 @@ public class SpotifyBulkQueueDecoratorTests {
     [TestMethod]
     public async Task EnqueueAsync_WhenSongIdLookup_ShouldSerializePayloadField( ) {
         // Arrange
-        NameValueEntry[]? capturedFields = null;
+        RedisValue[]? capturedArguments = null;
         _ = _databaseMock
-            .Setup( d => d.StreamAddAsync(
-                It.IsAny<RedisKey>( ),
-                It.IsAny<NameValueEntry[]>( ),
-                It.IsAny<RedisValue?>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<bool>( ),
-                It.IsAny<long?>( ),
-                It.IsAny<StreamTrimMode>( ),
+            .Setup( d => d.ScriptEvaluateAsync(
+                It.IsAny<string>( ), It.IsAny<RedisKey[]?>( ), It.IsAny<RedisValue[]?>( ),
                 It.IsAny<CommandFlags>( ) ) )
-            .Callback( ( RedisKey _, NameValueEntry[] fields, RedisValue? _, long? _, bool _, long? _, StreamTrimMode _, CommandFlags _ ) => {
-                capturedFields = fields;
+            .Callback( ( string _, RedisKey[]? _, RedisValue[]? arguments, CommandFlags _ ) => {
+                capturedArguments = arguments;
             } )
-            .ReturnsAsync( (RedisValue)"1234567890-0" );
+            .ReturnsAsync( (RedisResult)RedisResult.Create( (RedisValue)"1234567890-0" ) );
 
         QueuedLookupRequest request = CreateRequest( LookupRequestType.SongIdLookup, "3n3Ppam7vgaVa1iaRUc9Lp" );
 
@@ -420,9 +405,9 @@ public class SpotifyBulkQueueDecoratorTests {
         await _decorator.EnqueueAsync( request, QueuePriority.Bulk, TestContext.CancellationToken );
 
         // Assert — fields contain "payload" and "enqueuedAt"
-        Assert.IsNotNull( capturedFields );
-        string? payloadField = (string?)capturedFields.FirstOrDefault( f => f.Name == "payload" ).Value;
-        string? enqueuedAtField = (string?)capturedFields.FirstOrDefault( f => f.Name == "enqueuedAt" ).Value;
+        Assert.IsNotNull( capturedArguments );
+        string? payloadField = capturedArguments[1];
+        string? enqueuedAtField = capturedArguments[3];
         Assert.IsNotNull( payloadField, "payload field must be present" );
         Assert.IsNotNull( enqueuedAtField, "enqueuedAt field must be present" );
 

--- a/Tests/Unit/SpotifyBulkStatusMappingTests.cs
+++ b/Tests/Unit/SpotifyBulkStatusMappingTests.cs
@@ -146,6 +146,27 @@ public class SpotifyBulkStatusMappingTests {
             ( ) => svc.GetAlbumsByIdsAsync( [TestAlbumId] ) );
     }
 
+    /// <summary>Direct provider authentication failures remain operational failures, not no-results.</summary>
+    [TestMethod]
+    [DataRow( 401 )]
+    [DataRow( 403 )]
+    public async Task GetInfoByISRCAsync_WhenAuthenticationFails_ShouldThrow( int statusCode ) {
+        SpotifyLookupService service = CreateService( new HttpResponseMessage( (HttpStatusCode)statusCode ) );
+
+        HttpRequestException exception = await Assert.ThrowsExactlyAsync<HttpRequestException>(
+            ( ) => service.GetInfoByISRCAsync( "USRC17607839" ) );
+
+        Assert.AreEqual( (HttpStatusCode)statusCode, exception.StatusCode );
+    }
+
+    /// <summary>A deterministic direct-provider 404 remains an authoritative no-result.</summary>
+    [TestMethod]
+    public async Task GetInfoByISRCAsync_WhenNotFound_ShouldReturnNull( ) {
+        SpotifyLookupService service = CreateService( new HttpResponseMessage( HttpStatusCode.NotFound ) );
+
+        Assert.IsNull( await service.GetInfoByISRCAsync( "USRC17607839" ) );
+    }
+
     // ──── Harness ───────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/Tests/Unit/SpotifyBulkStatusMappingTests.cs
+++ b/Tests/Unit/SpotifyBulkStatusMappingTests.cs
@@ -2,8 +2,10 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
+using BridgeBeats.Core.Domain.Providers.Common;
 using BridgeBeats.Core.Domain.Providers.Spotify;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -15,15 +17,15 @@ namespace BridgeBeats.Tests.Unit;
 /// <see cref="SpotifyLookupService"/>'s bulk methods (<c>GetTracksByIdsAsync</c> and
 /// <c>GetAlbumsByIdsAsync</c>). Each test drives the concrete service through a stub
 /// <see cref="HttpMessageHandler"/>; no interfaces are substituted at the lookup-service
-/// boundary, so a change to the throw predicate in <c>NewBulkMusicApiRequest</c> is
-/// immediately observable here.
+/// boundary. The API stub includes the terminal provider-rate-limit handler used by the production
+/// named client, so status classification is exercised at its transport boundary.
 /// </summary>
 /// <remarks>
 /// Coverage panel:
 /// <list type="bullet">
 ///   <item>400 → <see cref="SpotifyBulkRejectedException"/> (HttpStatusCode == 400)</item>
 ///   <item>401, 403, 404, 500, 503 → empty dictionary, no throw (negative panel)</item>
-///   <item>429 → <see cref="RetryAfterExceededException"/> (rate-limit precedence)</item>
+///   <item>429 → <see cref="ProviderRateLimitException"/> (rate-limit precedence)</item>
 /// </list>
 /// All six panels are exercised against both <c>GetTracksByIdsAsync</c> and
 /// <c>GetAlbumsByIdsAsync</c>.
@@ -116,33 +118,33 @@ public class SpotifyBulkStatusMappingTests {
             $"GetAlbumsByIdsAsync must return an empty dictionary for HTTP {statusCode}, not throw" );
     }
 
-    // ──── 429 → RetryAfterExceededException ────────────────────────────────────
+    // ──── 429 → ProviderRateLimitException ─────────────────────────────────────
 
     /// <summary>
     /// Verifies that a 429 response from the tracks bulk endpoint throws
-    /// <see cref="RetryAfterExceededException"/>, confirming rate-limit precedence over the 400 path.
+    /// <see cref="ProviderRateLimitException"/>, confirming rate-limit precedence over the 400 path.
     /// </summary>
     [TestMethod]
-    public async Task GetTracksByIdsAsync_When429_ShouldThrowRetryAfterExceededException( ) {
+    public async Task GetTracksByIdsAsync_When429_ShouldThrowProviderRateLimitException( ) {
         HttpResponseMessage rateLimitResponse = new( HttpStatusCode.TooManyRequests );
         rateLimitResponse.Headers.RetryAfter = new RetryConditionHeaderValue( TimeSpan.FromSeconds( 60 ) );
         SpotifyLookupService svc = CreateService( rateLimitResponse );
 
-        _ = await Assert.ThrowsExactlyAsync<RetryAfterExceededException>(
+        _ = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
             ( ) => svc.GetTracksByIdsAsync( [TestTrackId] ) );
     }
 
     /// <summary>
     /// Verifies that a 429 response from the albums bulk endpoint throws
-    /// <see cref="RetryAfterExceededException"/>, confirming rate-limit precedence over the 400 path.
+    /// <see cref="ProviderRateLimitException"/>, confirming rate-limit precedence over the 400 path.
     /// </summary>
     [TestMethod]
-    public async Task GetAlbumsByIdsAsync_When429_ShouldThrowRetryAfterExceededException( ) {
+    public async Task GetAlbumsByIdsAsync_When429_ShouldThrowProviderRateLimitException( ) {
         HttpResponseMessage rateLimitResponse = new( HttpStatusCode.TooManyRequests );
         rateLimitResponse.Headers.RetryAfter = new RetryConditionHeaderValue( TimeSpan.FromSeconds( 60 ) );
         SpotifyLookupService svc = CreateService( rateLimitResponse );
 
-        _ = await Assert.ThrowsExactlyAsync<RetryAfterExceededException>(
+        _ = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
             ( ) => svc.GetAlbumsByIdsAsync( [TestAlbumId] ) );
     }
 
@@ -193,7 +195,10 @@ public class SpotifyBulkStatusMappingTests {
         SpotifyTokenHandler tokenHandler = new( credentials, tokenFactory.Object, tokenLogger.Object );
 
         // API-endpoint stub: returns apiResponse for every GET to the spotify-api client.
-        HttpClient apiClient = new( new FixedResponseHandler( apiResponse ) ) {
+        TerminalProviderRateLimitHandler terminalRateLimitHandler = new( SupportedProviders.Spotify ) {
+            InnerHandler = new FixedResponseHandler( apiResponse )
+        };
+        HttpClient apiClient = new( terminalRateLimitHandler ) {
             BaseAddress = new Uri( "https://api.spotify.com/v1/" )
         };
         Mock<IHttpClientFactory> apiFactory = new( );

--- a/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
+++ b/Tests/Unit/StaleCacheRefreshBackgroundServiceTests.cs
@@ -93,17 +93,19 @@ public class StaleCacheRefreshBackgroundServiceTests {
                 It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( MakeMinimalSaga( ) );
         _ = _sagaManagerMock
-            .Setup( m => m.InitializeProviderStatesAsync(
+            .Setup( m => m.TryInitializeProviderStatesAsync(
                 It.IsAny<string>( ),
                 It.IsAny<IEnumerable<SupportedProviders>>( ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .ReturnsAsync( true );
         _ = _sagaManagerMock
-            .Setup( m => m.UpdateProviderStateAsync(
+            .Setup( m => m.TryUpdateProviderStateAsync(
                 It.IsAny<string>( ),
                 It.IsAny<ProviderLookupState>( ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( ) ) )
-            .Returns( Task.CompletedTask );
+            .ReturnsAsync( true );
 
         _enabledProviders = [SupportedProviders.Spotify];
 
@@ -1213,7 +1215,7 @@ public class StaleCacheRefreshBackgroundServiceTests {
     #region Mode-B Pin — Registration Set
 
     /// <summary>
-    /// THE MODE-B PIN: InitializeProviderStatesAsync receives the exact enqueued-leg provider set,
+    /// THE MODE-B PIN: TryInitializeProviderStatesAsync receives the exact enqueued-leg provider set,
     /// NOT all enabledProviders. For a record where only Spotify+Apple are present/parseable and there
     /// is no external id, Tidal must NOT appear in the registered set.
     /// </summary>
@@ -1239,18 +1241,19 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         IEnumerable<SupportedProviders>? capturedProviders = null;
         _ = _sagaManagerMock
-            .Setup( m => m.InitializeProviderStatesAsync(
+            .Setup( m => m.TryInitializeProviderStatesAsync(
                 It.IsAny<string>( ),
                 It.IsAny<IEnumerable<SupportedProviders>>( ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( ) ) )
-            .Callback<string, IEnumerable<SupportedProviders>, CancellationToken>(
-                ( _, providers, _ ) => capturedProviders = [.. providers] )
-            .Returns( Task.CompletedTask );
+            .Callback<string, IEnumerable<SupportedProviders>, string, CancellationToken>(
+                ( _, providers, _, _ ) => capturedProviders = [.. providers] )
+            .ReturnsAsync( true );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
         await service.RunRefreshPassAsync( TestContext.CancellationToken );
 
-        Assert.IsNotNull( capturedProviders, "InitializeProviderStatesAsync must be called" );
+        Assert.IsNotNull( capturedProviders, "TryInitializeProviderStatesAsync must be called" );
         HashSet<SupportedProviders> registered = [.. capturedProviders];
 
         // Positive: exactly {Spotify, Apple} registered.
@@ -1286,11 +1289,11 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         IEnumerable<SupportedProviders>? capturedProviders = null;
         _ = _sagaManagerMock
-            .Setup( m => m.InitializeProviderStatesAsync(
-                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ) )
-            .Callback<string, IEnumerable<SupportedProviders>, CancellationToken>(
-                ( _, providers, _ ) => capturedProviders = [.. providers] )
-            .Returns( Task.CompletedTask );
+            .Setup( m => m.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback<string, IEnumerable<SupportedProviders>, string, CancellationToken>(
+                ( _, providers, _, _ ) => capturedProviders = [.. providers] )
+            .ReturnsAsync( true );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
         await service.RunRefreshPassAsync( TestContext.CancellationToken );
@@ -1323,11 +1326,11 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         IEnumerable<SupportedProviders>? capturedProviders = null;
         _ = _sagaManagerMock
-            .Setup( m => m.InitializeProviderStatesAsync(
-                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<CancellationToken>( ) ) )
-            .Callback<string, IEnumerable<SupportedProviders>, CancellationToken>(
-                ( _, providers, _ ) => capturedProviders = [.. providers] )
-            .Returns( Task.CompletedTask );
+            .Setup( m => m.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback<string, IEnumerable<SupportedProviders>, string, CancellationToken>(
+                ( _, providers, _, _ ) => capturedProviders = [.. providers] )
+            .ReturnsAsync( true );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
         await service.RunRefreshPassAsync( TestContext.CancellationToken );
@@ -1337,6 +1340,61 @@ public class StaleCacheRefreshBackgroundServiceTests {
         Assert.DoesNotContain( SupportedProviders.Tidal, registered,
             "Tidal has no leg and must not be registered" );
         Assert.Contains( SupportedProviders.Spotify, registered );
+    }
+
+    /// <summary>
+    /// A stale record with no derivable refresh legs still consumes sweep attempts and is promoted
+    /// to review on the third selection, after which the unresolved index suppresses selection.
+    /// </summary>
+    [TestMethod]
+    public async Task RunRefreshPass_NoLegRecord_QuarantinesAfterThreeSweepsAndSuppressesLaterSelection( ) {
+        const string RecordUri = "at://no-leg-quarantine";
+        MediaLinkResult record = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -60 ) };
+        record.Results[SupportedProviders.Spotify] = new MusicLookupResult {
+            URL = string.Empty,
+            ExternalId = string.Empty,
+            IsAlbum = false
+        };
+        _enabledProviders = [SupportedProviders.Spotify];
+        SetupRecordList( [(RecordUri, record)] );
+
+        int attempts = 0;
+        bool promoted = false;
+        _ = _refreshReviewStoreMock.Setup( store => store.IncrementSweepAttemptAsync(
+                RecordUri, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => ++attempts );
+        _ = _refreshReviewStoreMock.Setup( store => store.GetUnresolvedAsync( It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => promoted
+                ? [new RefreshReviewEntry {
+                    SourceRecordUri = RecordUri,
+                    SagaId = "no-leg-saga",
+                    LookupType = LookupRequestType.UriLookup,
+                    LookupValue = RecordUri
+                }]
+                : [] );
+        _ = _refreshReviewStoreMock.Setup( store => store.PromoteDirectAsync(
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback( ( ) => promoted = true )
+            .Returns( Task.CompletedTask );
+
+        StaleCacheRefreshBackgroundService service = CreateService( );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+
+        Assert.AreEqual( StaleCacheRefreshBackgroundService.MaxRefreshSweepAttemptsBeforeReview, attempts );
+        _refreshReviewStoreMock.Verify( store => store.PromoteDirectAsync(
+            It.Is<RefreshReviewEntry>( entry => entry.SourceRecordUri == RecordUri
+                && entry.LookupType == LookupRequestType.UriLookup
+                && entry.LookupValue == RecordUri
+                && entry.SourceRecordCid == "bafyreitestcid" ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _sagaManagerMock.Verify( manager => manager.GetOrCreateAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ), It.IsAny<string>( ),
+            It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     #endregion
@@ -1518,6 +1576,112 @@ public class StaleCacheRefreshBackgroundServiceTests {
         );
     }
 
+    /// <summary>
+    /// A shared deterministic saga is owned by record A while record B is observed across three
+    /// sweeps. B is promoted directly from its concrete context without overwriting A's pending
+    /// slot or deleting the shared active saga.
+    /// </summary>
+    [TestMethod]
+    public async Task RunRefreshPass_SharedSaga_ThreeSweepsPromotesBWithoutDeletingAOwner( ) {
+        const string RecordA = "at://shared/a";
+        const string RecordB = "at://shared/b";
+        const string SharedIsrc = "SHARED_THREE_SWEEP";
+        SetupRecordList( [
+            MakeStaleRecord( RecordA, DateTime.UtcNow.AddDays( -60 ), isrc: SharedIsrc ),
+            MakeStaleRecord( RecordB, DateTime.UtcNow.AddDays( -60 ), isrc: SharedIsrc )
+        ] );
+
+        string sharedSagaId = ISagaStateManager.GenerateSagaId( $"{LookupRequestType.IsrcLookup}:{SharedIsrc}" );
+        LookupSagaState activeSaga = MakeMinimalSaga( ) with { SagaId = sharedSagaId, InstanceToken = "owner-a" };
+        int getCount = 0;
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync(
+                It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => Interlocked.Increment( ref getCount ) == 1 ? null : activeSaga );
+        _ = _sagaManagerMock.Setup( manager => manager.GetOrCreateAsync(
+                It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<LookupRequestType>( ),
+                It.IsAny<string>( ), It.IsAny<QueuePriority?>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( activeSaga );
+        Dictionary<string, int> attempts = new( StringComparer.Ordinal );
+        _ = _refreshReviewStoreMock.Setup( store => store.IncrementSweepAttemptAsync(
+                It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( string uri, CancellationToken _ ) => {
+                if (uri == RecordA) { return 1; }
+                attempts[uri] = attempts.GetValueOrDefault( uri ) + 1;
+                return attempts[uri];
+            } );
+        RefreshReviewEntry ownerContext = new( ) {
+            SourceRecordUri = RecordA,
+            SagaId = activeSaga.SagaId,
+            InstanceToken = activeSaga.InstanceToken,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = SharedIsrc
+        };
+        _ = _refreshReviewStoreMock.Setup( store => store.GetPendingAsync(
+                RecordA, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( ownerContext );
+        _ = _refreshReviewStoreMock.Setup( store => store.GetPendingAsync(
+                RecordB, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( (RefreshReviewEntry?)null );
+        RefreshReviewEntry? promoted = null;
+        _ = _refreshReviewStoreMock.Setup( store => store.PromoteDirectAsync(
+                It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .Callback<RefreshReviewEntry, string, CancellationToken>( ( entry, _, _ ) => promoted = entry )
+            .Returns( Task.CompletedTask );
+
+        StaleCacheRefreshBackgroundService service = CreateService( );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+
+        _refreshReviewStoreMock.Verify( store => store.PromoteDirectAsync(
+            It.Is<RefreshReviewEntry>( entry => entry.SourceRecordUri == RecordB ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        Assert.IsNotNull( promoted );
+        Assert.AreEqual( activeSaga.SagaId, promoted!.SagaId );
+        Assert.AreEqual( activeSaga.InstanceToken, promoted.InstanceToken );
+        _refreshReviewStoreMock.Verify( store => store.MarkUnresolvedAsync(
+            It.Is<RefreshReviewEntry>( entry => entry.SourceRecordUri == RecordA ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync(
+            It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+    }
+
+    /// <summary>An active owner is quarantined after three sweeps without deleting its saga.</summary>
+    [TestMethod]
+    public async Task RunRefreshPass_ActiveOwner_ReachesThreeSweepsWithoutDeletingSaga( ) {
+        const string RecordUri = "at://active-owner";
+        const string Isrc = "ACTIVE_OWNER_THREE_SWEEPS";
+        SetupRecordList( [MakeStaleRecord( RecordUri, DateTime.UtcNow.AddDays( -60 ), Isrc )] );
+        string sagaId = ISagaStateManager.GenerateSagaId( $"{LookupRequestType.IsrcLookup}:{Isrc}" );
+        LookupSagaState activeSaga = MakeMinimalSaga( ) with { SagaId = sagaId, InstanceToken = "active-owner" };
+        _ = _sagaManagerMock.Setup( manager => manager.GetAsync( sagaId, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( activeSaga );
+        int attempts = 0;
+        _ = _refreshReviewStoreMock.Setup( store => store.IncrementSweepAttemptAsync( RecordUri, It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( ( ) => ++attempts );
+        RefreshReviewEntry pending = new( ) {
+            SourceRecordUri = RecordUri,
+            SagaId = sagaId,
+            InstanceToken = activeSaga.InstanceToken,
+            LookupType = LookupRequestType.IsrcLookup,
+            LookupValue = Isrc
+        };
+        _ = _refreshReviewStoreMock.Setup( store => store.GetPendingAsync( RecordUri, It.IsAny<CancellationToken>( ) ) ).ReturnsAsync( pending );
+
+        StaleCacheRefreshBackgroundService service = CreateService( );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+        await service.RunRefreshPassAsync( TestContext.CancellationToken );
+
+        _refreshReviewStoreMock.Verify( store => store.PromoteDirectAsync(
+            It.Is<RefreshReviewEntry>( entry => entry.SourceRecordUri == RecordUri && entry.InstanceToken == activeSaga.InstanceToken ),
+            It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        _refreshReviewStoreMock.Verify( store => store.MarkUnresolvedAsync(
+            It.IsAny<RefreshReviewEntry>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _sagaManagerMock.Verify( manager => manager.TryDeleteAsync( It.IsAny<string>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _refreshReviewStoreMock.Verify( store => store.RegisterPendingAsync( It.IsAny<RefreshReviewEntry>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.EnqueueAsync( It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
     #endregion
 
     #region Fire-and-Forget Tests
@@ -1543,13 +1707,69 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         _sagaManagerMock.Verify(
             m => m.GetAsync( It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ),
-            Times.Never
+            Times.Exactly( 2 )
         );
     }
 
     #endregion
 
     #region Reliability Tests
+
+    /// <summary>A replaced saga before token-fenced initialization leaves no pending context or queued legs.</summary>
+    [TestMethod]
+    public async Task EnqueueRecordAsync_WhenInitializationFenceIsLost_DoesNotRegisterOrEnqueue( ) {
+        _enabledProviders = [SupportedProviders.Spotify];
+        SetupRecordList( [MakeStaleRecord( "at://init-replaced", DateTime.UtcNow.AddDays( -60 ), isrc: "INIT_REPLACED" )] );
+        _ = _sagaManagerMock.Setup( manager => manager.TryInitializeProviderStatesAsync(
+                It.IsAny<string>( ), It.IsAny<IEnumerable<SupportedProviders>>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        await CreateService( ).RunRefreshPassAsync( TestContext.CancellationToken );
+
+        _refreshReviewStoreMock.Verify( store => store.RegisterPendingAsync(
+            It.IsAny<RefreshReviewEntry>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+        _queueMock.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
+
+    /// <summary>A replacement during enqueue-failure completion stops the remaining legs without mutation.</summary>
+    [TestMethod]
+    public async Task EnqueueRecordAsync_WhenEnqueueFailureCasIsLost_DoesNotEnqueueRemainingLegs( ) {
+        _enabledProviders = [SupportedProviders.Spotify, SupportedProviders.AppleMusic];
+        MediaLinkResult record = new( ) { LookedUpAt = DateTime.UtcNow.AddDays( -60 ) };
+        record.Results[SupportedProviders.Spotify] = new MusicLookupResult {
+            URL = "https://open.spotify.com/track/3SPOTID12345",
+            ExternalId = "CAS_LOST",
+            IsAlbum = false
+        };
+        record.Results[SupportedProviders.AppleMusic] = new MusicLookupResult {
+            URL = "https://music.apple.com/us/album/x/1234567890?i=9876543210",
+            ExternalId = "CAS_LOST",
+            IsAlbum = false
+        };
+        SetupRecordList( [("at://enqueue-cas-lost", record)] );
+
+        Mock<IRequestQueue<QueuedLookupRequest>> spotifyQueue = new( );
+        Mock<IRequestQueue<QueuedLookupRequest>> appleQueue = new( );
+        _ = spotifyQueue.Setup( queue => queue.EnqueueAsync(
+                It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .ThrowsAsync( new InvalidOperationException( "enqueue failed" ) );
+        _ = appleQueue.Setup( queue => queue.EnqueueAsync(
+                It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ) )
+            .Returns( Task.CompletedTask );
+        _ = _queueResolverMock.Setup( resolver => resolver.GetQueue( SupportedProviders.Spotify ) ).Returns( spotifyQueue.Object );
+        _ = _queueResolverMock.Setup( resolver => resolver.GetQueue( SupportedProviders.AppleMusic ) ).Returns( appleQueue.Object );
+        _ = _sagaManagerMock.Setup( manager => manager.TryUpdateProviderStateAsync(
+                It.IsAny<string>( ), It.IsAny<ProviderLookupState>( ), It.IsAny<string>( ), It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( false );
+
+        await CreateService( ).RunRefreshPassAsync( TestContext.CancellationToken );
+
+        _refreshReviewStoreMock.Verify( store => store.RegisterPendingAsync(
+            It.IsAny<RefreshReviewEntry>( ), It.IsAny<CancellationToken>( ) ), Times.Once );
+        appleQueue.Verify( queue => queue.EnqueueAsync(
+            It.IsAny<QueuedLookupRequest>( ), It.IsAny<QueuePriority>( ), It.IsAny<CancellationToken>( ) ), Times.Never );
+    }
 
     /// <summary>
     /// When enqueuing one record throws, it is counted as an error and skipped; the remaining
@@ -1764,12 +1984,13 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         List<ProviderLookupState> recordedStates = [];
         _ = _sagaManagerMock
-            .Setup( m => m.UpdateProviderStateAsync(
+            .Setup( m => m.TryUpdateProviderStateAsync(
                 It.IsAny<string>( ),
                 It.IsAny<ProviderLookupState>( ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( ) ) )
-            .Callback<string, ProviderLookupState, CancellationToken>( ( _, state, _ ) => recordedStates.Add( state ) )
-            .Returns( Task.CompletedTask );
+            .Callback<string, ProviderLookupState, string, CancellationToken>( ( _, state, _, _ ) => recordedStates.Add( state ) )
+            .ReturnsAsync( true );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
         await service.RunRefreshPassAsync( TestContext.CancellationToken );
@@ -1788,11 +2009,6 @@ public class StaleCacheRefreshBackgroundServiceTests {
         Assert.DoesNotContain( s => s.Provider == SupportedProviders.AppleMusic, recordedStates,
             "A successful leg must not be recorded as failed" );
 
-        // SetIsPartialAsync must never be called.
-        _sagaManagerMock.Verify(
-            m => m.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "SetIsPartialAsync must not be called when a leg fails; marking the provider complete-as-failed is sufficient" );
     }
 
     /// <summary>
@@ -1825,12 +2041,13 @@ public class StaleCacheRefreshBackgroundServiceTests {
 
         List<ProviderLookupState> recordedStates = [];
         _ = _sagaManagerMock
-            .Setup( m => m.UpdateProviderStateAsync(
+            .Setup( m => m.TryUpdateProviderStateAsync(
                 It.IsAny<string>( ),
                 It.IsAny<ProviderLookupState>( ),
+                It.IsAny<string>( ),
                 It.IsAny<CancellationToken>( ) ) )
-            .Callback<string, ProviderLookupState, CancellationToken>( ( _, state, _ ) => recordedStates.Add( state ) )
-            .Returns( Task.CompletedTask );
+            .Callback<string, ProviderLookupState, string, CancellationToken>( ( _, state, _, _ ) => recordedStates.Add( state ) )
+            .ReturnsAsync( true );
 
         StaleCacheRefreshBackgroundService service = CreateService( );
 
@@ -1845,11 +2062,6 @@ public class StaleCacheRefreshBackgroundServiceTests {
         Assert.IsTrue( recordedStates.All( s => !s.IsSuccess ),
             "All failing legs must be marked IsSuccess=false" );
 
-        // SetIsPartialAsync must never be called.
-        _sagaManagerMock.Verify(
-            m => m.SetIsPartialAsync( It.IsAny<string>( ), It.IsAny<bool>( ), It.IsAny<CancellationToken>( ) ),
-            Times.Never,
-            "SetIsPartialAsync must not be called when all legs fail" );
     }
 
     #endregion
@@ -2128,7 +2340,8 @@ public class StaleCacheRefreshBackgroundServiceTests {
             LookupKey = "test:key",
             LookupType = LookupRequestType.IsrcLookup,
             LookupValue = "TESTISRC",
-            OriginPriority = QueuePriority.Bulk
+            OriginPriority = QueuePriority.Bulk,
+            InstanceToken = "test-instance"
         };
 
     #endregion

--- a/Tests/Unit/StatisticsControllerTests.cs
+++ b/Tests/Unit/StatisticsControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Web.Controllers;
@@ -252,7 +253,7 @@ public class StatisticsControllerTests {
             .Setup( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ) )
             .ReturnsAsync( liveStatus );
 
-        StatisticsController controller = CreateController( );
+        StatisticsController controller = CreateController( WithAdminClaim( "bootstrap-admin" ) );
 
         IActionResult result = await controller.Index( );
 
@@ -262,6 +263,26 @@ public class StatisticsControllerTests {
         Assert.IsTrue( model.CacheBootstrapStatus.IsRunning );
         Assert.AreEqual( 247404, model.CacheBootstrapStatus.LastSuccessCount );
         Assert.AreEqual( 100, model.TotalRecords );
+    }
+
+    [TestMethod]
+    public async Task Index_WithAuthenticatedLowRole_DoesNotFetchOrExposeBootstrapStatus( ) {
+        CacheBootstrapStatus sentinel = new( ) { IsRunning = true, LastSuccessCount = 987654 };
+        _ = _statisticsServiceMock.Setup( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ) )
+            .ReturnsAsync( sentinel );
+        LookupStatistics cached = CreateTestStatistics( ).WithBootstrapStatus( new CacheBootstrapStatus { LastSuccessCount = 111111 } );
+        _ = _statisticsServiceMock.Setup( x => x.GetStatus( ) )
+            .Returns( new StatisticsStatus { Snapshot = cached } );
+
+        ClaimsPrincipal lowRole = new( new ClaimsIdentity(
+            [new Claim( ClaimTypes.Name, "reader" ), new Claim( ClaimTypes.Role, "Reader" )], "test" ) );
+        StatisticsController controller = CreateController( lowRole );
+
+        ViewResult result = Assert.IsInstanceOfType<ViewResult>( await controller.Index( ) );
+        LookupStatistics model = Assert.IsInstanceOfType<LookupStatistics>( result.Model );
+        Assert.IsNull( model.CacheBootstrapStatus );
+        Assert.AreNotEqual( 111111, model.CacheBootstrapStatus?.LastSuccessCount );
+        _statisticsServiceMock.Verify( x => x.GetLiveBootstrapStatusAsync( It.IsAny<CancellationToken>( ) ), Times.Never );
     }
 
     /// <summary>
@@ -454,7 +475,7 @@ public class StatisticsControllerTests {
     /// </summary>
     private static ClaimsPrincipal WithAdminClaim( string adminId ) {
         return new ClaimsPrincipal( new ClaimsIdentity(
-            [new Claim( ClaimTypes.NameIdentifier, adminId )],
+            [new Claim( ClaimTypes.NameIdentifier, adminId ), new Claim( ClaimTypes.Role, Roles.AspireDashboardAccess )],
             authenticationType: "Test"
         ) );
     }

--- a/Tests/Unit/TerminalProviderRateLimitHandlerTests.cs
+++ b/Tests/Unit/TerminalProviderRateLimitHandlerTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Headers;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
+using BridgeBeats.Core.Domain.Extensions;
+using BridgeBeats.Core.Domain.Providers.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+
+namespace BridgeBeats.Tests.Unit;
+
+/// <summary>
+/// Verifies terminal provider-rate-limit classification and its ordering outside Polly's standard
+/// resilience pipeline.
+/// </summary>
+[TestClass]
+public class TerminalProviderRateLimitHandlerTests {
+    /// <summary>MSTest context supplying cooperative cancellation.</summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    /// <summary>A terminal 429 preserves the provider's Retry-After delay and provider identity.</summary>
+    [TestMethod]
+    public async Task SendAsync_WhenFinalResponseIs429_ThrowsTypedRateLimit( ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        response.Headers.RetryAfter = new RetryConditionHeaderValue( TimeSpan.FromSeconds( 42 ) );
+        using HttpMessageInvoker invoker = CreateInvoker( response, SupportedProviders.AppleMusic );
+        using HttpRequestMessage request = new( HttpMethod.Get, "https://api.music.apple.com/v1/catalog/us/songs" );
+
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => invoker.SendAsync( request, CancellationToken.None )
+        );
+
+        Assert.AreEqual( TimeSpan.FromSeconds( 42 ), exception.RetryAfterValue );
+        Assert.AreEqual( SupportedProviders.AppleMusic, exception.Provider );
+        Assert.AreEqual( request.RequestUri, exception.RequestUri );
+    }
+
+    /// <summary>A terminal 429 without Retry-After uses the conservative queue delay.</summary>
+    [TestMethod]
+    public async Task SendAsync_WhenRetryAfterIsMissing_UsesThirtySecondFallback( ) {
+        using HttpResponseMessage response = new( HttpStatusCode.TooManyRequests );
+        using HttpMessageInvoker invoker = CreateInvoker( response, SupportedProviders.Tidal );
+        using HttpRequestMessage request = new( HttpMethod.Get, "https://openapi.tidal.com/v2/tracks/123" );
+
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => invoker.SendAsync( request, CancellationToken.None )
+        );
+
+        Assert.AreEqual( TimeSpan.FromSeconds( 30 ), exception.RetryAfterValue );
+    }
+
+    /// <summary>
+    /// The production provider registration places terminal classification outside Polly: Polly
+    /// performs all configured retries before the typed queue signal is raised.
+    /// </summary>
+    [TestMethod]
+    public async Task SpotifyApiPipeline_RetriesWithPollyBeforeClassifyingTerminal429( ) {
+        ServiceCollection services = new( );
+        _ = services.AddLogging( );
+        _ = services.ConfigureHttpClientDefaults( http => {
+            _ = http.AddStandardResilienceHandler( options => {
+                options.Retry.MaxRetryAttempts = 2;
+                options.Retry.Delay = TimeSpan.FromMilliseconds( 1 );
+                options.Retry.UseJitter = false;
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds( 5 );
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds( 30 );
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds( 10 );
+            } );
+        } );
+
+        HashSet<SupportedProviders> enabledProviders = [];
+        _ = services.AddSpotifyServices( "client", "secret", enabledProviders );
+        CountingRateLimitHandler primaryHandler = new( );
+        _ = services.AddHttpClient( "spotify-api" )
+            .ConfigurePrimaryHttpMessageHandler( ( ) => primaryHandler );
+
+        using ServiceProvider provider = services.BuildServiceProvider( );
+        using HttpClient client = provider.GetRequiredService<IHttpClientFactory>( ).CreateClient( "spotify-api" );
+
+        ProviderRateLimitException exception = await Assert.ThrowsExactlyAsync<ProviderRateLimitException>(
+            ( ) => client.GetAsync( "tracks/test", TestContext.CancellationToken )
+        );
+
+        Assert.AreEqual( 3, primaryHandler.CallCount, "One initial attempt plus two Polly retries were expected." );
+        Assert.AreEqual( TimeSpan.FromSeconds( 30 ), exception.RetryAfterValue );
+        Assert.AreEqual( SupportedProviders.Spotify, exception.Provider );
+    }
+
+    private static HttpMessageInvoker CreateInvoker(
+        HttpResponseMessage response,
+        SupportedProviders provider
+    ) {
+        TerminalProviderRateLimitHandler handler = new( provider ) {
+            InnerHandler = new FixedResponseHandler( response )
+        };
+        return new HttpMessageInvoker( handler );
+    }
+
+    private sealed class FixedResponseHandler( HttpResponseMessage response ) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult( response );
+    }
+
+    private sealed class CountingRateLimitHandler : HttpMessageHandler {
+        private int _callCount;
+
+        public int CallCount => _callCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) {
+            _ = Interlocked.Increment( ref _callCount );
+            return Task.FromResult( new HttpResponseMessage( HttpStatusCode.TooManyRequests ) {
+                RequestMessage = request
+            } );
+        }
+    }
+}

--- a/Tests/packages.lock.json
+++ b/Tests/packages.lock.json
@@ -98,22 +98,22 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.3.2, )",
-        "resolved": "4.3.2",
-        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
+        "requested": "[4.3.3, )",
+        "resolved": "4.3.3",
+        "contentHash": "YxXA1YGqwcZ1UjZXHgeu65AWDR25PQ2lN5N5CYOhxftqOQh/FcgQk0Vz0nfHqLhqOGFI6g9uIfOWqAdobSNKSg==",
         "dependencies": {
-          "MSTest.TestFramework": "4.3.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
-          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
+          "MSTest.TestFramework": "4.3.3",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.3.2, )",
-        "resolved": "4.3.2",
-        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
+        "requested": "[4.3.3, )",
+        "resolved": "4.3.3",
+        "contentHash": "Y4OSRh7VKV3nW+/vIqvfJ3sdLWfVJ9G11KpzynFAq3Bh/fpMaXt73v8GfL4mTz6pJ/ix3hcep4iy6qQNXt408w==",
         "dependencies": {
-          "MSTest.Analyzers": "4.3.2"
+          "MSTest.Analyzers": "4.3.3"
         }
       },
       "Testcontainers.Redis": {
@@ -470,8 +470,8 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
@@ -481,29 +481,29 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Http": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -1100,11 +1100,11 @@
       },
       "Microsoft.Extensions.Options.DataAnnotations": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "+GfvpicDQRYgQ5P3kjfzkiH+w4FlABL6xwmQ+EDE0Oc7E9haPV4oyqbstPlWPdwamF7u1ts6hzaVKqNptDEwGA==",
+        "resolved": "10.0.10",
+        "contentHash": "I9YZfS0FpPIIhU6WJgMnmKAVd4R9yFR5ck4Q3GnTpErFJxxesyiK2tFia5V8Ja9K3+XvnzIipjqE7KEZ1LIvOQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -1173,33 +1173,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Net.Http.Headers": {
@@ -1222,43 +1222,43 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.3.2",
-        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.3.2"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.3.2",
-        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.3.2"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.3.2",
-        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
+        "resolved": "2.3.3",
+        "contentHash": "JLovZjH6K10YiHO/BcidsaSHo/M2DfOe9FDjxjFdV6aoHO6VYTTYlLBNcyLJSo20q5gDTmNvmxYVH39A942aJA==",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "18.4.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
-          "Microsoft.Testing.Platform": "2.3.2"
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.3.2",
-        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.3.2",
-        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.3.2"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -1313,8 +1313,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.3.2",
-        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
+        "resolved": "4.3.3",
+        "contentHash": "cTcdSPIZ8WvchbC5DFmfHxrvVNZCtops+2W94le+Q+mx110Y9L9mqNVVc9flF35lFeL5GsY+rxGBylsjDk4+zg=="
       },
       "Nerdbank.MessagePack": {
         "type": "Transitive",
@@ -1337,19 +1337,19 @@
       },
       "NetCord": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.11",
-        "contentHash": "1mzToSQ3J6wtHt1NirCJ4O9Dt1Ou/G9sSiLrFpub3KwWFpUWZqi/bncjAeCCMymosBYTasbqI+M5r6m/3DoLHg=="
+        "resolved": "1.0.0-beta.12",
+        "contentHash": "FpHP7AABQ0dvr3+sYAaMPMDMsfzzdtdpuLAmEfnZU7N+eyOmEK//cnYk0RAkEoj2jDHH4O1+xCUDn5zIBYbRsw=="
       },
       "NetCord.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.11",
-        "contentHash": "81v1p+ns7Z/ky822idTHKEGy4tt8trC6MY+hB2i0k0rKqguCsSxo8syXMNlvksYBk+TLiQzJgHkfQ+aA+VmXJA==",
+        "resolved": "1.0.0-beta.12",
+        "contentHash": "6f2Tv3juHFu9jNh+jK9sGGAmQ4AtsGgy6qGPVccghJXGMowzBl4DtMa8D/fieQF6l5xjs3btRf92RkAGEiwDVg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9",
-          "Microsoft.Extensions.Options.DataAnnotations": "10.0.9",
-          "NetCord": "1.0.0-beta.11"
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.10",
+          "NetCord": "1.0.0-beta.12"
         }
       },
       "Newtonsoft.Json": {
@@ -1583,42 +1583,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "SSH.NET": {
@@ -1752,8 +1752,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -1772,7 +1772,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"
@@ -1791,15 +1791,15 @@
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
-          "NetCord.Hosting": "[1.0.0-beta.11, )"
+          "NetCord.Hosting": "[1.0.0-beta.12, )"
         }
       },
       "bridgebeats.worker.jetstreamwatcher": {
         "type": "Project",
         "dependencies": {
           "BridgeBeats.Core": "[1.0.0, )",
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.worker.maintenance": {

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -93,17 +93,16 @@ record present on the PDS but missing from Redis can still be served.
 `CheckRecordFreshness` marks a record stale on age alone: the record is stale when its `lookedUpAt`
 timestamp is older than `CacheDays`. Nothing else drives the freshness check.
 
-Partiality does not affect cache freshness. API partiality is transient metadata derived from the
-active saga and is not persisted to PDS records. A record read through the PDS/cache path is assumed
-complete; when it ages past the window it remains a complete-but-stale response and is eligible for
-refresh. This is the same age-based rule the bulk sweep applies, so interactive lookups and the sweep
-agree on what counts as stale.
+Partiality does not affect cache freshness. Interactive lookups may publish an interim PDS result
+while secondary provider legs are outstanding so their synchronous waiters can receive available
+links. The terminal write replaces that interim body once every leg reaches a terminal state.
 
-A partial saga generation can briefly occupy the deterministic PDS record before the final
-generation replaces it. A concurrent cache reader may treat that body as complete because fresh
-cache hits deliberately avoid an additional saga read. This bounded consistency window is accepted
-for the current single-service topology; a subsequent read after saga completion receives the final
-replacement.
+Maintenance refreshes are different: a pending refresh context suppresses all interim PDS writes.
+The saga still records each provider leg independently, and only failed legs are retried. Once all
+legs are terminal, one refresh write preserves every successful sibling result even if another
+provider exhausted its retries. Only a refresh with no successful provider result is promoted to the
+unresolved-review workflow. Thus one provider outage neither discards other providers nor causes an
+incomplete refresh body to replace the currently served record.
 
 ### Storage flow
 

--- a/docs/SPOTIFY_BATCH_AND_ROUTING.md
+++ b/docs/SPOTIFY_BATCH_AND_ROUTING.md
@@ -157,20 +157,23 @@ Its `EnqueueAsync` re-routes a request to a type-specific bulk stream only when 
 conditions hold:
 
 - the lookup type is `SongIdLookup` or `AlbumIdLookup`, and
-- the priority is not `Interactive`.
+- the priority is not `Interactive`, and
+- `BypassBulkRouting` is false.
 
 When routed, `SongIdLookup` goes to `SpotifyConstants.BulkTrackIdStream`
 (`queue:spotify:bulk:track-id`) and `AlbumIdLookup` goes to
 `SpotifyConstants.BulkAlbumIdStream` (`queue:spotify:bulk:album-id`). The request is
-serialized and written directly with `XADD`, carrying the `payload` and `enqueuedAt`
-fields, and an enqueue metric is recorded at bulk priority so dashboards can tell
-bulk-stream enqueues apart from generic ones.
+serialized and written directly with `XADD`, carrying the `payload` and `enqueuedAt` fields.
+After Redis returns a non-null stream id, the bulk enqueue acceptance metric is recorded at
+bulk priority so dashboards can tell bulk-stream enqueues apart from generic ones.
 
 Everything else passes through to the inner queue unchanged: interactive `SongIdLookup`
 and `AlbumIdLookup` (so an interactive caller is served on the interactive lane with a
 single-item call, preserving its latency budget), and every other lookup type at any
 priority. All non-enqueue operations on the decorator delegate straight to the inner
-queue.
+queue. `BypassBulkRouting` is used only by deterministic bulk-rejection isolation: the
+replacement stays on the background lane and cannot be routed straight back to the bulk
+stream that rejected it.
 
 Using the shared stream-name constants on both the producer and consumer side matters:
 the constant's own remarks call out that a producer and consumer disagreeing on the stream
@@ -206,19 +209,21 @@ The bulk path keeps work moving across crashes, bad data, and transient provider
 
 ### Stale-entry recovery with XAUTOCLAIM
 
-`SpotifyBatchQueueHelper` dequeues in two steps. First it runs an `XAUTOCLAIM` sweep to
-reclaim pending entries that have been idle longer than `AutoClaimMinIdleMs` (60 seconds),
-deserializing and appending them to the result; then it reads new entries with
-`XREADGROUP`. Reclaimed entries count against the requested batch size, so a single
-dequeue never returns more than asked. The 60-second idle threshold is chosen to be long
-enough that a slow-but-alive processing cycle is never reclaimed, yet short enough that a
-crashed consumer does not block the stream for more than a minute. There is exactly one
-consumer service reading these streams, which is what makes reclaiming another consumer's
-pending entries safe after the idle window.
+`SpotifyBatchQueueHelper` dequeues in three bounded-budget stages. It first reads the current
+consumer's pending entries for immediate recovery, then runs `XAUTOCLAIM` for entries owned by
+dead consumers that have been idle longer than `AutoClaimMinIdleMs` (15 minutes), and finally
+reads new entries with `XREADGROUP` using `>`. Entries recovered or reclaimed in either pending
+stage count against the requested batch size, so a single dequeue never returns more than asked.
+The 15-minute idle threshold is chosen to be long enough that a slow-but-alive processing cycle
+is never reclaimed, yet short enough that a crashed consumer does not block the stream for more
+than 15 minutes. There is exactly one consumer service reading these streams, which is what
+makes reclaiming another consumer's pending entries safe after the idle window.
 
 `XAUTOCLAIM` requires Redis 6.2 or newer. If the server is older, the reclaim step throws,
-is logged, and is skipped — the dequeue still reads new entries, only pending-entry
-recovery is unavailable.
+is logged, and is skipped. Current-consumer PEL recovery remains available because it uses the
+ordinary pending-entry read; only dead-consumer recovery through `XAUTOCLAIM` is unavailable.
+The dequeue still reads new entries, so a Redis version below 6.2 loses only that dead-consumer
+recovery path.
 
 ### Poison-entry handling
 
@@ -228,16 +233,44 @@ loop forever under repeated `XAUTOCLAIM` re-claims. Such entries are acknowledge
 deleted (`XACK` + `XDEL`) on both the reclaim and the new-read paths rather than retried,
 so they leave the pending list permanently.
 
+### Deterministic bulk rejection
+
+When Spotify rejects a bulk request with a deterministic 4xx, each source delivery is moved to
+`queue:spotify:background` for single-item isolation. The replacement carries
+`BypassBulkRouting = true`, so the decorator does not return it to the bulk stream. This avoids
+promoting maintenance-origin traffic into the live-user lane. The destination `XADD` and source
+`XACK`/`XDEL` execute in one Redis Lua script. The script first checks that the source entry still
+exists, so retrying an ambiguously completed handoff cannot create a duplicate background copy.
+This route change preserves `AttemptCount` and records the replacement as a requeue enqueue.
+
+### Generic-provider throughput and delayed retries
+
+Each generic provider worker uses one dequeue producer and a bounded set of processing tasks.
+`QueueSettings.ProviderConcurrency` controls the per-provider limit; the default is 4 and values
+are constrained to 1–32. Redis stream reads remain serialized while provider HTTP work can overlap.
+
+Ordinary transient failures do not sleep inside a provider's consumer loop. The failed delivery is
+replaced with an incremented `AttemptCount` and a `NotBefore` timestamp using the existing
+1/2/4/8-second schedule, then the original is acknowledged. Dequeue skips a future-dated request
+until it becomes eligible, so one failing lookup no longer blocks unrelated work for that provider.
+
+Active rate-limit discovery uses a per-provider sorted-set index rather than scanning the Redis
+keyspace. A short in-process cache further removes repeated Redis reads from the hot dequeue path;
+set and clear operations invalidate it immediately.
+
 ### Requeue cap and finalization
 
 Requeue is bounded by `LookupConstants.MaxQueueRetryAttempts` (5), the same cap the generic
-queue processor enforces. `SpotifyBatchQueueHelper.RequeueAsync` always acknowledges and
-deletes the original entry first, then:
+queue processor enforces. `SpotifyBatchQueueHelper.RequeueAsync` handles replacement and
+terminal-discard paths separately:
 
 - if the current attempt count is below the cap, it re-adds a fresh entry with a new
-  `enqueuedAt` and `AttemptCount + 1` and returns `Requeued`;
+  `enqueuedAt` and `AttemptCount + 1`. Once Redis accepts that replacement with `XADD`, the
+  enqueue acceptance metric is incremented, then the original delivery is acknowledged and deleted
+  (`XACK` + `XDEL`), and the helper returns `Requeued`;
 - if the cap is reached, or the payload cannot be deserialized to read its attempt count,
-  it discards the message and returns `CapReached`;
+  it terminally acknowledges and deletes the original message without adding a replacement, then
+  returns `CapReached`;
 - if the original entry no longer exists (already deleted, for example after an
   `XAUTOCLAIM` re-claim by a duplicate in flight), it returns `NotFound`.
 
@@ -245,6 +278,30 @@ The processor reacts to the outcome. On `CapReached` it writes a failed Spotify 
 state ("Bulk lookup failed after 5 attempts") and publishes saga-level and per-lookup
 completion so the saga coordinator and any interactive waiter unblock instead of hanging.
 On `NotFound` it leaves the saga untouched, since another consumer handled the entry.
+
+### Rollout metrics
+
+Queue health is observable by provider, priority, and stream through live pending count
+(`bridgebeats.queue.pending`), oldest pending age
+(`bridgebeats.queue.pending.oldest_age`), and consumer-group lag
+(`bridgebeats.queue.consumer.lag`). `bridgebeats.queue.sojourn.duration` measures enqueue-to-dequeue
+age, while dequeue, PEL scan, rate-limit discovery, provider HTTP, saga update, and message wall
+histograms isolate processing time sinks.
+
+`bridgebeats.queue.terminal.total` records terminal delivery outcomes;
+`bridgebeats.queue.saga.lifecycle.total` records fencing/finalization outcomes; and
+`bridgebeats.queue.refresh.outcome.total` records maintenance selection and disposition.
+Refresh enqueue volume is provider-leg based and is named
+`bridgebeats.queue.refresh.leg.enqueued.total`. Source deliveries removed with `XACK` + `XDEL`
+are counted by `bridgebeats.queue.delivery.removed.total`; this is deliberately not a success
+counter. Dead-letter moves are counted independently by `bridgebeats.queue.dlq.total`, so the
+terminal outcome counter remains one disposition per delivery. Poison destruction and
+missing/ghost PEL entries use distinct outcome tags, and new
+`XREADGROUP` deliveries are excluded from PEL-scan entry counts.
+
+For every replacement requeue, the new stream entry is accepted with `XADD` before the original
+delivery is removed with `XACK` and `XDEL`. This ordering preserves the retry if cleanup fails and
+is also the boundary used by enqueue telemetry.
 
 ### Failure shapes in the bulk dispatch
 

--- a/src/BridgeBeats.Contracts/BridgeBeats.Contracts.csproj
+++ b/src/BridgeBeats.Contracts/BridgeBeats.Contracts.csproj
@@ -14,8 +14,8 @@
 
   <!-- Shared package dependency for ATProto records - provides AtProtoRecord base class -->
   <ItemGroup>
-    <PackageReference Include="idunno.AtProto" Version="3.0.0" />
-    <PackageReference Include="idunno.Bluesky" Version="3.0.0" />
+    <PackageReference Include="idunno.AtProto" Version="3.1.0" />
+    <PackageReference Include="idunno.Bluesky" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Contracts/Constants/QueueStreamKeys.cs
+++ b/src/BridgeBeats.Contracts/Constants/QueueStreamKeys.cs
@@ -1,0 +1,36 @@
+using BridgeBeats.Contracts.Enums;
+
+namespace BridgeBeats.Contracts.Constants;
+
+/// <summary>Canonical derivation for Redis queue stream and work-signal keys.</summary>
+public static class QueueStreamKeys {
+    /// <summary>Returns the provider stream for a priority lane and optional isolated key prefix.</summary>
+    public static string For(
+        SupportedProviders provider,
+        QueuePriority priority,
+        string? keyPrefix = null
+    ) => $"{ProviderPrefix( provider, keyPrefix )}:{priority.ToString( ).ToLowerInvariant( )}";
+
+    /// <summary>Returns the provider dead-letter stream.</summary>
+    public static string DlqFor( SupportedProviders provider, string? keyPrefix = null ) =>
+        $"{ProviderPrefix( provider, keyPrefix )}:dlq";
+
+    /// <summary>Returns the provider's generic work-signal channel.</summary>
+    public static string WorkSignalFor( SupportedProviders provider, string? keyPrefix = null ) =>
+        $"{ProviderPrefix( provider, keyPrefix )}:work";
+
+    /// <summary>Returns a Spotify type-specific bulk stream.</summary>
+    public static string SpotifyBulkFor( bool isTrack, string? keyPrefix = null ) =>
+        $"{ProviderPrefix( SupportedProviders.Spotify, keyPrefix )}:bulk:{(isTrack ? "track-id" : "album-id")}";
+
+    /// <summary>Returns the Spotify bulk processor's work-signal channel.</summary>
+    public static string SpotifyBulkWorkSignal( string? keyPrefix = null ) =>
+        $"{ProviderPrefix( SupportedProviders.Spotify, keyPrefix )}:bulk:work";
+
+    private static string ProviderPrefix( SupportedProviders provider, string? keyPrefix ) {
+        string providerName = provider.ToString( ).ToLowerInvariant( );
+        return string.IsNullOrWhiteSpace( keyPrefix )
+            ? $"queue:{providerName}"
+            : $"queue:{keyPrefix}:{providerName}";
+    }
+}

--- a/src/BridgeBeats.Contracts/Constants/SpotifyConstants.cs
+++ b/src/BridgeBeats.Contracts/Constants/SpotifyConstants.cs
@@ -45,6 +45,23 @@ public static class SpotifyConstants {
     // Type-specific bulk stream names
 
     /// <summary>
+    /// Redis stream name <c>"queue:spotify:interactive"</c> for live-user Spotify lookups.
+    /// </summary>
+    public const string InteractiveStream = "queue:spotify:interactive";
+
+    /// <summary>Redis stream for single-item background Spotify lookups.</summary>
+    public const string BackgroundStream = "queue:spotify:background";
+
+    /// <summary>Consumer group shared by Spotify generic and bulk streams.</summary>
+    public const string ConsumerGroup = "spotify-workers";
+
+    /// <summary>Redis pub/sub channel that wakes the generic Spotify queue consumer.</summary>
+    public const string WorkSignalChannel = "queue:spotify:work";
+
+    /// <summary>Redis pub/sub channel that wakes the Spotify bulk batch consumer.</summary>
+    public const string BulkWorkSignalChannel = "queue:spotify:bulk:work";
+
+    /// <summary>
     /// Redis stream name <c>"queue:spotify:bulk:track-id"</c> for <c>SongIdLookup</c> messages routed
     /// by <c>SpotifyBulkQueueDecorator</c> and consumed by <c>SpotifyBulkProcessorService</c>.
     /// </summary>

--- a/src/BridgeBeats.Contracts/Enums/QueueEnqueueOrigin.cs
+++ b/src/BridgeBeats.Contracts/Enums/QueueEnqueueOrigin.cs
@@ -1,0 +1,11 @@
+namespace BridgeBeats.Contracts.Enums;
+
+/// <summary>Origin of an accepted queue enqueue.</summary>
+public enum QueueEnqueueOrigin {
+    /// <summary>New request.</summary>
+    New,
+    /// <summary>Retry or requeue.</summary>
+    Requeue,
+    /// <summary>Maintenance refresh sweep.</summary>
+    RefreshSweep
+}

--- a/src/BridgeBeats.Contracts/Enums/SagaFinalResultWriteOutcome.cs
+++ b/src/BridgeBeats.Contracts/Enums/SagaFinalResultWriteOutcome.cs
@@ -1,0 +1,16 @@
+namespace BridgeBeats.Contracts.Enums;
+
+/// <summary>Outcome of the instance-fenced, first-writer-wins final-result URI operation.</summary>
+public enum SagaFinalResultWriteOutcome {
+    /// <summary>The expected saga generation no longer owns the hash.</summary>
+    InstanceMismatch = 0,
+
+    /// <summary>The URI was stored for the first time.</summary>
+    Stored = 1,
+
+    /// <summary>The same URI was already stored by an idempotent replay.</summary>
+    Idempotent = 2,
+
+    /// <summary>A different URI was already stored for the same saga generation.</summary>
+    Conflict = -1
+}

--- a/src/BridgeBeats.Contracts/Exceptions/ProviderRateLimitException.cs
+++ b/src/BridgeBeats.Contracts/Exceptions/ProviderRateLimitException.cs
@@ -1,0 +1,74 @@
+using BridgeBeats.Contracts.Enums;
+
+namespace BridgeBeats.Contracts.Exceptions;
+
+/// <summary>Base exception for a provider rate-limit response that carries a retry delay.</summary>
+public class ProviderRateLimitException : Exception {
+    /// <summary>The nonnegative delay before the provider may be retried.</summary>
+    public TimeSpan RetryAfterValue { get; }
+
+    /// <summary>The request URI that was rate-limited, when known.</summary>
+    public Uri? RequestUri { get; }
+
+    /// <summary>The provider that issued the limit, when known.</summary>
+    public SupportedProviders? Provider { get; }
+
+    /// <summary>Creates a provider rate-limit exception.</summary>
+    public ProviderRateLimitException(
+        TimeSpan retryAfterValue,
+        Uri? requestUri,
+        SupportedProviders? provider
+    ) : base( BuildMessage( retryAfterValue, requestUri, provider ) ) {
+        RetryAfterValue = ValidateRetryAfter( retryAfterValue );
+        RequestUri = requestUri;
+        Provider = provider;
+    }
+
+    /// <summary>Creates a rate-limit exception with a caller-supplied diagnostic message.</summary>
+    protected ProviderRateLimitException(
+        string message,
+        TimeSpan retryAfterValue,
+        Uri? requestUri,
+        SupportedProviders? provider
+    ) : base( message ) {
+        RetryAfterValue = ValidateRetryAfter( retryAfterValue );
+        RequestUri = requestUri;
+        Provider = provider;
+    }
+
+    /// <summary>Creates a rate-limit exception with a caller-supplied message and inner cause.</summary>
+    protected ProviderRateLimitException(
+        string message,
+        TimeSpan retryAfterValue,
+        Uri? requestUri,
+        SupportedProviders? provider,
+        Exception innerException
+    ) : base( message, innerException ) {
+        RetryAfterValue = ValidateRetryAfter( retryAfterValue );
+        RequestUri = requestUri;
+        Provider = provider;
+    }
+
+    /// <summary>Creates a provider rate-limit exception with an inner cause.</summary>
+    public ProviderRateLimitException(
+        TimeSpan retryAfterValue,
+        Uri? requestUri,
+        SupportedProviders? provider,
+        Exception innerException
+    ) : base( BuildMessage( retryAfterValue, requestUri, provider ), innerException ) {
+        RetryAfterValue = ValidateRetryAfter( retryAfterValue );
+        RequestUri = requestUri;
+        Provider = provider;
+    }
+
+    private static TimeSpan ValidateRetryAfter( TimeSpan retryAfterValue ) {
+        if (retryAfterValue < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException( nameof( retryAfterValue ), "Retry-After must be nonnegative." );
+        }
+        return retryAfterValue;
+    }
+
+    private static string BuildMessage( TimeSpan retryAfterValue, Uri? requestUri, SupportedProviders? provider )
+        => $"Rate limit encountered for {provider?.ToString( ) ?? "Unknown"}; retry after {retryAfterValue.TotalSeconds:F0} seconds. " +
+           $"Request URI: {requestUri?.ToString( ) ?? "Unknown"}";
+}

--- a/src/BridgeBeats.Contracts/Exceptions/QueueDeliveryControlExceptions.cs
+++ b/src/BridgeBeats.Contracts/Exceptions/QueueDeliveryControlExceptions.cs
@@ -1,0 +1,20 @@
+namespace BridgeBeats.Contracts.Exceptions;
+
+/// <summary>Signals that durable provider state was committed but queue acknowledgement failed.</summary>
+public sealed class PostCommitAcknowledgementException( string messageId, Exception innerException )
+    : Exception( $"Acknowledgement failed after provider state commit for delivery {messageId}.", innerException );
+
+/// <summary>Signals that recovery of an already-terminal delivery into the DLQ failed.</summary>
+public sealed class TerminalDlqRecoveryException( string messageId, Exception innerException )
+    : Exception( $"DLQ recovery failed for terminal delivery {messageId}.", innerException );
+
+/// <summary>Signals that quarantining a delivery whose saga identity is invalid failed.</summary>
+public sealed class QueueDeliveryIdentityQuarantineException(
+    string messageId,
+    string? sagaId,
+    Exception innerException )
+    : Exception(
+        sagaId is null
+            ? $"Identity quarantine failed for delivery {messageId}."
+            : $"Saga identity quarantine failed for delivery {messageId} and saga {sagaId}.",
+        innerException );

--- a/src/BridgeBeats.Contracts/Exceptions/RetryAfterExceededException.cs
+++ b/src/BridgeBeats.Contracts/Exceptions/RetryAfterExceededException.cs
@@ -12,29 +12,13 @@ namespace BridgeBeats.Contracts.Exceptions {
     /// resilience handler is configured not to retry this exception, so it propagates immediately
     /// rather than waiting out the rate limit.
     /// </remarks>
-    public class RetryAfterExceededException : Exception {
-
-        /// <summary>
-        /// The provider's requested <c>Retry-After</c> wait duration that triggered this exception.
-        /// </summary>
-        public TimeSpan RetryAfterValue { get; }
+    public class RetryAfterExceededException : ProviderRateLimitException {
 
         /// <summary>
         /// The maximum retry wait the caller is willing to tolerate. When
-        /// <see cref="RetryAfterValue"/> exceeds this, the exception is raised.
+        /// <see cref="ProviderRateLimitException.RetryAfterValue"/> exceeds this, the exception is raised.
         /// </summary>
         public TimeSpan Threshold { get; }
-
-        /// <summary>
-        /// The request URI that was rate-limited, if known; otherwise <see langword="null"/>.
-        /// </summary>
-        public Uri? RequestUri { get; }
-
-        /// <summary>
-        /// The provider that issued the rate limit, if known; otherwise <see langword="null"/>.
-        /// Typically inferred from the request URI host via <see cref="DetermineProviderFromUri"/>.
-        /// </summary>
-        public SupportedProviders? Provider { get; }
 
         /// <summary>
         /// Initializes a new instance with the rate-limit context, building a descriptive message.
@@ -48,11 +32,8 @@ namespace BridgeBeats.Contracts.Exceptions {
             TimeSpan threshold,
             Uri? requestUri,
             SupportedProviders? provider
-        ) : base( BuildMessage( retryAfterValue, threshold, requestUri, provider ) ) {
-            RetryAfterValue = retryAfterValue;
-            Threshold = threshold;
-            RequestUri = requestUri;
-            Provider = provider;
+        ) : base( BuildExceededMessage( retryAfterValue, threshold, requestUri, provider ), retryAfterValue, requestUri, provider ) {
+            Threshold = ValidateThreshold( threshold );
         }
 
         /// <summary>
@@ -70,24 +51,20 @@ namespace BridgeBeats.Contracts.Exceptions {
             Uri? requestUri,
             SupportedProviders? provider,
             Exception innerException
-        ) : base( BuildMessage( retryAfterValue, threshold, requestUri, provider ), innerException ) {
-            RetryAfterValue = retryAfterValue;
-            Threshold = threshold;
-            RequestUri = requestUri;
-            Provider = provider;
+        ) : base( BuildExceededMessage( retryAfterValue, threshold, requestUri, provider ), retryAfterValue, requestUri, provider, innerException ) {
+            Threshold = ValidateThreshold( threshold );
         }
 
-        private static string BuildMessage(
-            TimeSpan retryAfterValue,
-            TimeSpan threshold,
-            Uri? requestUri,
-            SupportedProviders? provider
-        ) {
-            string providerName = provider?.ToString( ) ?? "Unknown";
-            string uri = requestUri?.ToString( ) ?? "Unknown";
-            return $"Rate limit exceeded for {providerName}. Retry-After of {retryAfterValue.TotalSeconds:F0} seconds " +
-                   $"exceeds maximum threshold of {threshold.TotalSeconds:F0} seconds. Request URI: {uri}";
+        private static TimeSpan ValidateThreshold( TimeSpan threshold ) {
+            if (threshold < TimeSpan.Zero) {
+                throw new ArgumentOutOfRangeException( nameof( threshold ), "Retry threshold must be nonnegative." );
+            }
+            return threshold;
         }
+
+        private static string BuildExceededMessage( TimeSpan retryAfterValue, TimeSpan threshold, Uri? requestUri, SupportedProviders? provider )
+            => $"Rate limit exceeded for {provider?.ToString( ) ?? "Unknown"}; retry after {retryAfterValue.TotalSeconds:F0} seconds exceeds threshold {threshold.TotalSeconds:F0}. " +
+               $"Request URI: {requestUri?.ToString( ) ?? "Unknown"}";
 
         /// <summary>
         /// Infers the <see cref="SupportedProviders"/> from a request URI by matching a substring of

--- a/src/BridgeBeats.Contracts/Exceptions/UnreadableSagaStateException.cs
+++ b/src/BridgeBeats.Contracts/Exceptions/UnreadableSagaStateException.cs
@@ -1,0 +1,17 @@
+namespace BridgeBeats.Contracts.Exceptions;
+
+/// <summary>
+/// Indicates that a Redis saga hash exists but cannot be reconstructed into a valid saga state.
+/// Queued deliveries referencing this state must be quarantined rather than retried forever.
+/// </summary>
+public sealed class UnreadableSagaStateException : InvalidOperationException {
+    /// <summary>The deterministic identifier of the unreadable saga.</summary>
+    public string SagaId { get; }
+
+    /// <summary>Creates an exception for an unreadable persisted saga.</summary>
+    public UnreadableSagaStateException( string sagaId )
+        : base( $"Saga '{sagaId}' exists but its persisted state is unreadable." ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        SagaId = sagaId;
+    }
+}

--- a/src/BridgeBeats.Contracts/Interfaces/IConsumerGroupAssurance.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IConsumerGroupAssurance.cs
@@ -1,0 +1,7 @@
+namespace BridgeBeats.Contracts.Interfaces;
+
+/// <summary>Provides an idempotent repair operation for a queue's Redis consumer groups.</summary>
+public interface IConsumerGroupAssurance {
+    /// <summary>Ensures all consumer groups required by the queue exist.</summary>
+    Task EnsureConsumerGroupsAsync( CancellationToken cancellationToken = default );
+}

--- a/src/BridgeBeats.Contracts/Interfaces/IRefreshReviewStore.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IRefreshReviewStore.cs
@@ -9,11 +9,32 @@ public interface IRefreshReviewStore {
     /// <summary>Registers the PDS source record for a refresh saga until that saga completes.</summary>
     Task RegisterPendingAsync( RefreshReviewEntry entry, CancellationToken cancellationToken = default );
 
-    /// <summary>Moves a registered refresh into the review queue after a zero-result completion.</summary>
-    Task MarkUnresolvedAsync( string sagaId, string reason, CancellationToken cancellationToken = default );
+    /// <summary>Returns the pending context for one source record, if any.</summary>
+    Task<RefreshReviewEntry?> GetPendingAsync( string sourceRecordUri, CancellationToken cancellationToken = default );
+    /// <summary>Returns every record context currently associated with a saga id.</summary>
+    Task<IReadOnlyList<RefreshReviewEntry>> GetPendingForSagaAsync( string sagaId, CancellationToken cancellationToken = default );
 
-    /// <summary>Clears pending refresh context after a successful completion.</summary>
-    Task CompleteAsync( string sagaId, CancellationToken cancellationToken = default );
+    /// <summary>Promotes the supplied record context without relying on a deterministic saga id.</summary>
+    Task MarkUnresolvedAsync( RefreshReviewEntry entry, string reason, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Promotes a concrete source-record context directly into the unresolved review list.
+    /// This path is used when no matching pending owner exists; it never changes pending saga
+    /// context and is idempotent for the source-record URI.
+    /// </summary>
+    Task PromoteDirectAsync( RefreshReviewEntry entry, string reason, CancellationToken cancellationToken = default );
+
+    /// <summary>Clears one source record's pending context after completion.</summary>
+    Task CompleteAsync( RefreshReviewEntry entry, CancellationToken cancellationToken = default );
+
+    /// <summary>Clears only review contexts owned by the expected saga generation.</summary>
+    Task CompleteAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default );
+
+    /// <summary>Increments the sweep observation count for a source record and returns the new value.</summary>
+    Task<int> IncrementSweepAttemptAsync( string sourceRecordUri, CancellationToken cancellationToken = default );
+
+    /// <summary>Clears the sweep observation count after a successful refresh.</summary>
+    Task ClearSweepAttemptsAsync( string sourceRecordUri, CancellationToken cancellationToken = default );
 
     /// <summary>Lists all records currently awaiting operator review.</summary>
     Task<IReadOnlyList<RefreshReviewEntry>> GetUnresolvedAsync( CancellationToken cancellationToken = default );

--- a/src/BridgeBeats.Contracts/Interfaces/IRequestQueue.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/IRequestQueue.cs
@@ -68,9 +68,8 @@ public interface IRequestQueue<T> where T : class, IQueueableRequest {
     /// </summary>
     /// <param name="messageId">The broker message id of the message to requeue.</param>
     /// <param name="delay">
-    /// Currently <b>ignored</b> by the implementation: the message is re-added to the stream
-    /// immediately regardless of the value supplied. The parameter is present for interface
-    /// compatibility but has no effect today.
+    /// An optional provider eligibility delay. When omitted, implementations may apply their
+    /// ordinary transient-retry schedule and increment retry bookkeeping.
     /// </param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>A task that completes when the message has been requeued.</returns>

--- a/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
+++ b/src/BridgeBeats.Contracts/Interfaces/ISagaStateManager.cs
@@ -1,4 +1,5 @@
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Records;
 
 namespace BridgeBeats.Contracts.Interfaces;
@@ -15,6 +16,10 @@ namespace BridgeBeats.Contracts.Interfaces;
 /// id is deterministically derived from the lookup key (see <see cref="GenerateSagaId"/>), so
 /// identical lookups always map to the same saga. Saga state is the <see cref="LookupSagaState"/>
 /// record; result pointers are AT-URIs (<c>at://…</c>).
+/// Instance fencing intentionally remains an explicit string parameter in this pre-v0.1 contract:
+/// the token is a serialized wire/storage value shared by Redis hashes and queued request payloads,
+/// while validation belongs at every public mutation boundary. A wrapper would not remove those
+/// validation or serialization obligations and would substantially widen this interface.
 /// </remarks>
 public interface ISagaStateManager {
     /// <summary>
@@ -52,77 +57,66 @@ public interface ISagaStateManager {
     /// A task whose result is the <see cref="LookupSagaState"/>, or <see langword="null"/> when no
     /// saga exists with the given id or it has expired.
     /// </returns>
+    /// <exception cref="UnreadableSagaStateException">
+    /// Thrown when the saga hash exists but cannot be reconstructed safely, including a missing or
+    /// invalid instance token.
+    /// </exception>
     Task<LookupSagaState?> GetAsync( string sagaId, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Records the outcome of one provider's leg of the saga when a provider lookup completes.
-    /// Each provider's state is stored separately, and the saga's TTL is extended to prevent
-    /// expiration during active processing.
-    /// </summary>
-    /// <param name="sagaId">The saga id to update.</param>
-    /// <param name="state">The per-provider <see cref="ProviderLookupState"/> to store for this leg.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the provider state has been stored.</returns>
-    Task UpdateProviderStateAsync(
-        string sagaId,
-        ProviderLookupState state,
-        CancellationToken cancellationToken = default
-    );
+    /// <summary>Updates a provider leg only when the saga instance token still matches.</summary>
+    Task<bool> TryUpdateProviderStateAsync( string sagaId, ProviderLookupState state, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Records the AT-URI of the saga's partial (in-progress) result record: the first ATProto
-    /// write, holding results from providers that completed before a rate limit, so users can see
-    /// available data while the remaining providers finish.
+    /// Promotes a background/bulk saga to interactive urgency once, fenced to its current instance.
     /// </summary>
+    /// <returns><see langword="true"/> only for the call that performed the promotion.</returns>
+    Task<bool> TryPromoteToInteractiveAsync(
+        string sagaId,
+        string expectedInstanceToken,
+        CancellationToken cancellationToken = default );
+
+    /// <summary>Stores the partial-result AT-URI when the saga instance token still matches.</summary>
     /// <param name="sagaId">The saga id to update.</param>
     /// <param name="uri">The AT-URI (<c>at://…</c>) of the partial result record.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the partial result URI has been stored.</returns>
-    Task SetPartialResultUriAsync(
-        string sagaId,
-        string uri,
-        CancellationToken cancellationToken = default
-    );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when the URI was stored; otherwise <see langword="false"/>.</returns>
+    Task<bool> TrySetPartialResultUriAsync( string sagaId, string uri, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Records the AT-URI of the saga's final (completed) result record: the final write, which
-    /// replaces any partial result. The saga is fully complete once this URI is set.
-    /// </summary>
+    /// <summary>Stores the final-result AT-URI with token fencing and first-writer-wins semantics.</summary>
     /// <param name="sagaId">The saga id to update.</param>
     /// <param name="uri">The AT-URI (<c>at://…</c>) of the final result record.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the final result URI has been stored.</returns>
-    Task SetFinalResultUriAsync(
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns>The applied, idempotent, conflicting, or instance-mismatch outcome.</returns>
+    Task<SagaFinalResultWriteOutcome> TrySetFinalResultUriAsync(
         string sagaId,
         string uri,
-        CancellationToken cancellationToken = default
-    );
+        string expectedInstanceToken,
+        CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Deletes a saga and all its associated provider states, used for cleanup after the final
-    /// result is written and cached, or for manual intervention (for example removing a stuck
-    /// saga).
-    /// </summary>
+    /// <summary>Deletes a saga and its provider states only when its instance token matches.</summary>
     /// <param name="sagaId">The saga id to delete.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>
     /// A task whose result is <see langword="true"/> when a saga was deleted, or
     /// <see langword="false"/> when no saga existed with the given id.
     /// </returns>
-    Task<bool> DeleteAsync( string sagaId, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    Task<bool> TryDeleteAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Finds sagas whose provider legs are all complete but which were never finalized (no final
-    /// result URI set), for a reconciliation sweep that finishes them. Used by the saga
-    /// coordinator's polling loop as a Pub/Sub fallback.
+    /// Finds completed sagas that still require reconciliation. This includes sagas without a
+    /// final URI and finalized sagas deliberately retained in the pending index until their
+    /// deduplication waiters have been notified.
     /// </summary>
     /// <param name="minimumAge">Only sagas at least this old are returned, to avoid racing in-flight Pub/Sub messages.</param>
     /// <param name="limit">The maximum number of sagas to return per call; defaults to 100.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>
-    /// A task whose result is the completed-but-unfinalized sagas; an empty list when none qualify.
+    /// A task whose result is the completed sagas still requiring reconciliation; an empty list when none qualify.
     /// </returns>
-    Task<IReadOnlyList<LookupSagaState>> GetCompletedButUnfinalizedAsync(
+    Task<IReadOnlyList<LookupSagaState>> GetPendingReconciliationAsync(
         TimeSpan minimumAge,
         int limit = 100,
         CancellationToken cancellationToken = default
@@ -146,77 +140,61 @@ public interface ISagaStateManager {
     /// <returns>A task that completes when the saga has been removed from the index.</returns>
     Task RemoveFromPendingIndexAsync( string sagaId, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Sets whether the saga's current result is partial (some providers still pending or
-    /// rate-limited).
-    /// </summary>
+    /// <summary>Sets whether a token-matched saga is partial.</summary>
     /// <param name="sagaId">The saga id to update.</param>
     /// <param name="isPartial"><see langword="true"/> when the result is still partial; <see langword="false"/> when complete.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the flag has been stored.</returns>
-    Task SetIsPartialAsync( string sagaId, bool isPartial, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when the flag was stored; otherwise <see langword="false"/>.</returns>
+    Task<bool> TrySetIsPartialAsync( string sagaId, bool isPartial, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Records which provider seeded the saga (the provider the originating lookup came from).
-    /// </summary>
+    /// <summary>Initializes provider legs only when the saga instance token still matches.</summary>
+    Task<bool> TryInitializeProviderStatesAsync( string sagaId, IEnumerable<SupportedProviders> providers, string expectedInstanceToken, CancellationToken cancellationToken = default );
+
+    /// <summary>Records the provider that seeded a token-matched saga.</summary>
     /// <param name="sagaId">The saga id to update.</param>
     /// <param name="provider">The initial provider for the saga.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the initial provider has been stored.</returns>
-    Task SetInitialProviderAsync( string sagaId, SupportedProviders provider, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when the provider was stored; otherwise <see langword="false"/>.</returns>
+    Task<bool> TrySetInitialProviderAsync( string sagaId, SupportedProviders provider, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Records the per-provider rate-limit information currently affecting the saga, for user
-    /// notification.
-    /// </summary>
+    /// <summary>Stores per-provider rate-limit information for a token-matched saga.</summary>
     /// <param name="sagaId">The saga id to update.</param>
     /// <param name="rateLimitInfo">The per-provider <see cref="ProviderRateLimitInfo"/> entries to store.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the rate-limit information has been stored.</returns>
-    Task SetRateLimitInfoAsync( string sagaId, List<ProviderRateLimitInfo> rateLimitInfo, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when the information was stored; otherwise <see langword="false"/>.</returns>
+    Task<bool> TrySetRateLimitInfoAsync( string sagaId, List<ProviderRateLimitInfo> rateLimitInfo, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Atomically marks the saga's secondary lookups as queued, succeeding only once (set-if-not-
-    /// exists) so the fan-out to secondary providers happens a single time even when both the
-    /// <c>saga:completed</c> and <c>complete:{key}</c> events arrive.
-    /// </summary>
+    /// <summary>Claims token-matched secondary fan-out once using a set-if-absent marker.</summary>
     /// <param name="sagaId">The saga id to mark.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>
     /// A task whose result is <see langword="true"/> when this caller set the marker (and should
     /// queue secondaries), or <see langword="false"/> when it was already set by an earlier caller.
     /// </returns>
-    Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Atomically claims the exclusive right to finalize a saga, succeeding only once
-    /// (set-if-not-exists) so exactly one of the overlapping finalization triggers
-    /// (<c>saga:completed</c>, <c>complete:{key}</c>, the polling sweep) performs the PDS write.
-    /// </summary>
+    /// <summary>Claims token-matched finalization once using a set-if-absent marker.</summary>
     /// <param name="sagaId">The saga id to claim finalization for.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>
     /// A task whose result is <see langword="true"/> when this caller acquired the claim (and must
     /// finalize), or <see langword="false"/> when another caller already holds it.
     /// </returns>
-    Task<bool> TryClaimFinalizeAsync( string sagaId, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    Task<bool> TryClaimFinalizeAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Releases a finalize claim previously acquired via <see cref="TryClaimFinalizeAsync"/>,
-    /// so a legitimate retry can re-finalize after a failed PDS write. Must be called only on
-    /// the failure path; a saga that finalized successfully keeps its claim until TTL expiry.
-    /// </summary>
+    /// <summary>Releases a token-matched finalize claim after a pre-durability failure.</summary>
     /// <param name="sagaId">The saga id whose finalize claim should be released.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the claim has been released.</returns>
-    Task ReleaseFinalizeClaimAsync( string sagaId, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when the claim was released; otherwise <see langword="false"/>.</returns>
+    Task<bool> TryReleaseFinalizeClaimAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
-    /// <summary>
-    /// Atomically advances the saga's write generation to <paramref name="generation"/> only when
-    /// the stored generation is strictly less than <paramref name="generation"/>. Guards against
-    /// redundant PDS writes: exactly one concurrent handler wins per generation level, so the
-    /// total number of writes is bounded by the number of providers.
-    /// </summary>
+    /// <summary>Advances a token-matched saga's write generation using compare-and-set semantics.</summary>
     /// <param name="sagaId">The saga id to advance.</param>
     /// <param name="generation">The generation to advance to; typically the number of provider results in the combined result.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
@@ -225,15 +203,12 @@ public interface ISagaStateManager {
     /// must perform the PDS write), or <see langword="false"/> when the stored generation was
     /// already at or above <paramref name="generation"/> and the write should be skipped.
     /// </returns>
-    Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Conditionally resets the saga's write generation from <paramref name="advancedTo"/> back to
-    /// <paramref name="priorGeneration"/>, used exclusively on the non-terminal pre-durability PDS
-    /// write failure path so the next retry can re-advance and re-write. The reset is a conditional
-    /// compare-and-set: it only takes effect when the stored generation still equals
-    /// <paramref name="advancedTo"/>, so a concurrent handler that has already advanced further is
-    /// not regressed. Must not be called after a successful write.
+    /// Resets a token-matched saga's write generation after a pre-durability failure, but only when
+    /// the stored value still equals <paramref name="advancedTo"/>.
     /// </summary>
     /// <param name="sagaId">The saga id whose write generation should be reset.</param>
     /// <param name="advancedTo">
@@ -242,18 +217,9 @@ public interface ISagaStateManager {
     /// </param>
     /// <param name="priorGeneration">The generation to restore; typically <c>advancedTo - 1</c>.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the conditional reset attempt has been made.</returns>
-    Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken cancellationToken = default );
-
-    /// <summary>
-    /// Seeds the saga with an initial, not-yet-complete provider state for each of the given
-    /// providers at the start of a saga, so the set of providers that must complete is known.
-    /// </summary>
-    /// <param name="sagaId">The saga id to initialize.</param>
-    /// <param name="providers">The set of enabled providers to register provider states for.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A task that completes when the provider states have been initialized.</returns>
-    Task InitializeProviderStatesAsync( string sagaId, IEnumerable<SupportedProviders> providers, CancellationToken cancellationToken = default );
+    /// <param name="expectedInstanceToken">The required saga instance token.</param>
+    /// <returns><see langword="true"/> when reset; otherwise <see langword="false"/>.</returns>
+    Task<bool> TryResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, string expectedInstanceToken, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Derives a deterministic saga id from a lookup key. The key is upper-cased, hashed with

--- a/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
+++ b/src/BridgeBeats.Contracts/Records/LookupSagaState.cs
@@ -10,6 +10,10 @@ namespace BridgeBeats.Contracts.Records;
 /// </summary>
 public sealed record LookupSagaState {
 
+    /// <summary>Redis-only instance token used to guard delete/recreate races.</summary>
+    [JsonIgnore]
+    public string? InstanceToken { get; init; }
+
     /// <summary>The unique identifier of this saga. Derived deterministically from the lookup key.</summary>
     [JsonPropertyName( "sagaId" )]
     [JsonRequired]

--- a/src/BridgeBeats.Contracts/Records/QueueSettings.cs
+++ b/src/BridgeBeats.Contracts/Records/QueueSettings.cs
@@ -81,6 +81,14 @@ public sealed record QueueSettings {
     [JsonPropertyName( "providerMinBulkThresholds" )]
     public Dictionary<SupportedProviders, int> ProviderMinBulkThresholds { get; init; } = [];
 
+    /// <summary>Maximum number of provider lookups processed concurrently by one queue worker.</summary>
+    [JsonPropertyName( "defaultProviderConcurrency" )]
+    public int DefaultProviderConcurrency { get; init; } = 4;
+
+    /// <summary>Optional per-provider overrides for <see cref="DefaultProviderConcurrency"/>.</summary>
+    [JsonPropertyName( "providerConcurrency" )]
+    public Dictionary<SupportedProviders, int> ProviderConcurrency { get; init; } = [];
+
     /// <summary>
     /// Returns the minimum bulk queue threshold for the given provider, falling back to
     /// <see cref="DefaultMinBulkQueueThreshold"/> when no per-provider override is configured.
@@ -91,4 +99,12 @@ public sealed record QueueSettings {
         => ProviderMinBulkThresholds.TryGetValue( provider, out int threshold )
             ? threshold
             : DefaultMinBulkQueueThreshold;
+
+    /// <summary>Returns a validated per-provider concurrency bound.</summary>
+    public int GetProviderConcurrency( SupportedProviders provider ) {
+        int configured = ProviderConcurrency.TryGetValue( provider, out int value )
+            ? value
+            : DefaultProviderConcurrency;
+        return Math.Clamp( configured, 1, 32 );
+    }
 }

--- a/src/BridgeBeats.Contracts/Records/QueuedLookupRequest.cs
+++ b/src/BridgeBeats.Contracts/Records/QueuedLookupRequest.cs
@@ -10,6 +10,9 @@ namespace BridgeBeats.Contracts.Records;
 /// re-deliver it. Implements <see cref="IQueueableRequest"/>.
 /// </summary>
 public sealed record QueuedLookupRequest : IQueueableRequest {
+    /// <summary>Telemetry origin for this queue payload.</summary>
+    [JsonPropertyName( "enqueueOrigin" )]
+    public QueueEnqueueOrigin EnqueueOrigin { get; init; } = QueueEnqueueOrigin.New;
 
     /// <summary>The unique identifier of this queued request.</summary>
     [JsonPropertyName( "requestId" )]
@@ -50,6 +53,14 @@ public sealed record QueuedLookupRequest : IQueueableRequest {
     [JsonRequired]
     public required string SagaId { get; init; }
 
+    /// <summary>
+    /// Saga generation this delivery was created for. Every producer must capture it after creating
+    /// or loading the saga; workers reject the delivery if the saga has since been replaced.
+    /// </summary>
+    [JsonPropertyName( "sagaInstanceToken" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? SagaInstanceToken { get; init; }
+
     /// <summary>The absolute instant the request was originally created. Defaults to the current UTC time.</summary>
     [JsonPropertyName( "createdAt" )]
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
@@ -57,6 +68,22 @@ public sealed record QueuedLookupRequest : IQueueableRequest {
     /// <summary>The number of times delivery of this request has been attempted.</summary>
     [JsonPropertyName( "attemptCount" )]
     public int AttemptCount { get; init; }
+
+    /// <summary>
+    /// Earliest instant at which a consumer may retry this delivery. A null value is immediately
+    /// eligible. Transient provider failures use this to avoid occupying a worker slot while the
+    /// retry backoff elapses.
+    /// </summary>
+    [JsonPropertyName( "notBefore" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DateTimeOffset? NotBefore { get; init; }
+
+    /// <summary>
+    /// Routes this typed Spotify id request through the generic single-item queue instead of
+    /// returning it to bulk batching. Set by bulk-rejection and interactive retry paths.
+    /// </summary>
+    [JsonPropertyName( "bypassBulkRouting" )]
+    public bool BypassBulkRouting { get; init; }
 
     /// <summary>The original endpoint that triggered the rate limit on a prior attempt, for tracking; otherwise <see langword="null"/>.</summary>
     [JsonPropertyName( "rateLimitedEndpoint" )]

--- a/src/BridgeBeats.Contracts/Records/QueuedMessage.cs
+++ b/src/BridgeBeats.Contracts/Records/QueuedMessage.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using BridgeBeats.Contracts.Enums;
 
 namespace BridgeBeats.Contracts.Records;
 
@@ -21,4 +22,8 @@ public sealed record QueuedMessage<T>(
     [property: JsonPropertyName( "enqueuedAt" )]
     DateTimeOffset EnqueuedAt
 
-);
+) {
+    /// <summary>The actual priority lane from which the broker delivered this message.</summary>
+    [JsonIgnore]
+    public QueuePriority Priority { get; init; } = QueuePriority.Background;
+}

--- a/src/BridgeBeats.Contracts/Records/RefreshReviewEntry.cs
+++ b/src/BridgeBeats.Contracts/Records/RefreshReviewEntry.cs
@@ -1,5 +1,6 @@
-using BridgeBeats.Contracts.Enums;
+using System.Text.Json.Serialization;
 using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Enums;
 
 namespace BridgeBeats.Contracts.Records;
 
@@ -8,35 +9,56 @@ namespace BridgeBeats.Contracts.Records;
 /// </summary>
 public sealed record RefreshReviewEntry {
     /// <summary>The AT-URI of the source PDS record.</summary>
+    [JsonPropertyName( "sourceRecordUri" )]
     public required string SourceRecordUri { get; init; }
 
     /// <summary>
     /// The source record CID observed when the refresh was registered. Destructive disposition uses
     /// this value as an ATProto compare-and-swap guard so a newer record revision cannot be deleted.
     /// </summary>
+    [JsonPropertyName( "sourceRecordCid" )]
     public string? SourceRecordCid { get; init; }
 
     /// <summary>The refresh saga that attempted to resolve the record.</summary>
+    [JsonPropertyName( "sagaId" )]
     public required string SagaId { get; init; }
 
+    /// <summary>Redis-only saga instance token fencing this review context to one generation.</summary>
+    [JsonPropertyName( "instanceToken" )]
+    public string? InstanceToken { get; init; }
+
     /// <summary>The canonical lookup type used to identify the refresh saga.</summary>
+    [JsonPropertyName( "lookupType" )]
     public required LookupRequestType LookupType { get; init; }
 
     /// <summary>The canonical lookup value used to identify the refresh saga.</summary>
+    [JsonPropertyName( "lookupValue" )]
     public required string LookupValue { get; init; }
 
     /// <summary>Whether the source record represents an album.</summary>
-    public bool IsAlbum { get; init; }
+    [JsonPropertyName( "isAlbum" )]
+    public bool? IsAlbum { get; init; }
 
     /// <summary>The last-known provider results from the source PDS record.</summary>
+    [JsonPropertyName( "sourceResult" )]
     public MediaLinkResult? SourceResult { get; init; }
 
     /// <summary>When the refresh was first registered.</summary>
+    [JsonPropertyName( "createdAt" )]
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 
+    /// <summary>
+    /// Numeric form of <see cref="CreatedAt"/> used by Redis Lua guards for chronological
+    /// comparisons. ISO-8601 strings with different offsets are not lexically time-ordered.
+    /// </summary>
+    [JsonPropertyName( "createdAtUnixMilliseconds" )]
+    public long CreatedAtUnixMilliseconds => CreatedAt.ToUnixTimeMilliseconds( );
+
     /// <summary>When the refresh became reviewable; null while it is still pending.</summary>
+    [JsonPropertyName( "failedAt" )]
     public DateTimeOffset? FailedAt { get; init; }
 
     /// <summary>Why the record was placed in the review queue.</summary>
+    [JsonPropertyName( "failureReason" )]
     public string? FailureReason { get; init; }
 }

--- a/src/BridgeBeats.Contracts/Records/WorkerApi/ProviderLookupResponse.cs
+++ b/src/BridgeBeats.Contracts/Records/WorkerApi/ProviderLookupResponse.cs
@@ -4,52 +4,51 @@ namespace BridgeBeats.Contracts.Records.WorkerApi;
 
 /// <summary>
 /// The single response envelope a provider worker returns from any of its <c>/lookup/*</c>
-/// endpoints, wrapping the resolved <see cref="MusicLookupResult"/> with status information. The
-/// endpoints reply with HTTP 200 even when the lookup fails, so <see cref="Success"/> and
-/// <see cref="ErrorMessage"/> (not the HTTP status code) carry the outcome for the caller.
+/// endpoints, wrapping the resolved <see cref="MusicLookupResult"/> with status information. A
+/// successful lookup and a successful no-match return HTTP 200; typed failures use status-bearing
+/// HTTP responses and this envelope for machine-readable error metadata.
 /// </summary>
 /// <param name="Success">Whether the lookup succeeded.</param>
 /// <param name="Result">The resolved item, or <see langword="null"/> when there is none.</param>
 /// <param name="ErrorMessage">
 /// A human-readable failure reason, or <see langword="null"/> when no error message is set.
 /// </param>
-/// <remarks>
-/// Construct instances through the factory methods rather than the primary constructor. The three
-/// factories do not all collapse to the same shape: <see cref="Ok(MusicLookupResult?)"/> sets
-/// <see cref="Success"/> from whether its argument is non-null, so <c>Ok(null)</c> yields
-/// <c>Success = false, Result = null</c>; <see cref="NotFound"/> yields
-/// <c>Success = true, Result = null</c>; and <see cref="Error(string)"/> yields
-/// <c>Success = false</c> with the supplied message. <c>Ok(null)</c> and <see cref="NotFound"/>
-/// therefore differ in <see cref="Success"/> despite both carrying a <see langword="null"/> result.
-/// </remarks>
+/// <param name="RetryAfterSeconds">The provider retry delay in seconds, when rate limited.</param>
+/// <param name="RetryThresholdSeconds">The retry threshold in seconds, when rate limited.</param>
+/// <remarks>Construct instances through the factory methods rather than the primary constructor.</remarks>
 public sealed record ProviderLookupResponse(
     bool Success,
     MusicLookupResult? Result,
-    string? ErrorMessage
+    string? ErrorMessage,
+    double? RetryAfterSeconds = null,
+    double? RetryThresholdSeconds = null
 ) {
     /// <summary>
-    /// Creates a response from a lookup result. <see cref="Success"/> is set to <see langword="true"/>
-    /// only when <paramref name="result"/> is non-null; a <see langword="null"/> argument produces a
-    /// response with <c>Success = false</c> and no result.
+    /// Creates a successful response from a lookup result. A null result has the same successful
+    /// no-match semantics as <see cref="NotFound"/>.
     /// </summary>
     /// <param name="result">The resolved item, or <see langword="null"/> when nothing was found.</param>
     /// <returns>
-    /// A response whose <see cref="Success"/> is <see langword="true"/> exactly when
-    /// <paramref name="result"/> is non-null, with no error message.
+    /// A successful response containing <paramref name="result"/>, with no error message.
     /// </returns>
     public static ProviderLookupResponse Ok( MusicLookupResult? result )
-        => new( result is not null, result, null );
+        => new( true, result, null );
 
     /// <summary>
     /// Creates a failed response carrying an error reason.
     /// </summary>
     /// <param name="errorMessage">The human-readable reason the lookup failed.</param>
+    /// <param name="retryAfterSeconds">The retry delay in seconds, when rate limited.</param>
+    /// <param name="retryThresholdSeconds">The retry threshold in seconds, when rate limited.</param>
     /// <returns>
     /// A response with <see cref="Success"/> set to <see langword="false"/>, no result, and the
     /// supplied <paramref name="errorMessage"/>.
     /// </returns>
-    public static ProviderLookupResponse Error( string errorMessage )
-        => new( false, null, errorMessage );
+    public static ProviderLookupResponse Error(
+        string errorMessage,
+        double? retryAfterSeconds = null,
+        double? retryThresholdSeconds = null
+    ) => new( false, null, errorMessage, retryAfterSeconds, retryThresholdSeconds );
 
     /// <summary>
     /// Creates a "nothing matched" response: the lookup ran without error but found no item.

--- a/src/BridgeBeats.Contracts/packages.lock.json
+++ b/src/BridgeBeats.Contracts/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "idunno.AtProto": {
         "type": "Direct",
-        "requested": "[3.0.0, )",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
@@ -16,22 +16,22 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Http": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.Bluesky": {
         "type": "Direct",
-        "requested": "[3.0.0, )",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "DnsClient": {
@@ -65,20 +65,20 @@
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Security.Ssrf": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "IJhyGIolnc/ZSueqhL+gq9f8Yb3oqErQamQGJ2JT/LXPOALA16t4SIWRWjFx9XeBez3/JnIApJTCkQCTM3wTWg==",
+        "resolved": "5.4.0",
+        "contentHash": "OvSoiN3KRXk23Zp1FdTp33NYfBRH9qRaJD/DJv8RFQ+nSxEhYGqDICjbAu2bfAkZFf0LiUonkCiCTHQwpL2E1g==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "10.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "OpenTelemetry.Extensions.Hosting": "1.15.3"
+          "OpenTelemetry.Extensions.Hosting": "1.16.0"
         }
       },
       "Microsoft.AspNetCore.WebUtilities": {
@@ -135,6 +135,15 @@
         "type": "Transitive",
         "resolved": "10.0.0",
         "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
@@ -266,33 +275,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Net.Http.Headers": {
@@ -305,35 +314,36 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.16.0",
-        "contentHash": "nE/Px3MUvQC8c0UG0DOP5OJE7vMtiMaPYi/6TkSS/o/O0s/oPq+8WaPYTVEPzb7lwu/QyLgknc+sFm2FjPXe2A==",
+        "resolved": "1.17.0",
+        "contentHash": "rMLOTftlMlTm7+MSrvXDHnJRjVkROFNKXHZrYjOsX+LankaFG7QSflx7qRRGjoqZoirohnxmJQ7GEb9occO4Gg==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.16.0"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.17.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.16.0",
-        "contentHash": "WZP8Eb6vZTeNqeV+fjBitc7iefBoTHIhaWorqg/h/YiQBlcQJu0bICuTqKV0XRyjiE0eWs80yLlnUtHAFSkFWA=="
+        "resolved": "1.17.0",
+        "contentHash": "mSBxzomZgHIJu9CyVNqyDu/n2JHEtqVgfcCD1Br0cV5iLYogjZOMqhlVLt99PEp+0KGBNUR3GXgeOdN2GR3F9g=="
       },
       "OpenTelemetry.Api.ProviderBuilderExtensions": {
         "type": "Transitive",
-        "resolved": "1.16.0",
-        "contentHash": "hZwaHAkXvUNn9+cS+vEvYBgIrIQOQRz2cIRUODZ5gxHsDsLeNCueLgZFkybopjE0jUhLut6lm5eL3LTqbW0hMg==",
+        "resolved": "1.17.0",
+        "contentHash": "Xgc3Qf9B9TFMFpx6exTdGqMWuYIT2miNzkdMPutVvT9YuMFaEovXWke1Gb6z8NxYaQbbGF38vYLuSg1JCeui5Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "OpenTelemetry.Api": "1.16.0"
+          "OpenTelemetry.Api": "1.17.0"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.16.0",
-        "contentHash": "/YfrO5MRaA156vhNanYGPX2JjOwKUrA0+Jf7ltT2eD3VkfHqXcEJY5Oxt/nWH8lqBOTc1nJpn2soBtD5Cml8Dg==",
+        "resolved": "1.17.0",
+        "contentHash": "t1OwL/4qgboGMobYVT+UV5zgWnFqCp4Pw8lcsmzh8m2K8PQsTKkyxrC32tqYTMYny3GOW4q5cltE3dTVzLmRew==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "OpenTelemetry": "1.16.0"
+          "OpenTelemetry": "1.17.0"
         }
       },
       "PeterO.Cbor": {
@@ -357,8 +367,8 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",

--- a/src/BridgeBeats.Core/BridgeBeats.Core.csproj
+++ b/src/BridgeBeats.Core/BridgeBeats.Core.csproj
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
     <PackageReference Include="QRCoder" Version="1.8.0" />
   </ItemGroup>

--- a/src/BridgeBeats.Core/Domain/Extensions/AspireServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/AspireServiceExtensions.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.Exceptions;
+using BridgeBeats.Core.Infrastructure.Queue;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Http.Resilience;
 using OpenTelemetry;
@@ -35,8 +36,8 @@ public static class AspireServiceExtensions {
     /// Adds the Aspire service defaults to a web-application host: service discovery, health checks,
     /// the standard HTTP resilience pipeline, and OpenTelemetry. The resilience pipeline uses
     /// exponential backoff with jitter, honors server <c>Retry-After</c> headers, and is explicitly
-    /// configured <b>not</b> to retry <see cref="BridgeBeats.Contracts.Exceptions.RetryAfterExceededException"/>
-    /// (the provider fail-fast signal). Retry/timeout values are read from <c>BridgeBeats:Resilience:*</c>
+    /// configured <b>not</b> to retry <see cref="BridgeBeats.Contracts.Exceptions.ProviderRateLimitException"/>
+    /// (including its provider fail-fast subtype). Retry/timeout values are read from <c>BridgeBeats:Resilience:*</c>
     /// configuration, falling back to built-in defaults.
     /// </summary>
     /// <param name="builder">The web-application host builder to configure.</param>
@@ -62,12 +63,12 @@ public static class AspireServiceExtensions {
                 options.Retry.ShouldRetryAfterHeader = true;
                 options.Retry.DisableForUnsafeHttpMethods( );
 
-                // Exclude RetryAfterExceededException from retry logic - this is thrown intentionally
-                // to fail fast when Retry-After headers exceed the configured threshold
+                // Exclude ProviderRateLimitException (including RetryAfterExceededException) from
+                // retry logic; these are handled by the provider queue's rate-limit path.
                 Func<RetryPredicateArguments<HttpResponseMessage>, ValueTask<bool>> originalShouldHandle = options.Retry.ShouldHandle;
                 options.Retry.ShouldHandle = args => {
-                    // If the exception is RetryAfterExceededException, do not retry
-                    return args.Outcome.Exception is RetryAfterExceededException ? ValueTask.FromResult( false ) : originalShouldHandle( args );
+                    // ProviderRateLimitException is intentionally handled by the queue consumer.
+                    return args.Outcome.Exception is ProviderRateLimitException ? ValueTask.FromResult( false ) : originalShouldHandle( args );
                 };
 
                 options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes( totalTimeoutMinutes );
@@ -129,7 +130,7 @@ public static class AspireServiceExtensions {
     /// standard HTTP resilience pipeline, and OpenTelemetry. This is the worker counterpart to the
     /// <see cref="AddServiceDefaults(WebApplicationBuilder)"/> overload and shares the same resilience
     /// configuration, including not retrying
-    /// <see cref="BridgeBeats.Contracts.Exceptions.RetryAfterExceededException"/>. Health checks are
+    /// <see cref="BridgeBeats.Contracts.Exceptions.ProviderRateLimitException"/>. Health checks are
     /// not registered here because generic hosts do not expose the HTTP health endpoint.
     /// </summary>
     /// <param name="builder">The generic host builder to configure.</param>
@@ -154,12 +155,12 @@ public static class AspireServiceExtensions {
                 options.Retry.ShouldRetryAfterHeader = true;
                 options.Retry.DisableForUnsafeHttpMethods( );
 
-                // Exclude RetryAfterExceededException from retry logic - this is thrown intentionally
-                // to fail fast when Retry-After headers exceed the configured threshold
+                // Exclude ProviderRateLimitException (including RetryAfterExceededException) from
+                // retry logic; these are handled by the provider queue's rate-limit path.
                 Func<RetryPredicateArguments<HttpResponseMessage>, ValueTask<bool>> originalShouldHandle = options.Retry.ShouldHandle;
                 options.Retry.ShouldHandle = args => {
-                    // If the exception is RetryAfterExceededException, do not retry
-                    return args.Outcome.Exception is RetryAfterExceededException ? ValueTask.FromResult( false ) : originalShouldHandle( args );
+                    // ProviderRateLimitException is intentionally handled by the queue consumer.
+                    return args.Outcome.Exception is ProviderRateLimitException ? ValueTask.FromResult( false ) : originalShouldHandle( args );
                 };
 
                 options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes( totalTimeoutMinutes );
@@ -242,7 +243,8 @@ public static class AspireServiceExtensions {
                 _ = tracing
                     .SetResourceBuilder( resourceBuilder )
                     .AddAspNetCoreInstrumentation( )
-                    .AddHttpClientInstrumentation( );
+                    .AddHttpClientInstrumentation( )
+                    .AddSource( QueueMetrics.ActivitySourceName );
 
                 _ = tracing.AddOtlpExporter( otlpOptions => {
                     if (hasCustomEndpoint) {
@@ -263,7 +265,7 @@ public static class AspireServiceExtensions {
                     .AddAspNetCoreInstrumentation( )
                     .AddHttpClientInstrumentation( )
                     .AddRuntimeInstrumentation( )
-                    .AddMeter( "BridgeBeats.Queue" )
+                    .AddMeter( QueueMetrics.MeterName )
                     .AddMeter( "BridgeBeats.Providers" )
                     .AddMeter( "BridgeBeats.Spotify.Batch" );
 
@@ -321,7 +323,8 @@ public static class AspireServiceExtensions {
                 // Note: No AddAspNetCoreInstrumentation() for non-web hosts
                 _ = tracing
                     .SetResourceBuilder( resourceBuilder )
-                    .AddHttpClientInstrumentation( );
+                    .AddHttpClientInstrumentation( )
+                    .AddSource( QueueMetrics.ActivitySourceName );
 
                 _ = tracing.AddOtlpExporter( otlpOptions => {
                     if (hasCustomEndpoint) {
@@ -342,7 +345,7 @@ public static class AspireServiceExtensions {
                     .SetResourceBuilder( resourceBuilder )
                     .AddHttpClientInstrumentation( )
                     .AddRuntimeInstrumentation( )
-                    .AddMeter( "BridgeBeats.Queue" )
+                    .AddMeter( QueueMetrics.MeterName )
                     .AddMeter( "BridgeBeats.Providers" )
                     .AddMeter( "BridgeBeats.Spotify.Batch" );
 

--- a/src/BridgeBeats.Core/Domain/Extensions/ProviderServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/ProviderServiceExtensions.cs
@@ -165,6 +165,8 @@ namespace BridgeBeats.Core.Domain.Extensions {
             } )
             .ConfigurePrimaryHttpMessageHandler( ( ) => SsrfSocketsHttpHandlerFactory.Create(
                 connectTimeout: TimeSpan.FromSeconds( 10 ) ) )
+            .ConfigureAdditionalHttpMessageHandlers( ( handlers, _ ) =>
+                handlers.Insert( 0, new TerminalProviderRateLimitHandler( SupportedProviders.AppleMusic ) ) )
             .AddHttpMessageHandler( CreateRetryAfterLimitHandlerFactory( maxRetryAfterSeconds ) )
             .AddHttpMessageHandler( ( ) => new ProviderMetricsHandler( "applemusic" ) );
 
@@ -215,6 +217,8 @@ namespace BridgeBeats.Core.Domain.Extensions {
             } )
             .ConfigurePrimaryHttpMessageHandler( ( ) => SsrfSocketsHttpHandlerFactory.Create(
                 connectTimeout: TimeSpan.FromSeconds( 10 ) ) )
+            .ConfigureAdditionalHttpMessageHandlers( ( handlers, _ ) =>
+                handlers.Insert( 0, new TerminalProviderRateLimitHandler( SupportedProviders.Spotify ) ) )
             .AddHttpMessageHandler( handlerFactory )
             .AddHttpMessageHandler( ( ) => new ProviderMetricsHandler( "spotify" ) );
 
@@ -269,6 +273,8 @@ namespace BridgeBeats.Core.Domain.Extensions {
             } )
             .ConfigurePrimaryHttpMessageHandler( ( ) => SsrfSocketsHttpHandlerFactory.Create(
                 connectTimeout: TimeSpan.FromSeconds( 10 ) ) )
+            .ConfigureAdditionalHttpMessageHandlers( ( handlers, _ ) =>
+                handlers.Insert( 0, new TerminalProviderRateLimitHandler( SupportedProviders.Tidal ) ) )
             .AddHttpMessageHandler( handlerFactory )
             .AddHttpMessageHandler( ( ) => new ProviderMetricsHandler( "tidal" ) );
 

--- a/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/ServiceExtensions.cs
@@ -208,7 +208,8 @@ public static class ServiceExtensions {
             sp.GetRequiredService<ISagaStateManager>( ),
             sp.GetRequiredService<TLookupService>( ),
             provider,
-            sp.GetRequiredService<ILogger<QueueProcessorBackgroundService>>( )
+            sp.GetRequiredService<ILogger<QueueProcessorBackgroundService>>( ),
+            sp.GetRequiredService<IOptions<QueueSettings>>( ).Value
         ) );
 
         return services;
@@ -253,7 +254,8 @@ public static class ServiceExtensions {
             sp.GetRequiredService<ISagaStateManager>( ),
             lookupServiceFactory( sp ),
             provider,
-            sp.GetRequiredService<ILogger<QueueProcessorBackgroundService>>( )
+            sp.GetRequiredService<ILogger<QueueProcessorBackgroundService>>( ),
+            sp.GetRequiredService<IOptions<QueueSettings>>( ).Value
         ) );
 
         return services;

--- a/src/BridgeBeats.Core/Domain/Extensions/WorkerEndpointExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/WorkerEndpointExtensions.cs
@@ -1,8 +1,12 @@
+using System.Globalization;
 using BridgeBeats.Contracts.DTOs;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records.WorkerApi;
+using BridgeBeats.Core.Infrastructure.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace BridgeBeats.Core.Domain.Extensions;
 
@@ -13,7 +17,7 @@ namespace BridgeBeats.Core.Domain.Extensions;
 /// <see cref="BridgeBeats.Contracts.Interfaces.IMusicLookupService"/>, and the result is returned in
 /// a <see cref="BridgeBeats.Contracts.Records.WorkerApi.ProviderLookupResponse"/> envelope.
 /// </summary>
-public static class WorkerEndpointExtensions {
+public static partial class WorkerEndpointExtensions {
 
     /// <summary>
     /// Maps the six <c>/lookup/*</c> minimal-API routes (<c>url</c>, <c>isrc</c>, <c>upc</c>,
@@ -29,9 +33,7 @@ public static class WorkerEndpointExtensions {
     /// <param name="app">The endpoint route builder to map the routes onto.</param>
     /// <returns>The same <paramref name="app"/>, to allow call chaining.</returns>
     /// <remarks>
-    /// Every route returns HTTP 200 regardless of outcome — successes carry the result and failures
-    /// carry an error envelope (see <see cref="ExecuteLookupAsync"/>). Callers must read the
-    /// envelope's success flag, not the HTTP status code, to tell success from failure.
+    /// Every route returns HTTP 200 for success and no-match, or a sanitized status-bearing error.
     /// </remarks>
     public static IEndpointRouteBuilder MapProviderLookupEndpoints<TService>(
         this IEndpointRouteBuilder app
@@ -39,27 +41,27 @@ public static class WorkerEndpointExtensions {
         // Resolve service per-request instead of at startup to avoid lifecycle issues
         _ = app.MapPost( "/lookup/url", async ( LookupByUrlRequest request, HttpContext context ) => {
             TService service = context.RequestServices.GetRequiredService<TService>( );
-            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( request.Url ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( request.Url ), context );
         } );
 
         _ = app.MapPost( "/lookup/isrc", async ( LookupByIsrcRequest request, HttpContext context ) => {
             TService service = context.RequestServices.GetRequiredService<TService>( );
-            return await ExecuteLookupAsync( ( ) => service.GetInfoByISRCAsync( request.Isrc ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoByISRCAsync( request.Isrc ), context );
         } );
 
         _ = app.MapPost( "/lookup/upc", async ( LookupByUpcRequest request, HttpContext context ) => {
             TService service = context.RequestServices.GetRequiredService<TService>( );
-            return await ExecuteLookupAsync( ( ) => service.GetInfoByUPCAsync( request.Upc ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoByUPCAsync( request.Upc ), context );
         } );
 
         _ = app.MapPost( "/lookup/id", async ( LookupByIdRequest request, HttpContext context ) => {
             TService service = context.RequestServices.GetRequiredService<TService>( );
-            return await ExecuteLookupAsync( ( ) => service.GetInfoByIDAsync( request.ProviderId, request.IsAlbum ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoByIDAsync( request.ProviderId, request.IsAlbum ), context );
         } );
 
         _ = app.MapPost( "/lookup/metadata", async ( LookupByMetadataRequest request, HttpContext context ) => {
             TService service = context.RequestServices.GetRequiredService<TService>( );
-            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( request.Title, request.Artist ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( request.Title, request.Artist ), context );
         } );
 
         _ = app.MapPost( "/lookup/from-result", async ( LookupFromResultRequest request, HttpContext context ) => {
@@ -70,27 +72,61 @@ public static class WorkerEndpointExtensions {
                 ExternalId = request.ExternalId ?? string.Empty,
                 IsAlbum = request.IsAlbum
             };
-            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( lookup ) );
+            return await ExecuteLookupAsync( ( ) => service.GetInfoAsync( lookup ), context );
         } );
 
         return app;
     }
 
     /// <summary>
-    /// Runs a single lookup and wraps its outcome in a
-    /// <see cref="BridgeBeats.Contracts.Records.WorkerApi.ProviderLookupResponse"/> returned as HTTP
-    /// 200. A successful call yields an <c>Ok</c> envelope; any thrown exception is caught and
-    /// returned as an <c>Error</c> envelope (still HTTP 200), so the success flag in the envelope is
-    /// the authoritative outcome signal.
+    /// Runs a single lookup and returns the current status-bearing worker contract.
     /// </summary>
     /// <param name="lookupFunc">The lookup to invoke.</param>
-    /// <returns>An HTTP 200 result carrying the success or error envelope.</returns>
-    private static async Task<IResult> ExecuteLookupAsync( Func<Task<MusicLookupResult?>> lookupFunc ) {
+    /// <param name="context">The current request, used for cancellation.</param>
+    /// <returns>A successful envelope or a sanitized status-bearing error.</returns>
+    private static async Task<IResult> ExecuteLookupAsync( Func<Task<MusicLookupResult?>> lookupFunc, HttpContext context ) {
         try {
             MusicLookupResult? result = await lookupFunc( );
-            return Results.Ok( ProviderLookupResponse.Ok( result ) );
+            return Results.Ok( result is null ? ProviderLookupResponse.NotFound( ) : ProviderLookupResponse.Ok( result ) );
+        } catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested) {
+            throw;
+        } catch (OperationCanceledException) {
+            return Results.Json( ProviderLookupResponse.Error( "Provider lookup timed out." ), statusCode: StatusCodes.Status504GatewayTimeout );
+        } catch (ProviderRateLimitException ex) {
+            double retrySeconds = Math.Max( 0, ex.RetryAfterValue.TotalSeconds );
+            int retryHeaderSeconds = retrySeconds >= int.MaxValue
+                ? int.MaxValue
+                : (int)Math.Ceiling( retrySeconds );
+            context.Response.Headers.RetryAfter = retryHeaderSeconds.ToString( CultureInfo.InvariantCulture );
+            ProviderLookupResponse envelope = ex is RetryAfterExceededException exceeded
+                ? ProviderLookupResponse.Error(
+                    "Provider rate limit exceeded.",
+                    retrySeconds,
+                    Math.Max( 0, exceeded.Threshold.TotalSeconds ) )
+                : ProviderLookupResponse.Error( "Provider rate limit exceeded.", retrySeconds );
+            return Results.Json(
+                envelope,
+                statusCode: StatusCodes.Status429TooManyRequests );
+        } catch (HttpRequestException) {
+            return Results.Json( ProviderLookupResponse.Error( "Provider lookup failed." ), statusCode: StatusCodes.Status503ServiceUnavailable );
+        } catch (IOException) {
+            return Results.Json( ProviderLookupResponse.Error( "Provider lookup failed." ), statusCode: StatusCodes.Status503ServiceUnavailable );
+        } catch (TimeoutException) {
+            return Results.Json( ProviderLookupResponse.Error( "Provider lookup timed out." ), statusCode: StatusCodes.Status504GatewayTimeout );
         } catch (Exception ex) {
-            return Results.Ok( ProviderLookupResponse.Error( ex.Message ) );
+            ILogger<WorkerEndpointLogCategory> logger =
+                context.RequestServices.GetRequiredService<ILogger<WorkerEndpointLogCategory>>( );
+            LogUnexpectedProviderLookupFailure( logger, ex );
+            return Results.Json( ProviderLookupResponse.Error( "Provider lookup failed." ), statusCode: StatusCodes.Status500InternalServerError );
         }
     }
+
+    [LoggerMessage(
+        EventId = LogEventIds.Providers.Common.UnexpectedWorkerLookupFailure,
+        Level = LogLevel.Error,
+        Message = "Unexpected provider lookup failure." )]
+    private static partial void LogUnexpectedProviderLookupFailure( ILogger logger, Exception ex );
 }
+
+/// <summary>Typed logging category for worker HTTP endpoint execution.</summary>
+internal sealed class WorkerEndpointLogCategory;

--- a/src/BridgeBeats.Core/Domain/Extensions/WorkerEndpointExtensions.cs
+++ b/src/BridgeBeats.Core/Domain/Extensions/WorkerEndpointExtensions.cs
@@ -87,7 +87,7 @@ public static partial class WorkerEndpointExtensions {
     private static async Task<IResult> ExecuteLookupAsync( Func<Task<MusicLookupResult?>> lookupFunc, HttpContext context ) {
         try {
             MusicLookupResult? result = await lookupFunc( );
-            return Results.Ok( result is null ? ProviderLookupResponse.NotFound( ) : ProviderLookupResponse.Ok( result ) );
+            return Results.Ok( ProviderLookupResponse.Ok( result ) );
         } catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested) {
             throw;
         } catch (OperationCanceledException) {

--- a/src/BridgeBeats.Core/Domain/Providers/Common/HttpMusicLookupService.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Common/HttpMusicLookupService.cs
@@ -1,6 +1,8 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records.WorkerApi;
 using BridgeBeats.Core.Infrastructure.Logging;
@@ -14,9 +16,8 @@ namespace BridgeBeats.Core.Domain.Providers.Common;
 /// <remarks>
 /// This is the proxy half of the two <see cref="IMusicLookupService"/> implementation families. It
 /// posts each request to a named worker (one of the <c>/lookup/*</c> routes) and unwraps the worker's
-/// <see cref="ProviderLookupResponse"/> envelope. Success is signalled by the envelope, not the HTTP
-/// status code: the worker returns HTTP 200 even for handled errors and reports failure through
-/// <see cref="ProviderLookupResponse.Success"/> / <see cref="ProviderLookupResponse.ErrorMessage"/>.
+/// <see cref="ProviderLookupResponse"/> envelope. Status-bearing responses are mapped to typed
+/// exceptions while a successful no-match envelope maps to <see langword="null"/>.
 /// Direct, in-process provider services derive instead from <see cref="MusicLookupServiceBase"/>.
 /// </remarks>
 /// <param name="provider">The provider this proxy represents, surfaced through <see cref="Provider"/>.</param>
@@ -104,34 +105,64 @@ public partial class HttpMusicLookupService(
     /// <param name="endpoint">The worker route (for example <c>/lookup/url</c>) to post to.</param>
     /// <param name="request">The request payload to serialize as JSON.</param>
     /// <returns>
-    /// The <see cref="ProviderLookupResponse.Result"/> on success; <see langword="null"/> when the HTTP
-    /// status is unsuccessful, the body is empty, or the envelope reports an error message.
+    /// The <see cref="ProviderLookupResponse.Result"/> on success; <see langword="null"/> for an empty
+    /// response body or the worker's successful no-match envelope.
     /// </returns>
-    /// <exception cref="HttpRequestException">Re-thrown (after logging) on a transport-level failure.</exception>
+    /// <exception cref="ProviderRateLimitException">Thrown for a worker 429 response with a valid retry delay.</exception>
+    /// <exception cref="HttpRequestException">Thrown (after logging) for a worker error status, an error envelope,
+    /// an invalid success body, or a transport-level failure.</exception>
     private async Task<MusicLookupResult?> PostAsync<TRequest>( string endpoint, TRequest request ) {
         try {
             using HttpClient client = httpClientFactory.CreateClient( httpClientName );
+            using HttpResponseMessage response = await client.PostAsJsonAsync( endpoint, request );
 
-            HttpResponseMessage response = await client.PostAsJsonAsync( endpoint, request );
+            ProviderLookupResponse? result = null;
+            try {
+                result = await response.Content.ReadFromJsonAsync<ProviderLookupResponse>( );
+            } catch (JsonException) when (!response.IsSuccessStatusCode) {
+                // Status-bearing failures do not require a response envelope.
+                LogWorkerHttpError( logger, provider, (int)response.StatusCode, endpoint );
+            } catch (JsonException ex) {
+                throw new HttpRequestException( "Provider worker returned an invalid response.", ex, response.StatusCode );
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests) {
+                // The envelope preserves sub-second precision; Retry-After is integer-rounded for
+                // HTTP interoperability and is only a fallback for non-envelope responses.
+                double? retryAfter = result?.RetryAfterSeconds ?? ParseRetryAfterSeconds( response );
+                double? threshold = result?.RetryThresholdSeconds;
+                if (!retryAfter.HasValue || !IsValidRetrySeconds( retryAfter.Value )) {
+                    throw new HttpRequestException( "Worker rate-limit response was missing retry metadata.", null, response.StatusCode );
+                }
+                TimeSpan retryDelay = TimeSpan.FromSeconds( retryAfter.Value );
+                if (threshold.HasValue && !IsValidRetrySeconds( threshold.Value )) {
+                    throw new HttpRequestException( "Worker rate-limit response contained invalid threshold metadata.", null, response.StatusCode );
+                }
+                if (threshold is >= 0 && retryAfter.Value > threshold.Value) {
+                    throw new RetryAfterExceededException( retryDelay, TimeSpan.FromSeconds( threshold.Value ), null, provider );
+                }
+                throw new ProviderRateLimitException( retryDelay, null, provider );
+            }
 
             if (!response.IsSuccessStatusCode) {
                 LogWorkerHttpError( logger, provider, (int)response.StatusCode, endpoint );
-                return null;
+                throw new HttpRequestException( "Provider worker request failed.", null, response.StatusCode );
             }
-
-            ProviderLookupResponse? result = await response.Content.ReadFromJsonAsync<ProviderLookupResponse>( );
 
             if (result == null) {
                 LogWorkerNullResponse( logger, provider, endpoint );
                 return null;
             }
 
-            if (!result.Success && !string.IsNullOrWhiteSpace( result.ErrorMessage )) {
-                LogWorkerError( logger, provider, endpoint, result.ErrorMessage );
-                return null;
+            if (!result.Success) {
+                const string Sanitized = "Provider worker reported a lookup failure.";
+                LogWorkerError( logger, provider, endpoint, Sanitized );
+                throw new HttpRequestException( Sanitized, null, System.Net.HttpStatusCode.ServiceUnavailable );
             }
 
             return result.Result;
+        } catch (ProviderRateLimitException) {
+            throw;
         } catch (HttpRequestException ex) {
             LogHttpRequestError( logger, ex, provider, endpoint );
             throw; // Re-throw to let the caller handle worker unavailability
@@ -140,6 +171,33 @@ public partial class HttpMusicLookupService(
             throw;
         }
     }
+
+    private static double? ParseRetryAfterSeconds( HttpResponseMessage response ) {
+        if (!response.Headers.TryGetValues( "Retry-After", out IEnumerable<string>? values )) {
+            return null;
+        }
+
+        string? value = values.FirstOrDefault( );
+        if (double.TryParse( value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double seconds )
+            && double.IsFinite( seconds )
+            && seconds >= 0
+            && seconds <= TimeSpan.MaxValue.TotalSeconds) {
+            return seconds;
+        }
+
+        if (DateTimeOffset.TryParse(
+                value,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AllowWhiteSpaces | System.Globalization.DateTimeStyles.AssumeUniversal,
+                out DateTimeOffset date )) {
+            return Math.Max( 0, (date - DateTimeOffset.UtcNow).TotalSeconds );
+        }
+
+        return null;
+    }
+
+    private static bool IsValidRetrySeconds( double seconds )
+        => double.IsFinite( seconds ) && seconds >= 0 && seconds <= TimeSpan.MaxValue.TotalSeconds;
 
     #region LoggerMessage Methods
 

--- a/src/BridgeBeats.Core/Domain/Providers/Common/MusicLookupServiceBase.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Common/MusicLookupServiceBase.cs
@@ -107,6 +107,12 @@ namespace BridgeBeats.Core.Domain.Providers.Common {
             HttpResponseMessage resp = await http.GetAsync( requestUri );
             if (!resp.IsSuccessStatusCode) {
                 LogApiRequestError( Logger, lookupKey, Provider.ToString( ), (int)resp.StatusCode, resp.ReasonPhrase );
+                if (resp.StatusCode is System.Net.HttpStatusCode.Unauthorized
+                    or System.Net.HttpStatusCode.Forbidden
+                    or System.Net.HttpStatusCode.RequestTimeout
+                    || (int)resp.StatusCode >= 500) {
+                    throw new HttpRequestException( $"{Provider} returned {(int)resp.StatusCode}.", null, resp.StatusCode );
+                }
                 return null;
             }
             return await resp.Content.ReadAsStringAsync( );

--- a/src/BridgeBeats.Core/Domain/Providers/Common/RetryAfterLimitHandler.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Common/RetryAfterLimitHandler.cs
@@ -11,9 +11,8 @@ namespace BridgeBeats.Core.Domain.Providers.Common {
     /// On <see cref="System.Net.HttpStatusCode.TooManyRequests"/>, the handler reads the
     /// <c>Retry-After</c> header in both delta-seconds and HTTP-date forms. When the wait exceeds
     /// <paramref name="maxRetryAfterSeconds"/> it throws <see cref="RetryAfterExceededException"/>;
-    /// otherwise the original response flows through unchanged. Register this handler before the
-    /// resilience handler in the HTTP client pipeline so 429 responses are intercepted before retry
-    /// logic is applied.
+    /// otherwise the original response flows through unchanged. Register this handler inside the
+    /// resilience handler so every Polly attempt can fail fast when the requested wait is excessive.
     /// </remarks>
     /// <param name="maxRetryAfterSeconds">The maximum tolerable <c>Retry-After</c> wait, in seconds, before failing fast.</param>
     /// <param name="logger">Logger used to record fail-fast decisions.</param>
@@ -74,7 +73,7 @@ namespace BridgeBeats.Core.Domain.Providers.Common {
         /// The wait duration; <see cref="TimeSpan.Zero"/> when a date-form value is already in the past;
         /// or <see langword="null"/> when no <c>Retry-After</c> header is present.
         /// </returns>
-        private static TimeSpan? GetRetryAfterValue( HttpResponseMessage response ) {
+        internal static TimeSpan? GetRetryAfterValue( HttpResponseMessage response ) {
             // Check for delta seconds (e.g., "Retry-After: 120")
             if (response.Headers.RetryAfter?.Delta.HasValue == true) {
                 return response.Headers.RetryAfter.Delta;

--- a/src/BridgeBeats.Core/Domain/Providers/Common/TerminalProviderRateLimitHandler.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Common/TerminalProviderRateLimitHandler.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
+
+namespace BridgeBeats.Core.Domain.Providers.Common;
+
+/// <summary>
+/// Classifies an HTTP 429 that remains after the inner resilience pipeline has exhausted its retry
+/// policy, translating it into the typed signal consumed by the provider queue.
+/// </summary>
+/// <remarks>
+/// Register this handler as the outermost provider-API handler. Polly remains responsible for all
+/// retry attempts, backoff, jitter, timeouts, and circuit breaking; this handler observes only the
+/// terminal response returned by that pipeline.
+/// </remarks>
+/// <param name="provider">The provider represented by the named HTTP client.</param>
+internal sealed class TerminalProviderRateLimitHandler( SupportedProviders provider ) : DelegatingHandler {
+    private static readonly TimeSpan s_defaultRetryAfter = TimeSpan.FromSeconds( 30 );
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    ) {
+        HttpResponseMessage response = await base.SendAsync( request, cancellationToken );
+        if (response.StatusCode != HttpStatusCode.TooManyRequests) {
+            return response;
+        }
+
+        TimeSpan retryAfter = RetryAfterLimitHandler.GetRetryAfterValue( response ) ?? s_defaultRetryAfter;
+        response.Dispose( );
+        throw new ProviderRateLimitException( retryAfter, request.RequestUri, provider );
+    }
+}

--- a/src/BridgeBeats.Core/Domain/Providers/Spotify/SpotifyLookupService.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Spotify/SpotifyLookupService.cs
@@ -376,15 +376,14 @@ namespace BridgeBeats.Core.Domain.Providers.Spotify {
         }
 
         /// <summary>
-        /// Performs an API request for bulk lookup operations with a custom endpoint key for rate
-        /// limiting, translating a 429 into a rate-limit exception.
+        /// Performs an API request for bulk lookup operations, using a custom endpoint key for
+        /// failure diagnostics.
         /// </summary>
         /// <param name="requestUri">The API endpoint URI.</param>
         /// <param name="endpointKey">The endpoint key for rate limit tracking.</param>
-        /// <returns>The response body on success, or <see langword="null"/> on any non-2xx status other than 400 and 429 (which throw — see exceptions below); 401, 403, 404, and 5xx return <see langword="null"/>.</returns>
-        /// <exception cref="Contracts.Exceptions.RetryAfterExceededException">
-        /// Thrown when the response is HTTP 429; the <c>Retry-After</c> delta (or 30 seconds when absent)
-        /// is carried on the exception.
+        /// <returns>The response body on success, or <see langword="null"/> on any non-2xx status other than 400 (which throws — see exceptions below); 401, 403, 404, and 5xx return <see langword="null"/>.</returns>
+        /// <exception cref="Contracts.Exceptions.ProviderRateLimitException">
+        /// Thrown by the provider HTTP pipeline when its Polly retry policy exhausts an HTTP 429.
         /// </exception>
         /// <exception cref="Contracts.Exceptions.SpotifyBulkRejectedException">
         /// Thrown when the response is HTTP 400 Bad Request. A 400 indicates a malformed or otherwise
@@ -398,19 +397,6 @@ namespace BridgeBeats.Core.Domain.Providers.Spotify {
 
             if (response.IsSuccessStatusCode) {
                 return await response.Content.ReadAsStringAsync( );
-            }
-
-            // Handle rate limiting with custom endpoint key
-            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests) {
-                TimeSpan retryAfter = response.Headers.RetryAfter?.Delta ?? TimeSpan.FromSeconds( 30 );
-                LogBulkRateLimited( Logger, endpointKey, retryAfter );
-                // Use the standard threshold - bulk requests are always thrown for requeue
-                throw new Contracts.Exceptions.RetryAfterExceededException(
-                    retryAfter,
-                    TimeSpan.Zero, // Threshold is 0 since bulk requests are always queued
-                    new Uri( client.BaseAddress!, requestUri ),
-                    SupportedProviders.Spotify
-                );
             }
 
             // Only a 400 Bad Request indicates a malformed id; other failures fall through to
@@ -813,16 +799,6 @@ namespace BridgeBeats.Core.Domain.Providers.Spotify {
             Level = LogLevel.Error,
             Message = "An error occurred while parsing bulk artists response from Spotify." )]
         internal static partial void LogParseBulkArtistsError( ILogger logger, Exception ex );
-
-        /// <summary>Logs rate limiting on bulk endpoint.</summary>
-        /// <param name="logger">The logger to write to.</param>
-        /// <param name="endpoint">The bulk endpoint label.</param>
-        /// <param name="retryAfter">The wait before retrying.</param>
-        [LoggerMessage(
-            EventId = LogEventIds.Providers.Spotify.BulkRateLimited,
-            Level = LogLevel.Warning,
-            Message = "Rate limited on bulk endpoint {Endpoint}, retry after {RetryAfter}" )]
-        internal static partial void LogBulkRateLimited( ILogger logger, string endpoint, TimeSpan retryAfter );
 
         /// <summary>Logs bulk API request failure.</summary>
         /// <param name="logger">The logger to write to.</param>

--- a/src/BridgeBeats.Core/Domain/Providers/Spotify/SpotifyLookupService.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Spotify/SpotifyLookupService.cs
@@ -609,7 +609,7 @@ namespace BridgeBeats.Core.Domain.Providers.Spotify {
                         }
                     }
                 } while (response?.Artists?.Next != null);
-            } catch (Exception ex) {
+            } catch (JsonException ex) {
                 LogParseArtistListError( Logger, ex );
             }
 

--- a/src/BridgeBeats.Core/Domain/Providers/Tidal/TidalLookupService.cs
+++ b/src/BridgeBeats.Core/Domain/Providers/Tidal/TidalLookupService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using BridgeBeats.Contracts.DTOs;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Core.Domain.Providers.Common;
 using BridgeBeats.Core.Domain.Providers.Tidal.Models;
@@ -415,6 +416,8 @@ namespace BridgeBeats.Core.Domain.Providers.Tidal {
                 if (data != null && included != null) {
                     return await ParseTidalResponse( data, included, lookupKey, kind, isPrimary, storefront );
                 }
+            } catch (ProviderRateLimitException) {
+                throw;
             } catch (Exception ex) {
                 LogParseResponseError( Logger, ex, lookupKey );
                 LogResponseBodySerialized( Logger, body, SerializerOptions );
@@ -485,6 +488,8 @@ namespace BridgeBeats.Core.Domain.Providers.Tidal {
                 }
 
                 return result;
+            } catch (ProviderRateLimitException) {
+                throw;
             } catch (Exception ex) {
                 LogParseResponseError( Logger, ex, lookupKey );
                 LogDataSerialized( Logger, data, SerializerOptions );

--- a/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
+++ b/src/BridgeBeats.Core/Domain/Services/LinkResolver/LookupOrchestrator.cs
@@ -348,6 +348,16 @@ public sealed partial class LookupOrchestrator(
             // straight to the final-result wait, which honors the rate-limit escape hatch
             // and time budget (during a rate-limit window no publish would ever arrive)
             LookupSagaState? inFlightSaga = await _sagaManager.GetAsync( inFlightSagaId );
+            if (inFlightSaga is not null) {
+                await PromotePendingSagaAsync(
+                    inFlightSaga,
+                    lookupType,
+                    lookupValue,
+                    isAlbum,
+                    title,
+                    artist,
+                    initialProvider );
+            }
             string? storedResultUri = inFlightSaga?.FinalResultUri ?? inFlightSaga?.PartialResultUri;
             if (!string.IsNullOrEmpty( storedResultUri )) {
                 LogInFlightSagaHasStoredResult( _logger, inFlightSagaId );
@@ -405,6 +415,49 @@ public sealed partial class LookupOrchestrator(
     }
 
     /// <summary>
+    /// Atomically promotes an existing maintenance generation and publishes interactive copies of
+    /// its unfinished provider legs. Only the caller that changes the persisted priority publishes,
+    /// so concurrent manual lookups cannot create an interactive fan-out storm.
+    /// </summary>
+    private async Task PromotePendingSagaAsync(
+        LookupSagaState saga,
+        LookupRequestType lookupType,
+        string lookupValue,
+        bool isAlbum,
+        string? title,
+        string? artist,
+        SupportedProviders? initialProvider
+    ) {
+        if (string.IsNullOrWhiteSpace( saga.InstanceToken )
+            || !await _sagaManager.TryPromoteToInteractiveAsync( saga.SagaId, saga.InstanceToken )) {
+            return;
+        }
+
+        IEnumerable<SupportedProviders> candidates = initialProvider.HasValue
+            ? [initialProvider.Value]
+            : _enabledProviders;
+        foreach (SupportedProviders provider in candidates) {
+            if (saga.ProviderStates.TryGetValue( provider, out ProviderLookupState? state ) && state.IsComplete) {
+                continue;
+            }
+
+            IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue( provider );
+            await queue.EnqueueAsync( new QueuedLookupRequest {
+                RequestId = Guid.NewGuid( ).ToString( "N" ),
+                Provider = provider,
+                LookupType = lookupType,
+                LookupValue = lookupValue,
+                SagaId = saga.SagaId,
+                SagaInstanceToken = saga.InstanceToken,
+                IsAlbum = isAlbum,
+                Title = title,
+                Artist = artist,
+                OriginPriority = QueuePriority.Interactive
+            }, QueuePriority.Interactive );
+        }
+    }
+
+    /// <summary>
     /// Creates (or resumes) the saga for an acquired lookup and drives it to a result. Generates the
     /// saga id from the lookup key, gets-or-creates the saga, and — if it already carries a stored
     /// result — releases the dedup lock with that URI and waits for the final result. Otherwise it
@@ -436,7 +489,8 @@ public sealed partial class LookupOrchestrator(
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
 
         // Create a saga, or resume one already started for this deterministic lookup key.
-        LookupSagaState saga = await _sagaManager.GetOrCreateAsync( sagaId, lookupKey, lookupType, lookupValue );
+        LookupSagaState saga = await _sagaManager.GetOrCreateAsync(
+            sagaId, lookupKey, lookupType, lookupValue, QueuePriority.Interactive );
 
         DateTimeOffset deadline = DateTimeOffset.UtcNow + waitTimeout;
 
@@ -456,6 +510,9 @@ public sealed partial class LookupOrchestrator(
 
         // Determine which provider to queue first
         SupportedProviders firstProvider = initialProvider ?? _enabledProviders.First();
+        if (!string.IsNullOrWhiteSpace( saga.InstanceToken )) {
+            _ = await _sagaManager.TryPromoteToInteractiveAsync( sagaId, saga.InstanceToken );
+        }
 
         // For direct lookups (ISRC/UPC without initialProvider), initialize all enabled providers
         // For URL lookups (with initialProvider), only initialize the first provider
@@ -465,22 +522,40 @@ public sealed partial class LookupOrchestrator(
             ? [firstProvider]
             : [.. _enabledProviders];
 
-        await _sagaManager.InitializeProviderStatesAsync( sagaId, providersToInitialize );
+        if (string.IsNullOrWhiteSpace( saga.InstanceToken )
+            || !await _sagaManager.TryInitializeProviderStatesAsync( sagaId, providersToInitialize, saga.InstanceToken )) {
+            throw new InvalidOperationException( $"Saga instance was replaced before provider initialization for {sagaId}." );
+        }
 
         // If we have an initial provider (from URL lookup), set it
         if (initialProvider.HasValue) {
-            await _sagaManager.SetInitialProviderAsync( sagaId, initialProvider.Value );
+            if (!await _sagaManager.TrySetInitialProviderAsync( sagaId, initialProvider.Value, saga.InstanceToken )) {
+                throw new InvalidOperationException( $"Saga instance was replaced before initial-provider registration for {sagaId}." );
+            }
         }
 
-        // Queue the initial provider lookup at Interactive priority,
-        // unless the resumed saga already has this provider queued or completed
-        if (!saga.ProviderStates.ContainsKey( firstProvider )) {
+        // Direct external-id lookups own one independent leg per enabled provider. URL lookups
+        // intentionally start with only the URL's provider and let the coordinator derive
+        // secondary identifiers. When a maintenance saga is promoted, enqueue an interactive copy
+        // for every still-pending direct leg; the generation fence makes the old bulk copy stale
+        // after the first successful commit.
+        IReadOnlyList<SupportedProviders> providersToEnqueue = initialProvider.HasValue
+            ? [firstProvider]
+            : providersToInitialize;
+        foreach (SupportedProviders provider in providersToEnqueue) {
+            bool providerMissing = !saga.ProviderStates.TryGetValue(
+                provider, out ProviderLookupState? queuedProviderState );
+            if (!providerMissing && queuedProviderState!.IsComplete) {
+                continue;
+            }
+
             QueuedLookupRequest request = new( ) {
                 RequestId = Guid.NewGuid( ).ToString( "N" ),
-                Provider = firstProvider,
+                Provider = provider,
                 LookupType = lookupType,
                 LookupValue = lookupValue,
                 SagaId = sagaId,
+                SagaInstanceToken = saga.InstanceToken,
                 IsAlbum = isAlbum,
                 Title = title,
                 Artist = artist,
@@ -489,10 +564,10 @@ public sealed partial class LookupOrchestrator(
                 OriginPriority = QueuePriority.Interactive
             };
 
-            IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue( firstProvider );
+            IRequestQueue<QueuedLookupRequest> queue = _queueResolver.GetQueue( provider );
             await queue.EnqueueAsync( request, QueuePriority.Interactive );
 
-            LogSagaCreated( _logger, sagaId, firstProvider, lookupType, lookupValue );
+            LogSagaCreated( _logger, sagaId, provider, lookupType, lookupValue );
         }
 
         // Wait for initial result via deduplicator subscription

--- a/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
+++ b/src/BridgeBeats.Core/Domain/Services/Queue/QueueProcessorBackgroundService.cs
@@ -24,12 +24,15 @@ namespace BridgeBeats.Core.Domain.Services.Queue;
 /// Per message the loop: resolves or creates the saga and initializes this provider's state;
 /// pre-checks the endpoint rate limit and requeues if limited; performs the lookup; on success
 /// records the serialized result, checks/publishes saga completion, publishes the per-lookup
-/// completion, and acknowledges. A <see cref="RetryAfterExceededException"/> marks the saga partial,
-/// merges this provider's rate-limit window, publishes the rate-limited sentinel, and re-enqueues at
-/// background priority (interactive requests are explicitly deferred to the background lane). Other
-/// exceptions retry up to <see cref="LookupConstants.MaxQueueRetryAttempts"/>, then move to the DLQ.
+/// completion, and acknowledges. A <see cref="ProviderRateLimitException"/> (including its
+/// <see cref="RetryAfterExceededException"/> subtype) marks the saga partial,
+/// merges this provider's rate-limit window, publishes the rate-limited sentinel, and re-enqueues on
+/// the origin lane (interactive requests remain interactive). Other exceptions retry up to
+/// <see cref="LookupConstants.MaxQueueRetryAttempts"/>, then move to the DLQ.
 /// </remarks>
 public sealed partial class QueueProcessorBackgroundService : BackgroundService {
+    private sealed class PermanentRequestException( string message ) : Exception( message );
+
     /// <summary>The Redis connection used to publish saga and lookup completion events.</summary>
     private readonly IConnectionMultiplexer _redis;
     /// <summary>This provider's request queue, drained for work.</summary>
@@ -44,6 +47,8 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     private readonly SupportedProviders _provider;
     /// <summary>The logger for processing lifecycle, rate-limit, and failure diagnostics.</summary>
     private readonly ILogger<QueueProcessorBackgroundService> _logger;
+    /// <summary>Bound on simultaneous provider calls made by this worker.</summary>
+    private readonly int _maxConcurrency;
     /// <summary>camelCase JSON options used to serialize provider results into saga state.</summary>
     private readonly JsonSerializerOptions _jsonOptions;
 
@@ -51,10 +56,9 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     private const string SagaCompletedChannel = "saga:completed";
     /// <summary>Prefix for the per-lookup Redis channel (<c>complete:{lookupKey}</c>) that wakes orchestrator waiters.</summary>
     private const string LookupCompleteChannelPrefix = "complete:";
-    /// <summary>Idle-poll delay applied when the queue has no message ready (100 ms).</summary>
-    private static readonly TimeSpan s_noMessageDelay = TimeSpan.FromMilliseconds( 100 );
-    /// <summary>Backoff applied after an unexpected loop error before retrying (1 second).</summary>
+    /// <summary>Scheduled recovery event after an unexpected loop error (1 second).</summary>
     private static readonly TimeSpan s_errorDelay = TimeSpan.FromSeconds( 1 );
+    private const int MaxAcknowledgementRecoveryAttempts = 4;
 
     /// <summary>
     /// Initializes a processor for a single provider with its queue, rate-limit tracker, saga manager,
@@ -67,6 +71,7 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// <param name="lookupService">The provider lookup service that performs the actual API call.</param>
     /// <param name="provider">The provider this processor serves.</param>
     /// <param name="logger">The logger for processing diagnostics.</param>
+    /// <param name="settings">Queue settings that bound per-provider concurrency.</param>
     /// <exception cref="ArgumentNullException">Thrown when any required dependency is null.</exception>
     public QueueProcessorBackgroundService(
         IConnectionMultiplexer redis,
@@ -75,7 +80,8 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
         ISagaStateManager sagaManager,
         IMusicLookupService lookupService,
         SupportedProviders provider,
-        ILogger<QueueProcessorBackgroundService> logger
+        ILogger<QueueProcessorBackgroundService> logger,
+        QueueSettings? settings = null
     ) {
         _redis = redis ?? throw new ArgumentNullException( nameof( redis ) );
         _queue = queue ?? throw new ArgumentNullException( nameof( queue ) );
@@ -84,6 +90,7 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
         _lookupService = lookupService ?? throw new ArgumentNullException( nameof( lookupService ) );
         _provider = provider;
         _logger = logger ?? throw new ArgumentNullException( nameof( logger ) );
+        _maxConcurrency = (settings ?? new QueueSettings( )).GetProviderConcurrency( provider );
 
         _jsonOptions = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -93,50 +100,224 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
 
     /// <summary>
     /// Runs the consume loop until the host stops. Ensures Redis Streams consumer groups exist, then
-    /// repeatedly dequeues (rate-limit aware), processing each message or idle-polling when none is
-    /// ready. Cancellation ends the loop; other loop-level errors are logged and followed by a short
-    /// backoff before continuing.
+    /// repeatedly dequeues (rate-limit aware) up to the configured concurrency. When no delivery is
+    /// eligible it waits for a Redis work notification, an in-flight completion, or the exact expiry
+    /// of a provider rate-limit window. Cancellation ends the loop; control-plane failures use a
+    /// scheduled recovery event rather than sleeping the consumer.
     /// </summary>
     /// <param name="stoppingToken">Signals that the host is shutting down.</param>
     /// <returns>A task that completes when the processor stops.</returns>
     protected override async Task ExecuteAsync( CancellationToken stoppingToken ) {
         LogQueueProcessorStarting( _logger, _provider );
 
-        // Ensure consumer groups exist before starting to consume
-        if (_queue is RedisRequestQueue<QueuedLookupRequest> redisQueue) {
-            await redisQueue.EnsureConsumerGroupsAsync( stoppingToken );
-        }
-
-        while (!stoppingToken.IsCancellationRequested) {
-            try {
-                // Use rate-limit-aware dequeue to skip messages for blocked endpoints
-                QueuedMessage<QueuedLookupRequest>? message = await _queue.DequeueAsync( _rateLimitTracker, stoppingToken );
-
-                if (message is null) {
-                    // No messages available, wait briefly before checking again
-                    await Task.Delay( s_noMessageDelay, stoppingToken );
-                    continue;
+        if (_queue is IQueueWorkSignal workSignal) {
+            while (!stoppingToken.IsCancellationRequested) {
+                try {
+                    await workSignal.InitializeWorkSignalAsync( stoppingToken );
+                    break;
+                } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+                    return;
+                } catch (Exception ex) {
+                    LogQueueProcessorLoopError( _logger, ex, _provider );
+                    await WaitForTimerEventAsync( s_errorDelay, stoppingToken );
                 }
-
-                await ProcessMessageAsync( message, stoppingToken );
-            } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
-                // Normal shutdown
-                break;
-            } catch (Exception ex) {
-                LogQueueProcessorLoopError( _logger, ex, _provider );
-                await Task.Delay( s_errorDelay, stoppingToken );
             }
         }
 
+        // Ensure consumer groups exist before starting to consume. Decorated queues expose the
+        // same capability so the processor does not depend on a concrete queue implementation.
+        if (_queue is IConsumerGroupAssurance startupQueue) {
+            try {
+                await startupQueue.EnsureConsumerGroupsAsync( stoppingToken );
+            } catch (Exception ex) when (ex is not OperationCanceledException || !stoppingToken.IsCancellationRequested) {
+                LogQueueProcessorLoopError( _logger, ex, _provider );
+                await WaitForTimerEventAsync( s_errorDelay, stoppingToken );
+            }
+        }
+
+        Dictionary<Task, string> inFlight = [];
+        while (!stoppingToken.IsCancellationRequested) {
+            try {
+                if (inFlight.Count >= _maxConcurrency) {
+                    Task completed = await Task.WhenAny( inFlight.Keys );
+                    _ = inFlight.Remove( completed );
+                    await completed;
+                    continue;
+                }
+
+                long observedWorkVersion = _queue is IQueueWorkSignal versionedSignal
+                    ? versionedSignal.CaptureWorkVersion( )
+                    : 0;
+                QueuedMessage<QueuedLookupRequest>? message;
+                // Use rate-limit-aware dequeue to skip messages for blocked endpoints
+                message = await _queue.DequeueAsync( _rateLimitTracker, stoppingToken );
+
+                if (message is null) {
+                    foreach (Task completed in inFlight.Keys.Where( task => task.IsCompleted ).ToArray( )) {
+                        _ = inFlight.Remove( completed );
+                        await completed;
+                    }
+                    await WaitForQueueEventAsync( observedWorkVersion, inFlight, stoppingToken );
+                    continue;
+                }
+
+                if (inFlight.ContainsValue( message.MessageId )) {
+                    // Defensive second fence: a queue implementation must not hand out an active
+                    // PEL entry, but the processor still refuses concurrent work for one delivery.
+                    Task completed = await Task.WhenAny( inFlight.Keys );
+                    _ = inFlight.Remove( completed );
+                    await completed;
+                    continue;
+                }
+
+                Task processing = ProcessDequeuedMessageAsync( message, stoppingToken );
+                inFlight.Add( processing, message.MessageId );
+            } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+                // Normal shutdown
+                break;
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )
+                                                      && _queue is IConsumerGroupAssurance recoveryQueue) {
+                try {
+                    await recoveryQueue.EnsureConsumerGroupsAsync( stoppingToken );
+                } catch (Exception repairEx) when (repairEx is not OperationCanceledException || !stoppingToken.IsCancellationRequested) {
+                    LogQueueProcessorLoopError( _logger, repairEx, _provider );
+                    await WaitForTimerEventAsync( s_errorDelay, stoppingToken );
+                }
+            } catch (Exception ex) {
+                LogQueueProcessorLoopError( _logger, ex, _provider );
+                await WaitForTimerEventAsync( s_errorDelay, stoppingToken );
+            }
+        }
+
+        try {
+            await Task.WhenAll( inFlight.Keys );
+        } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+            // Normal shutdown of in-flight provider calls.
+        }
+
         LogQueueProcessorStopping( _logger, _provider );
+    }
+
+    private async Task WaitForQueueEventAsync(
+        long observedWorkVersion,
+        IReadOnlyDictionary<Task, string> inFlight,
+        CancellationToken cancellationToken
+    ) {
+        if (_queue is IQueueWorkSignal workSignal) {
+            IReadOnlyList<RateLimitedEndpoint> limits =
+                await _rateLimitTracker.GetAllRateLimitedAsync( _provider, cancellationToken );
+            DateTimeOffset? nextEligibility = limits.Count == 0
+                ? null
+                : limits.Min( limit => limit.RetryAfter );
+            Task wake = workSignal.WaitForWorkAsync( observedWorkVersion, nextEligibility, cancellationToken );
+            if (inFlight.Count == 0) {
+                await wake;
+            } else {
+                _ = await Task.WhenAny( inFlight.Keys.Append( wake ) );
+            }
+            return;
+        }
+
+        if (inFlight.Count > 0) {
+            _ = await Task.WhenAny( inFlight.Keys );
+            return;
+        }
+
+        // Alternate queue implementations without broker notifications receive a scheduled event;
+        // the production Redis queue never enters this fallback.
+        await WaitForTimerEventAsync( TimeSpan.FromMilliseconds( 100 ), cancellationToken );
+    }
+
+    private static async Task WaitForTimerEventAsync( TimeSpan dueTime, CancellationToken cancellationToken ) {
+        TaskCompletionSource elapsed = new( TaskCreationOptions.RunContinuationsAsynchronously );
+        using Timer timer = new(
+            static state => ((TaskCompletionSource)state!).TrySetResult( ),
+            elapsed,
+            dueTime,
+            Timeout.InfiniteTimeSpan );
+        await elapsed.Task.WaitAsync( cancellationToken );
+    }
+
+    private async Task ProcessDequeuedMessageAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        CancellationToken stoppingToken
+    ) {
+        Stopwatch wallStopwatch = Stopwatch.StartNew( );
+        using Activity? wallActivity = QueueMetrics.ActivitySource.StartActivity( "queue.message.wall" );
+        _ = (wallActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+        _ = (wallActivity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+        try {
+            await ProcessMessageAsync( message, stoppingToken );
+        } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+            // The unacknowledged delivery remains in the PEL for recovery after restart.
+        } catch (PostCommitAcknowledgementException ex) {
+            LogQueueProcessorLoopError( _logger, ex, _provider );
+            // The provider result is committed. Broker recovery must not consume one of the
+            // bounded provider-work slots during a Redis outage.
+            Task recovery = RecoverCommittedAcknowledgementAsync( message, stoppingToken );
+            if (_queue is IQueueDeliveryTracker) {
+                _ = recovery;
+            } else {
+                // Alternate/test queues have no active-delivery fence, so they must keep this
+                // delivery attached to the loop until recovery finishes or shutdown cancels it.
+                await recovery;
+            }
+        } catch (Exception ex) {
+            LogQueueProcessorLoopError( _logger, ex, _provider );
+            // Control-plane recovery is scheduled independently of provider retries. Keeping the
+            // delivery active until the event fires prevents an immediate own-PEL hot loop.
+            try {
+                await WaitForTimerEventAsync( s_errorDelay, stoppingToken );
+            } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+                return;
+            }
+            if (_queue is IQueueDeliveryTracker tracker) tracker.ReleaseDelivery( message.MessageId );
+        } finally {
+            wallStopwatch.Stop( );
+            QueueMetrics.MessageWallDuration.Record( wallStopwatch.Elapsed.TotalSeconds,
+                new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+        }
+    }
+
+    /// <summary>Retries a post-commit acknowledgement with bounded exponential backoff.</summary>
+    internal async Task RecoverCommittedAcknowledgementAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        CancellationToken cancellationToken,
+        Func<TimeSpan, CancellationToken, Task>? waitAsync = null
+    ) {
+        waitAsync ??= WaitForTimerEventAsync;
+        for (int attempt = 1; attempt <= MaxAcknowledgementRecoveryAttempts; attempt++) {
+            try {
+                await waitAsync(
+                    TimeSpan.FromSeconds( 1 << (attempt - 1) ), cancellationToken );
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                return;
+            }
+            try {
+                await _queue.AcknowledgeAsync( message.MessageId, cancellationToken );
+                QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "ack_recovered" );
+                return;
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                return;
+            } catch (Exception ackEx) {
+                LogQueueProcessorLoopError( _logger, ackEx, _provider );
+                QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "ack_recovery_failed" );
+            }
+        }
+
+        // The entry remains in Redis's PEL. Release only the local delivery fence so normal
+        // idempotent processing can recover it on a later work signal or reclaim wake.
+        if (_queue is IQueueDeliveryTracker tracker) tracker.ReleaseDelivery( message.MessageId );
     }
 
     /// <summary>
     /// Processes one dequeued message end to end: rebuilds the lookup key, ensures the saga and this
     /// provider's state, pre-checks the endpoint rate limit (requeuing if limited), performs the
     /// lookup, records the result in saga state, publishes saga and lookup completion, and
-    /// acknowledges. Rate-limit and other failures are routed to their handlers; processing duration
-    /// is always recorded as a metric.
+    /// acknowledges. Rate-limit and other failures are routed to their handlers. The processing
+    /// duration recorded here is deliberately post-dequeue only (it excludes <c>DequeueAsync</c>);
+    /// the end-to-end dequeue-to-completion metric is <c>queue.message.wall.duration</c>.
     /// </summary>
     /// <param name="message">The dequeued message carrying the lookup request.</param>
     /// <param name="ct">Cancels processing.</param>
@@ -144,96 +325,200 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     private async Task ProcessMessageAsync( QueuedMessage<QueuedLookupRequest> message, CancellationToken ct ) {
         QueuedLookupRequest request = message.Payload;
         Stopwatch stopwatch = Stopwatch.StartNew( );
+        Stopwatch? httpTimer = null;
         string status = "success";
+        string? instanceToken = null;
 
         LogProcessingMessage( _logger, message.MessageId, request.SagaId, request.LookupType );
 
-        // Ensure saga exists before processing. This handles JetStream bulk lookups where
-        // the saga ID is set but the saga hasn't been created yet (fire-and-forget pattern).
-        // For web lookups, this will return the existing saga.
-        // The lookupKey MUST use the same canonical format as LookupOrchestrator so that
-        // orchestrator-produced and worker-produced saga IDs agree for the same entity.
-        // Use LookupKeyBuilder to derive the key from the request's own fields.
-        string lookupKey = request.LookupType is LookupRequestType.SongIdLookup or LookupRequestType.AlbumIdLookup
+        try {
+
+            // Every producer creates and fences the saga before publishing its delivery. A missing
+            // saga therefore identifies an expired or stale delivery and must never be recreated
+            // here, because doing so would attach old work to a new generation.
+            // The lookupKey MUST use the same canonical format as LookupOrchestrator so that
+            // orchestrator-produced and worker-produced saga IDs agree for the same entity.
+            // Use LookupKeyBuilder to derive the key from the request's own fields.
+            string lookupKey = request.LookupType is LookupRequestType.SongIdLookup or LookupRequestType.AlbumIdLookup
             ? LookupKeyBuilder.TypedKey( request.LookupType, _provider, request.LookupValue )
             : request.LookupType == LookupRequestType.UriLookup
                 ? LookupKeyBuilder.UrlKey( request.LookupValue )
                 : $"{request.LookupType}:{request.LookupValue}";
-        _ = await _sagaManager.GetOrCreateAsync(
-            request.SagaId,
-            lookupKey,
-            request.LookupType,
-            request.LookupValue,
-            request.OriginPriority,
-            ct
-        );
-
-        // Initialize provider state for this provider if not already done
-        await _sagaManager.InitializeProviderStatesAsync( request.SagaId, [_provider], ct );
-
-        // Check if the endpoint for this lookup type is rate-limited
-        string endpoint = request.LookupType.ToString( );
-        RateLimitState rateLimitState = await _rateLimitTracker.GetStateAsync( _provider, endpoint, ct );
-
-        if (rateLimitState.IsRateLimited) {
-            if (_logger.IsEnabled( LogLevel.Debug )) {
-                DateTimeOffset retryAfter = rateLimitState.RetryAfter.GetValueOrDefault( );
-                LogEndpointRateLimited( _logger, endpoint, retryAfter, message.MessageId );
+            LookupSagaState? authoritativeSaga = await _sagaManager.GetAsync( request.SagaId, ct );
+            if (authoritativeSaga is null) {
+                // Producers create and fence the saga before publishing a delivery. Recreating it
+                // here would let a delivery from an expired generation attach to a new instance.
+                status = "stale";
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
             }
 
-            // Requeue with delay until rate limit expires
-            await _queue.RequeueAsync( message.MessageId, rateLimitState.TimeRemaining, ct );
+            bool rootIdentityMatches = string.Equals( authoritativeSaga.LookupKey, lookupKey, StringComparison.Ordinal )
+                && authoritativeSaga.LookupType == request.LookupType
+                && string.Equals( authoritativeSaga.LookupValue, request.LookupValue, StringComparison.Ordinal );
+            instanceToken = authoritativeSaga.InstanceToken;
+            if (string.IsNullOrWhiteSpace( instanceToken )) {
+                status = "stale";
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+            if (string.IsNullOrWhiteSpace( request.SagaInstanceToken )
+                || !string.Equals( request.SagaInstanceToken, instanceToken, StringComparison.Ordinal )) {
+                status = "stale";
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+            bool legitimateChild = authoritativeSaga.ProviderStates.TryGetValue( _provider, out ProviderLookupState? existingProviderState )
+                && !existingProviderState.IsComplete;
+            if (authoritativeSaga.ProviderStates.TryGetValue( _provider, out ProviderLookupState? completedProviderState )
+                && completedProviderState.IsComplete) {
+                if (completedProviderState.ErrorMessage is not null) {
+                    try {
+                        await _queue.MoveToDlqAsync( message.MessageId, completedProviderState.ErrorMessage, ct );
+                    } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                        throw;
+                    } catch (Exception ex) {
+                        throw new TerminalDlqRecoveryException( message.MessageId, ex );
+                    }
+                    QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "dlq_recovery" );
+                    status = "failure";
+                    return;
+                }
+                // A redelivered delivery can follow a successful provider commit whose ACK was
+                // lost. It is already represented by the active saga leg, so clear only this stale
+                // delivery and never invoke the provider, mutate state, or quarantine it.
+                status = "stale";
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+            if (!rootIdentityMatches
+                && !legitimateChild) {
+                status = "failure";
+                await QuarantineIdentityMismatchAsync( message, request, lookupKey, authoritativeSaga, ct );
+                return;
+            }
+            if (!await _sagaManager.TryInitializeProviderStatesAsync( request.SagaId, [_provider], instanceToken, ct )) {
+                status = "stale";
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
 
-            // Record processing duration with rate_limited status
-            stopwatch.Stop( );
-            QueueMetrics.RecordProcessingDuration( _provider, request.LookupType, "rate_limited", stopwatch.Elapsed.TotalSeconds );
-            return;
-        }
+            // Check if the endpoint for this lookup type is rate-limited
+            string endpoint = request.LookupType.ToString( );
+            RateLimitState rateLimitState = await _rateLimitTracker.GetStateAsync( _provider, endpoint, ct );
 
-        try {
+            if (rateLimitState.IsRateLimited) {
+                status = "rate_limited";
+                if (_logger.IsEnabled( LogLevel.Debug )) {
+                    DateTimeOffset retryAfter = rateLimitState.RetryAfter.GetValueOrDefault( );
+                    LogEndpointRateLimited( _logger, endpoint, retryAfter, message.MessageId );
+                }
+
+                // Requeue with delay until rate limit expires
+                await _queue.RequeueAsync( message.MessageId, rateLimitState.TimeRemaining, ct );
+
+                return;
+            }
+
             // Perform the lookup
-            MusicLookupResult? result = await PerformLookupAsync( request, ct );
+            using Activity? httpActivity = QueueMetrics.ActivitySource.StartActivity( "queue.provider_http" );
+            _ = (httpActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+            _ = (httpActivity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+            httpTimer = Stopwatch.StartNew( );
+            MusicLookupResult? result;
+            try {
+                result = await PerformLookupAsync( request, ct );
+            } finally {
+                httpTimer.Stop( );
+                httpActivity?.Stop( );
+            }
 
-            // Update saga state with successful result
-            await _sagaManager.UpdateProviderStateAsync(
-                request.SagaId,
-                new ProviderLookupState(
-                    Provider: _provider,
-                    IsComplete: true,
-                    IsSuccess: result is not null,
-                    ResultJson: result is not null ? JsonSerializer.Serialize( result, _jsonOptions ) : null,
-                    CompletedAt: DateTimeOffset.UtcNow,
-                    ErrorMessage: null
-                ),
-                ct
-            );
-
+            Stopwatch sagaTimer = Stopwatch.StartNew( );
+            using Activity? sagaActivity = QueueMetrics.ActivitySource.StartActivity( "queue.saga.update" );
+            _ = (sagaActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+            _ = (sagaActivity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+            try {
+                if (!await _sagaManager.TryUpdateProviderStateAsync( request.SagaId,
+                        new ProviderLookupState( _provider, true, result is not null,
+                            result is not null ? JsonSerializer.Serialize( result, _jsonOptions ) : null,
+                            DateTimeOffset.UtcNow, null ), instanceToken, ct )) {
+                    status = "stale";
+                    await AcknowledgeStaleDeliveryAsync( message, ct );
+                    return;
+                }
+            } finally {
+                sagaTimer.Stop( );
+                sagaActivity?.Stop( );
+                QueueMetrics.SagaUpdateDuration.Record( sagaTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+            }
             // Acknowledge the message before publishing completion events so that a crash
             // between the two does not leave the message in the PEL and re-publish both
             // completion channels on redelivery. If the publish calls are lost, the 30-second
             // polling sweep re-finalizes within one cycle.
-            await _queue.AcknowledgeAsync( message.MessageId, ct );
+            try {
+                await _queue.AcknowledgeAsync( message.MessageId, ct );
+                QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "success" );
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) {
+                // Provider state is already committed. Keep the PEL delivery pending for the
+                // worker loop's recovery/backoff path; do not feed an ACK failure into the
+                // ordinary provider-failure handler, which could overwrite or DLQ the result.
+                throw new PostCommitAcknowledgementException( message.MessageId, ex );
+            }
 
-            // Check if saga is complete and publish saga completion event for coordinator
-            await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
-
-            // Publish lookup completion so the SagaCoordinator can process via pattern subscription
-            await PublishLookupCompletionAsync( request.SagaId, ct );
+            // Provider state is already durable. Publish an idempotent progress event without a
+            // second saga read; a transient read failure here must not suppress finalization after
+            // the delivery has been acknowledged.
+            await PublishSagaProgressAsync( request.SagaId );
+            QueueMetrics.RecordSagaLegCompleted( _provider, message.Priority, "committed" );
 
             LogMessageProcessed( _logger, message.MessageId, request.SagaId );
-        } catch (OperationCanceledException) {
-            // Host is shutting down; do not publish completion events.
-            // The message will be redelivered after restart, or the polling sweep will finalize.
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Host shutdown is not a retryable provider failure; leave the message pending for
+            // redelivery after restart.
             throw;
-        } catch (RetryAfterExceededException ex) {
+        } catch (UnreadableSagaStateException ex) {
+            status = "failure";
+            await QuarantineUnreadableSagaAsync( message, request, ex, ct );
+        } catch (PostCommitAcknowledgementException) {
+            status = "failure";
+            throw;
+        } catch (TerminalDlqRecoveryException) {
+            status = "failure";
+            throw;
+        } catch (QueueDeliveryIdentityQuarantineException) {
+            status = "failure";
+            throw;
+        } catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound) {
+            status = "failure";
+            await HandlePermanentRequestExceptionAsync(
+                message,
+                request,
+                new PermanentRequestException( "Provider returned HTTP 404 (not found)." ),
+                instanceToken,
+                ct );
+        } catch (PermanentRequestException ex) {
+            status = "failure";
+            await HandlePermanentRequestExceptionAsync( message, request, ex, instanceToken, ct );
+        } catch (ProviderRateLimitException ex) {
             status = "rate_limited";
-            await HandleRateLimitExceptionAsync( message, request, ex, ct );
+            if (string.IsNullOrWhiteSpace( instanceToken )) throw;
+            await HandleRateLimitExceptionAsync( message, request, ex, instanceToken, ct );
         } catch (Exception ex) {
             status = "failure";
-            await HandleProcessingExceptionAsync( message, request, ex, ct );
+            if (string.IsNullOrWhiteSpace( instanceToken )) throw;
+            await HandleProcessingExceptionAsync( message, request, ex, instanceToken, ct );
         } finally {
             stopwatch.Stop( );
-            QueueMetrics.RecordProcessingDuration( _provider, request.LookupType, status, stopwatch.Elapsed.TotalSeconds );
+            if (httpTimer is not null) {
+                QueueMetrics.ProviderHttpDuration.Record( httpTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+            }
+            QueueMetrics.RecordProcessingDuration( _provider, request.LookupType, status, stopwatch.Elapsed.TotalSeconds, message.Priority );
         }
     }
 
@@ -319,29 +604,57 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
                 await _lookupService.GetInfoAsync( title, artist ),
             LookupRequestType.AlbumTrackLookup when title is not null && artist is not null =>
                 await _lookupService.GetInfoAsync( title, artist ),
-            _ => throw new InvalidOperationException(
+            _ => throw new PermanentRequestException(
                             $"Unsupported lookup type {lookupType} or missing required parameters"
                         )
         };
     }
 
+    private async Task HandlePermanentRequestExceptionAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        QueuedLookupRequest request,
+        PermanentRequestException ex,
+        string? instanceToken,
+        CancellationToken ct
+    ) {
+        LogProcessingFailed( _logger, ex, request.RequestId, request.SagaId );
+        if (string.IsNullOrWhiteSpace( instanceToken ) || !await _sagaManager.TryUpdateProviderStateAsync(
+            request.SagaId,
+            new ProviderLookupState(
+                _provider,
+                IsComplete: true,
+                IsSuccess: false,
+                ResultJson: null,
+                CompletedAt: DateTimeOffset.UtcNow,
+                ErrorMessage: ex.Message ),
+            instanceToken, ct )) {
+            await AcknowledgeStaleDeliveryAsync( message, ct );
+            return;
+        }
+        await _queue.MoveToDlqAsync( message.MessageId, ex.Message, ct );
+        QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "permanent_failure" );
+        await PublishSagaProgressAsync( request.SagaId );
+        QueueMetrics.RecordSagaLegCompleted( _provider, message.Priority, "committed_failure" );
+    }
+
     /// <summary>
     /// Handles a provider rate-limit hit: records the endpoint's retry window, marks the saga partial,
     /// merges this provider's rate-limit info into the saga (replacing any prior entry for it),
-    /// publishes the rate-limited sentinel to wake waiters with a partial, then acknowledges the
-    /// current message and re-enqueues the request at <see cref="QueuePriority.Background"/> with an
-    /// incremented attempt count. An interactive-origin request that hits a limit is explicitly logged
-    /// and metered as deferred to the background lane.
+    /// publishes the rate-limited sentinel to wake waiters with a partial, then re-enqueues the
+    /// request before acknowledging the current message. Interactive-origin work remains on the
+    /// interactive single-item lane across the rate-limit window.
     /// </summary>
     /// <param name="message">The message being processed when the limit was hit.</param>
     /// <param name="request">The lookup request that hit the rate limit.</param>
     /// <param name="ex">The rate-limit exception carrying the retry-after window.</param>
+    /// <param name="instanceToken">The saga instance fence captured before provider work.</param>
     /// <param name="ct">Cancels the saga and queue operations.</param>
     /// <returns>A task that completes once the saga is updated and the request re-enqueued.</returns>
     private async Task HandleRateLimitExceptionAsync(
         QueuedMessage<QueuedLookupRequest> message,
         QueuedLookupRequest request,
-        RetryAfterExceededException ex,
+        ProviderRateLimitException ex,
+        string instanceToken,
         CancellationToken ct
     ) {
         // Use the LookupRequestType as the endpoint identifier
@@ -350,11 +663,16 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
         LogRateLimitEncountered( _logger, _provider, endpoint, ex.RetryAfterValue );
 
         // Record the rate limit state
-        DateTimeOffset retryAfter = DateTimeOffset.UtcNow.Add( ex.RetryAfterValue );
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TimeSpan boundedRetry = TimeSpan.FromTicks( Math.Min( ex.RetryAfterValue.Ticks, (DateTimeOffset.MaxValue - now).Ticks ) );
+        DateTimeOffset retryAfter = now.Add( boundedRetry );
         await _rateLimitTracker.SetRateLimitedAsync( _provider, endpoint, retryAfter, ct );
 
         // Mark saga as partial and record rate limit info for user notification
-        await _sagaManager.SetIsPartialAsync( request.SagaId, true, ct );
+        if (!await _sagaManager.TrySetIsPartialAsync( request.SagaId, true, instanceToken, ct )) {
+            await AcknowledgeStaleDeliveryAsync( message, ct );
+            return;
+        }
 
         // Merge with rate limit info recorded by other providers so no entry is lost -
         // the orchestrator's all-pending-providers-rate-limited escape hatch depends on
@@ -367,25 +685,32 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
             : [];
         mergedRateLimitInfo.Add( new ProviderRateLimitInfo( _provider, retryAfter, endpoint ) );
 
-        await _sagaManager.SetRateLimitInfoAsync( request.SagaId, mergedRateLimitInfo, ct );
+        if (!await _sagaManager.TrySetRateLimitInfoAsync( request.SagaId, mergedRateLimitInfo, instanceToken, ct )) {
+            await AcknowledgeStaleDeliveryAsync( message, ct );
+            return;
+        }
 
         // Publish rate-limited sentinel so waiting clients know this is a partial result
-        await PublishRateLimitSentinelAsync( request.SagaId, ct );
+        await PublishRateLimitSentinelAsync( request.SagaId, instanceToken, ct );
 
         // Requeue request - it will be skipped by rate-limit-aware dequeue until rate limit expires
         // The RateLimitedEndpoint field helps track which endpoint triggered the limit
         QueuedLookupRequest requeuedRequest = request with {
             AttemptCount = request.AttemptCount + 1,
-            RateLimitedEndpoint = endpoint
+            RateLimitedEndpoint = endpoint,
+            EnqueueOrigin = QueueEnqueueOrigin.Requeue,
+            // Interactive typed-id work must remain on the single-item lane rather than being
+            // intercepted by Spotify's bulk decorator after the rate-limit window.
+            BypassBulkRouting = request.BypassBulkRouting
+                || request.OriginPriority == QueuePriority.Interactive
         };
 
-        if (request.OriginPriority == QueuePriority.Interactive) {
-            LogInteractiveDeferredToBackground( _logger, request.SagaId, request.LookupType, endpoint, retryAfter );
-            QueueMetrics.RecordInteractiveDeferral( _provider, endpoint );
+        QueuePriority requeuePriority = request.OriginPriority;
+        await _queue.EnqueueAsync( requeuedRequest, requeuePriority, ct );
+        if (requeuePriority == QueuePriority.Interactive) {
+            QueueMetrics.RecordInteractiveRetry( _provider, endpoint );
         }
-
         await _queue.AcknowledgeAsync( message.MessageId, ct );
-        await _queue.EnqueueAsync( requeuedRequest, QueuePriority.Background, ct );
 
         LogSagaMarkedPartial( _logger, request.SagaId, endpoint, _provider, retryAfter );
     }
@@ -394,28 +719,29 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// Handles a non-rate-limit processing failure. When the request has reached
     /// <see cref="LookupConstants.MaxQueueRetryAttempts"/>, marks this provider's saga state failed,
     /// moves the message to the dead-letter queue, and checks/publishes saga completion. Otherwise
-    /// records the provider failure, checks/publishes saga completion, and acknowledges the message so
-    /// it can be retried.
+    /// records the provider failure as incomplete and atomically replaces the delivery for another
+    /// event-driven attempt.
     /// </summary>
     /// <param name="message">The message being processed when the failure occurred.</param>
     /// <param name="request">The lookup request that failed.</param>
     /// <param name="ex">The exception that caused the failure.</param>
+    /// <param name="instanceToken">The saga instance fence captured before provider work.</param>
     /// <param name="ct">Cancels the saga and queue operations.</param>
     /// <returns>A task that completes once the failure has been recorded and routed.</returns>
     private async Task HandleProcessingExceptionAsync(
         QueuedMessage<QueuedLookupRequest> message,
         QueuedLookupRequest request,
         Exception ex,
+        string instanceToken,
         CancellationToken ct
     ) {
         LogProcessingFailed( _logger, ex, request.RequestId, request.SagaId );
 
-        // Check if we've exceeded retry attempts
-        if (request.AttemptCount >= LookupConstants.MaxQueueRetryAttempts) {
+        if (request.AttemptCount >= LookupConstants.MaxQueueRetryAttempts - 1) {
             LogMaxRetriesExceeded( _logger, message.MessageId, LookupConstants.MaxQueueRetryAttempts );
 
             // Update saga with error state
-            await _sagaManager.UpdateProviderStateAsync(
+            if (!await _sagaManager.TryUpdateProviderStateAsync(
                 request.SagaId,
                 new ProviderLookupState(
                     Provider: _provider,
@@ -425,35 +751,72 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
                     CompletedAt: DateTimeOffset.UtcNow,
                     ErrorMessage: $"Failed after {LookupConstants.MaxQueueRetryAttempts} attempts: {ex.Message}"
                 ),
-                ct
-            );
+                instanceToken, ct )) {
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
 
             // Move to Dead Letter Queue
             await _queue.MoveToDlqAsync( message.MessageId, ex.Message, ct );
-
-            // Check if saga is complete and publish completion event
-            await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
+            QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "retry_exhausted" );
+            await PublishSagaProgressAsync( request.SagaId );
+            QueueMetrics.RecordSagaLegCompleted( _provider, message.Priority, "committed_failure" );
         } else {
-            // Update saga with error state but don't mark as complete
-            await _sagaManager.UpdateProviderStateAsync(
+            if (!await _sagaManager.TryUpdateProviderStateAsync(
                 request.SagaId,
-                new ProviderLookupState(
-                    Provider: _provider,
-                    IsComplete: true,
-                    IsSuccess: false,
-                    ResultJson: null,
-                    CompletedAt: DateTimeOffset.UtcNow,
-                    ErrorMessage: ex.Message
-                ),
-                ct
-            );
+                new ProviderLookupState( _provider, false, false, null, null, ex.Message ), instanceToken, ct )) {
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+            await _queue.RequeueAsync( message.MessageId, cancellationToken: ct );
+        }
+    }
 
-            // Acknowledge before publishing so a crash between the two does not re-publish
-            // the completion event on redelivery.
+    private async Task QuarantineUnreadableSagaAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        QueuedLookupRequest request,
+        UnreadableSagaStateException exception,
+        CancellationToken ct
+    ) {
+        try {
+            await _queue.MoveToDlqAsync( message.MessageId, exception.Message, ct );
+            QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "corrupt_saga_quarantine" );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) {
+            LogIdentityQuarantineFailed( _logger, ex, message.MessageId, request.SagaId );
+            throw new QueueDeliveryIdentityQuarantineException( message.MessageId, request.SagaId, ex );
+        }
+    }
+
+    private async Task QuarantineIdentityMismatchAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        QueuedLookupRequest request,
+        string requestLookupKey,
+        LookupSagaState? authoritativeSaga,
+        CancellationToken ct
+    ) {
+        LogSagaIdentityMismatch( _logger, request.SagaId, message.MessageId, requestLookupKey,
+            authoritativeSaga?.LookupKey ?? "(missing)", request.LookupType,
+            authoritativeSaga?.LookupType ?? request.LookupType, request.LookupValue,
+            authoritativeSaga?.LookupValue ?? "(missing)" );
+        try {
+            await _queue.MoveToDlqAsync( message.MessageId, "Saga identity does not match queued request.", ct );
+            QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "identity_quarantine" );
+        } catch (Exception ex) {
+            LogIdentityQuarantineFailed( _logger, ex, message.MessageId, request.SagaId );
+            throw new QueueDeliveryIdentityQuarantineException( message.MessageId, request.SagaId, ex );
+        }
+    }
+
+    private async Task AcknowledgeStaleDeliveryAsync( QueuedMessage<QueuedLookupRequest> message, CancellationToken ct ) {
+        try {
             await _queue.AcknowledgeAsync( message.MessageId, ct );
-
-            // Check if saga is complete and publish completion event
-            await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
+            QueueMetrics.RecordTerminalOutcome( _provider, message.Priority, "stale_delivery" );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) {
+            throw new PostCommitAcknowledgementException( message.MessageId, ex );
         }
     }
 
@@ -463,29 +826,45 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// missing, incomplete, or already has a final result. Failures are logged and swallowed.
     /// </summary>
     /// <param name="sagaId">The saga to check and possibly announce.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Cancels the saga read.</param>
     /// <returns>A task that completes once the check (and any publish) finishes.</returns>
-    private async Task CheckAndPublishSagaCompletionAsync( string sagaId, CancellationToken ct ) {
+    private async Task<LookupSagaState?> CheckAndPublishSagaCompletionAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
-            if (saga is null) {
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) {
                 LogSagaNotFoundForCompletion( _logger, sagaId );
-                return;
+                return null;
             }
 
             if (!saga.IsComplete) {
                 LogSagaNotYetComplete( _logger, sagaId );
-                return;
+                return saga;
             }
 
             if (!string.IsNullOrEmpty( saga.FinalResultUri )) {
                 LogSagaAlreadyHasFinalResult( _logger, sagaId );
-                return;
+                return saga;
             }
 
             // Saga is complete but doesn't have a final result - publish completion event
             LogSagaCompletePublishing( _logger, sagaId );
+            ISubscriber subscriber = _redis.GetSubscriber( );
+            _ = await subscriber.PublishAsync( RedisChannel.Literal( SagaCompletedChannel ), sagaId );
+            return saga;
+        } catch (Exception ex) {
+            LogSagaCompletionCheckFailed( _logger, ex, sagaId );
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Publishes an idempotent provider-leg progress hint. The coordinator owns the authoritative
+    /// completeness and instance-token checks; publishing does not depend on a post-commit read.
+    /// </summary>
+    private async Task PublishSagaProgressAsync( string sagaId ) {
+        try {
             ISubscriber subscriber = _redis.GetSubscriber( );
             _ = await subscriber.PublishAsync( RedisChannel.Literal( SagaCompletedChannel ), sagaId );
         } catch (Exception ex) {
@@ -499,14 +878,15 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// (with a diagnostic log) when the saga is missing. Failures are logged and swallowed.
     /// </summary>
     /// <param name="sagaId">The saga whose lookup completion is announced.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Cancels the saga read.</param>
     /// <returns>A task that completes once the publish (or no-op) finishes.</returns>
-    private async Task PublishLookupCompletionAsync( string sagaId, CancellationToken ct ) {
+    private async Task PublishLookupCompletionAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             // Get the saga to retrieve the lookup key for the completion channel
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
-            if (saga is null) {
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) {
                 LogSagaNotFoundForLookupCompletion( _logger, sagaId );
                 return;
             }
@@ -531,13 +911,14 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
     /// No-ops (with a diagnostic log) when the saga is missing. Failures are logged and swallowed.
     /// </summary>
     /// <param name="sagaId">The saga whose pending providers are rate-limited.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Cancels the saga read.</param>
     /// <returns>A task that completes once the publish (or no-op) finishes.</returns>
-    private async Task PublishRateLimitSentinelAsync( string sagaId, CancellationToken ct ) {
+    private async Task PublishRateLimitSentinelAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
-            if (saga is null) {
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) {
                 LogSagaNotFoundForLookupCompletion( _logger, sagaId );
                 return;
             }
@@ -593,6 +974,26 @@ public sealed partial class QueueProcessorBackgroundService : BackgroundService 
         Level = LogLevel.Debug,
         Message = "Processing message {MessageId} for saga {SagaId}, lookup type {LookupType}" )]
     private static partial void LogProcessingMessage( ILogger logger, string messageId, string sagaId, LookupRequestType lookupType );
+
+    /// <summary>Logs an error when the authoritative saga identity differs from the queued request.</summary>
+    [LoggerMessage(
+        EventId = LogEventIds.Services.Queue.SagaIdentityMismatch,
+        Level = LogLevel.Error,
+        Message = "Saga identity mismatch for message {MessageId}, saga {SagaId}: request {RequestLookupType}/{RequestLookupValue}/{RequestLookupKey}; authoritative {AuthoritativeLookupType}/{AuthoritativeLookupValue}/{AuthoritativeLookupKey}" )]
+    private static partial void LogSagaIdentityMismatch(
+        ILogger logger,
+        string sagaId,
+        string messageId,
+        string requestLookupKey,
+        string authoritativeLookupKey,
+        LookupRequestType requestLookupType,
+        LookupRequestType authoritativeLookupType,
+        string requestLookupValue,
+        string authoritativeLookupValue );
+
+    [LoggerMessage( EventId = LogEventIds.Services.Queue.SagaIdentityQuarantineFailed, Level = LogLevel.Error,
+        Message = "Failed to quarantine identity-mismatched message {MessageId} for saga {SagaId}" )]
+    private static partial void LogIdentityQuarantineFailed( ILogger logger, Exception ex, string messageId, string sagaId );
 
     /// <summary>Logs (Debug) that an endpoint is rate-limited and the message is being requeued.</summary>
     /// <param name="logger">The logger to write to.</param>

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -1010,11 +1010,6 @@ public static class LogEventIds {
             public const int ParseBulkArtistsError = 2007;
 
             /// <summary>
-            /// EventId for <see cref="SpotifyLookupService.LogBulkRateLimited"/>.
-            /// </summary>
-            public const int BulkRateLimited = 2008;
-
-            /// <summary>
             /// EventId for <see cref="SpotifyLookupService.LogBulkRequestFailed"/>.
             /// </summary>
             public const int BulkRequestFailed = 2009;

--- a/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Logging/LogEventIds.cs
@@ -333,11 +333,6 @@ public static class LogEventIds {
             public const int RedisRequestQueueMessageNotFoundForRequeue = 1256;
 
             /// <summary>
-            /// EventId for <see cref="RedisRequestQueue.LogDelayedRequeueNotImplemented"/>.
-            /// </summary>
-            public const int RedisRequestQueueDelayedRequeueNotImplemented = 1257;
-
-            /// <summary>
             /// EventId for <see cref="RedisRequestQueue.LogRequeued"/>.
             /// </summary>
             public const int RedisRequestQueueRequeued = 1258;
@@ -1161,6 +1156,11 @@ public static class LogEventIds {
             /// </summary>
             public const int UnexpectedError = 2754;
 
+            /// <summary>
+            /// EventId for unexpected exceptions handled by worker HTTP lookup endpoints.
+            /// </summary>
+            public const int UnexpectedWorkerLookupFailure = 2755;
+
             // MusicLookupServiceBase (2800-2824)
 
             /// <summary>
@@ -1283,6 +1283,11 @@ public static class LogEventIds {
             /// requeued at Background priority, deferring it to the bulk-stream retry lane.
             /// </summary>
             public const int InteractiveDeferredToBackground = 3018;
+
+            /// <summary>EventId for a queue message whose saga identity does not match its payload.</summary>
+            public const int SagaIdentityMismatch = 3019;
+            /// <summary>EventId for a failed identity quarantine operation.</summary>
+            public const int SagaIdentityQuarantineFailed = 3020;
 
             // SagaResultCombiner (3100-3149)
 

--- a/src/BridgeBeats.Core/Infrastructure/Queue/IQueueDeliveryTracker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/IQueueDeliveryTracker.cs
@@ -1,0 +1,10 @@
+namespace BridgeBeats.Core.Infrastructure.Queue;
+
+/// <summary>
+/// Tracks deliveries currently executing inside one queue consumer so its own PEL recovery scan
+/// cannot hand the same Redis entry to another concurrent processing task.
+/// </summary>
+public interface IQueueDeliveryTracker {
+    /// <summary>Releases a failed delivery for a later recovery attempt without acknowledging it.</summary>
+    void ReleaseDelivery( string messageId );
+}

--- a/src/BridgeBeats.Core/Infrastructure/Queue/IQueueWorkSignal.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/IQueueWorkSignal.cs
@@ -1,0 +1,25 @@
+namespace BridgeBeats.Core.Infrastructure.Queue;
+
+/// <summary>
+/// Event-driven wake-up seam for queue consumers. A version captured before dequeue closes the
+/// race between observing an empty queue and subscribing to the next notification.
+/// </summary>
+public interface IQueueWorkSignal {
+    /// <summary>Subscribes to the broker notification channel before consumption starts.</summary>
+    Task InitializeWorkSignalAsync( CancellationToken cancellationToken = default );
+
+    /// <summary>Captures the notification generation immediately before dequeue.</summary>
+    long CaptureWorkVersion( );
+
+    /// <summary>
+    /// Waits for work published after <paramref name="observedVersion"/> or for a known endpoint
+    /// rate limit to reach <paramref name="scheduledWake"/>. If the captured version is already
+    /// stale on entry, returns immediately. Implementations merge the supplied wake with any
+    /// internally known retry/reclaim deadline and wait for the earliest one; a null wake means
+    /// there is no caller-supplied deadline, not that internal deadlines should be ignored.
+    /// </summary>
+    Task WaitForWorkAsync(
+        long observedVersion,
+        DateTimeOffset? scheduledWake,
+        CancellationToken cancellationToken = default );
+}

--- a/src/BridgeBeats.Core/Infrastructure/Queue/QueueMetricTags.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/QueueMetricTags.cs
@@ -51,4 +51,19 @@ public static class QueueMetricTags {
     /// Literal value: <c>"method"</c>.
     /// </summary>
     public const string Method = "method";
+
+    /// <summary>Tag key for enqueue origin.</summary>
+    public const string Origin = "origin";
+
+    /// <summary>Tag key for a Redis stream name.</summary>
+    public const string Stream = "stream";
+
+    /// <summary>Tag key for an operational outcome.</summary>
+    public const string Outcome = "outcome";
+
+    /// <summary>Tag key indicating whether maintenance selected a record again.</summary>
+    public const string Reselected = "reselected";
+
+    /// <summary>Tag key for the authoritative saga state observed after a leg completes.</summary>
+    public const string SagaState = "saga_state";
 }

--- a/src/BridgeBeats.Core/Infrastructure/Queue/QueueMetrics.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/QueueMetrics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.Enums;
@@ -24,10 +25,15 @@ public static class QueueMetrics {
     /// </summary>
     public const string MeterName = "BridgeBeats.Queue";
 
+    /// <summary>Name of the activity source that owns queue operational spans.</summary>
+    public const string ActivitySourceName = MeterName;
+
     /// <summary>
     /// The shared meter (version 1.0.0) on which all queue instruments are created.
     /// </summary>
     public static readonly Meter Meter = new( MeterName, "1.0.0" );
+    /// <summary>Activity source for queue operational spans.</summary>
+    public static readonly ActivitySource ActivitySource = new( ActivitySourceName );
 
     #region Counters
 
@@ -51,13 +57,20 @@ public static class QueueMetrics {
     );
 
     /// <summary>
-    /// Counts requests successfully processed and acknowledged (XACK + XDEL), tagged by provider.
+    /// Counts live-stream source deliveries removed with XACK + XDEL. This includes successful,
+    /// stale, and retry-replaced deliveries; terminal processing outcomes are recorded separately.
     /// </summary>
-    public static readonly Counter<long> AcknowledgedTotal = Meter.CreateCounter<long>(
-        "bridgebeats.queue.acknowledged.total",
+    public static readonly Counter<long> DeliveryRemovedTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.delivery.removed.total",
         unit: "{requests}",
-        description: "Total number of requests successfully processed"
+        description: "Total source deliveries acknowledged and removed from live streams"
     );
+
+    /// <summary>Counts source deliveries moved into a dead-letter stream.</summary>
+    public static readonly Counter<long> DlqTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.dlq.total",
+        unit: "{requests}",
+        description: "Total source deliveries moved to a dead-letter stream" );
 
     /// <summary>
     /// Counts requests returned to the queue for retry, tagged by provider.
@@ -87,28 +100,56 @@ public static class QueueMetrics {
     );
 
     /// <summary>
-    /// Counts interactive-origin lookups that were deferred to the background retry lane after a
-    /// provider rate limit, tagged by provider and endpoint. This is the signal that interactive
-    /// callers are being pushed onto slower processing because an endpoint is throttled.
+    /// Counts interactive-origin lookups that remain on the interactive single-item lane after a
+    /// provider rate limit, tagged by provider and endpoint.
     /// </summary>
-    public static readonly Counter<long> InteractiveDeferredTotal = Meter.CreateCounter<long>(
-        "bridgebeats.ratelimit.interactive_deferred.total",
+    public static readonly Counter<long> InteractiveRetryTotal = Meter.CreateCounter<long>(
+        "bridgebeats.ratelimit.interactive_retry.total",
         unit: "{requests}",
-        description: "Total number of interactive-origin lookups deferred to background due to rate limiting"
+        description: "Total interactive-origin lookups preserved on the interactive lane after rate limiting"
     );
+
+    /// <summary>Counts refresh provider legs accepted for enqueue.</summary>
+    public static readonly Counter<long> RefreshLegEnqueuedTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.refresh.leg.enqueued.total",
+        unit: "{legs}",
+        description: "Total number of refresh provider legs accepted for enqueue" );
+    /// <summary>Counts completed saga legs.</summary>
+    public static readonly Counter<long> SagaLegCompletedTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.saga.leg.completed.total",
+        unit: "{legs}",
+        description: "Total number of completed saga provider legs" );
+    /// <summary>Counts delivery terminal outcomes.</summary>
+    public static readonly Counter<long> TerminalOutcomeTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.terminal.total", unit: "{deliveries}",
+        description: "Total terminal delivery outcomes" );
+    /// <summary>Counts saga lifecycle outcomes relevant to finalization and fencing.</summary>
+    public static readonly Counter<long> SagaLifecycleTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.saga.lifecycle.total", unit: "{events}",
+        description: "Total saga lifecycle and fencing outcomes" );
+    /// <summary>Counts maintenance refresh selection and disposition outcomes.</summary>
+    public static readonly Counter<long> MaintenanceOutcomeTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.refresh.outcome.total", unit: "{records}",
+        description: "Total maintenance refresh record outcomes" );
+    /// <summary>Counts failures while collecting live Redis queue gauges.</summary>
+    public static readonly Counter<long> GaugeCollectionFailuresTotal = Meter.CreateCounter<long>(
+        "bridgebeats.queue.gauge.collection.failure.total", unit: "{failures}",
+        description: "Failures while collecting Redis-backed queue gauges" );
 
     #endregion
 
     #region Histograms
 
     /// <summary>
-    /// Records, in seconds, how long it took to process a queued request, tagged by provider,
-    /// lookup type, and status.
+    /// Records, in seconds, the post-dequeue processing time for a queued request, tagged by
+    /// provider, lookup type, and status. This intentionally starts after <c>DequeueAsync</c> and
+    /// excludes dequeue and PEL-scan latency; use <c>queue.message.wall.duration</c> for the
+    /// end-to-end dequeue-to-completion measurement.
     /// </summary>
     public static readonly Histogram<double> ProcessingDuration = Meter.CreateHistogram<double>(
         "bridgebeats.queue.processing.duration",
         unit: "s",
-        description: "Time taken to process a queued request"
+        description: "Post-dequeue processing time for a queued request (excludes DequeueAsync); use queue.message.wall.duration for end-to-end time"
     );
 
     /// <summary>
@@ -120,6 +161,37 @@ public static class QueueMetrics {
         unit: "s",
         description: "Duration of rate limit Retry-After periods"
     );
+    /// <summary>Whole dequeue duration.</summary>
+    public static readonly Histogram<double> DequeueDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.dequeue.duration", unit: "s", description: "Duration of a complete queue dequeue attempt" );
+    /// <summary>PEL scan duration.</summary>
+    public static readonly Histogram<double> PelScanDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.dequeue.pel_scan.duration", unit: "s", description: "Duration of pending-entry recovery scans" );
+    /// <summary>PEL entries scanned.</summary>
+    public static readonly Counter<long> PelScanEntries = Meter.CreateCounter<long>(
+        "bridgebeats.queue.dequeue.pel_scan.entries", unit: "{entries}", description: "Pending entries examined during dequeue recovery" );
+    /// <summary>Redis group read duration.</summary>
+    public static readonly Histogram<double> ReadGroupDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.dequeue.read_group.duration", unit: "s", description: "Duration of Redis consumer-group reads" );
+    /// <summary>Queue depth probe duration.</summary>
+    public static readonly Histogram<double> DepthProbeDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.dequeue.depth_probe.duration", unit: "s", description: "Duration of queue-depth probes used for dequeue scheduling" );
+    /// <summary>Saga update duration.</summary>
+    public static readonly Histogram<double> SagaUpdateDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.saga.update.duration", unit: "s", description: "Duration of saga state updates for queued requests" );
+    /// <summary>Provider HTTP duration.</summary>
+    public static readonly Histogram<double> ProviderHttpDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.provider_http.duration", unit: "s", description: "Duration of provider HTTP calls made for queued requests" );
+    /// <summary>End-to-end message wall duration.</summary>
+    public static readonly Histogram<double> MessageWallDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.message.wall.duration", unit: "s", description: "End-to-end wall duration from dequeue through terminal handling" );
+    /// <summary>Time a delivery waited in a live stream before dequeue.</summary>
+    public static readonly Histogram<double> QueueSojournDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.sojourn.duration", unit: "s", description: "Time from stream enqueue to dequeue" );
+    /// <summary>Duration of active rate-limit discovery before dequeue.</summary>
+    public static readonly Histogram<double> RateLimitDiscoveryDuration = Meter.CreateHistogram<double>(
+        "bridgebeats.queue.ratelimit.discovery.duration", unit: "s",
+        description: "Duration of provider active-rate-limit discovery" );
 
     #endregion
 
@@ -152,17 +224,22 @@ public static class QueueMetrics {
     /// independent hosts share this process (for example, multiple <c>WebApplicationFactory</c>
     /// instances in a test run) and register with their own connection: without updating the
     /// connection on each call, the gauges would stay bound to whichever caller registered first, and
-    /// silently report zero forever once that caller's connection is disposed. Three gauges are
-    /// created: <c>bridgebeats.queue.depth</c> (one measurement per provider and priority lane),
-    /// <c>bridgebeats.queue.spotify.bulk.track.depth</c>, and
-    /// <c>bridgebeats.queue.spotify.bulk.album.depth</c> (the two dedicated Spotify bulk streams).
+    /// silently report zero forever once that caller's connection is disposed. Depth gauges cover
+    /// every generic provider/priority stream and both dedicated Spotify bulk streams. Consumer-group
+    /// gauges report live pending count, oldest-pending age, and lag using the same stream tags.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="redis"/> is null.</exception>
     public static void RegisterQueueDepthGauges( IConnectionMultiplexer redis ) {
         ArgumentNullException.ThrowIfNull( redis );
 
         lock (s_gaugesLock) {
+            bool connectionChanged = !ReferenceEquals( s_redis, redis );
             s_redis = redis;
+            if (connectionChanged) {
+                lock (s_consumerGroupSnapshotLock) {
+                    s_consumerGroupSnapshotValidUntil = DateTimeOffset.MinValue;
+                }
+            }
 
             if (s_gaugesRegistered) {
                 return;
@@ -190,6 +267,24 @@ public static class QueueMetrics {
                 unit: "{requests}",
                 description: "Current depth of the Spotify bulk album-id stream (queue:spotify:bulk:album-id)"
             );
+
+            _ = Meter.CreateObservableGauge(
+                "bridgebeats.queue.pending",
+                ( ) => GetConsumerGroupMeasurements( s_redis, ConsumerGroupMeasurement.Pending ),
+                unit: "{requests}",
+                description: "Current consumer-group pending-entry count" );
+
+            _ = Meter.CreateObservableGauge(
+                "bridgebeats.queue.pending.oldest_age",
+                ( ) => GetConsumerGroupMeasurements( s_redis, ConsumerGroupMeasurement.OldestPendingAge ),
+                unit: "s",
+                description: "Idle age of the oldest pending consumer-group delivery" );
+
+            _ = Meter.CreateObservableGauge(
+                "bridgebeats.queue.consumer.lag",
+                ( ) => GetConsumerGroupMeasurements( s_redis, ConsumerGroupMeasurement.Lag ),
+                unit: "{requests}",
+                description: "Consumer-group lag reported by Redis" );
 
             s_gaugesRegistered = true;
         }
@@ -272,8 +367,111 @@ public static class QueueMetrics {
         yield return new Measurement<long>(
             length,
             new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
-            new KeyValuePair<string, object?>( "stream", stream )
+            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream )
         );
+    }
+
+    private enum ConsumerGroupMeasurement { Pending, OldestPendingAge, Lag }
+    private sealed record ConsumerGroupSnapshot(
+        string Provider,
+        string Priority,
+        string Stream,
+        long Pending,
+        long OldestPendingAge,
+        long Lag );
+    private static readonly Lock s_consumerGroupSnapshotLock = new( );
+    private static DateTimeOffset s_consumerGroupSnapshotValidUntil;
+    private static IReadOnlyList<ConsumerGroupSnapshot> s_consumerGroupSnapshot = [];
+    private static readonly TimeSpan s_consumerGroupSnapshotDuration = TimeSpan.FromSeconds( 5 );
+    private static bool s_consumerGroupRefreshInProgress;
+
+    /// <summary>Returns live PEL and group-lag measurements for every production queue stream.</summary>
+    private static IEnumerable<Measurement<long>> GetConsumerGroupMeasurements(
+        IConnectionMultiplexer? redis,
+        ConsumerGroupMeasurement measurement
+    ) {
+        if (redis is null) yield break;
+
+        foreach (ConsumerGroupSnapshot snapshot in GetConsumerGroupSnapshot( redis )) {
+            long value = measurement switch {
+                ConsumerGroupMeasurement.Pending => snapshot.Pending,
+                ConsumerGroupMeasurement.Lag => snapshot.Lag,
+                ConsumerGroupMeasurement.OldestPendingAge => snapshot.OldestPendingAge,
+                _ => 0
+            };
+            yield return new Measurement<long>( value,
+                new KeyValuePair<string, object?>( QueueMetricTags.Provider, snapshot.Provider ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Priority, snapshot.Priority ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Stream, snapshot.Stream ) );
+        }
+    }
+
+    private static IReadOnlyList<ConsumerGroupSnapshot> GetConsumerGroupSnapshot( IConnectionMultiplexer redis ) {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        lock (s_consumerGroupSnapshotLock) {
+            if (now < s_consumerGroupSnapshotValidUntil) return s_consumerGroupSnapshot;
+            if (!s_consumerGroupRefreshInProgress) {
+                s_consumerGroupRefreshInProgress = true;
+                _ = Task.Run( ( ) => RefreshConsumerGroupSnapshotAsync( redis ) );
+            }
+            return s_consumerGroupSnapshot;
+        }
+    }
+
+    private static async Task RefreshConsumerGroupSnapshotAsync( IConnectionMultiplexer redis ) {
+        List<ConsumerGroupSnapshot> snapshots = [];
+        try {
+            IDatabase db = redis.GetDatabase( );
+            foreach (SupportedProviders provider in Enum.GetValues<SupportedProviders>( )) {
+                string providerName = provider.ToString( ).ToLowerInvariant( );
+                string group = $"{providerName}-workers";
+                foreach (QueuePriority priority in Enum.GetValues<QueuePriority>( )) {
+                    snapshots.Add( await ReadConsumerGroupSnapshotAsync(
+                        db,
+                        QueueStreamKeys.For( provider, priority ),
+                        group,
+                        providerName,
+                        priority.ToString( ).ToLowerInvariant( ) ) );
+                }
+            }
+            snapshots.Add( await ReadConsumerGroupSnapshotAsync(
+                db, QueueStreamKeys.SpotifyBulkFor( isTrack: true ),
+                SpotifyConstants.ConsumerGroup, "spotify", "bulk" ) );
+            snapshots.Add( await ReadConsumerGroupSnapshotAsync(
+                db, QueueStreamKeys.SpotifyBulkFor( isTrack: false ),
+                SpotifyConstants.ConsumerGroup, "spotify", "bulk" ) );
+        } catch {
+            // Connection acquisition and teardown failures preserve the last good snapshot.
+        } finally {
+            lock (s_consumerGroupSnapshotLock) {
+                if (snapshots.Count > 0) s_consumerGroupSnapshot = snapshots;
+                s_consumerGroupSnapshotValidUntil = DateTimeOffset.UtcNow + s_consumerGroupSnapshotDuration;
+                s_consumerGroupRefreshInProgress = false;
+            }
+        }
+    }
+
+    private static async Task<ConsumerGroupSnapshot> ReadConsumerGroupSnapshotAsync(
+        IDatabase db, string stream, string group, string provider, string priority ) {
+        try {
+            StreamGroupInfo? groupInfo = (await db.StreamGroupInfoAsync( stream ))
+                .FirstOrDefault( candidate => candidate.Name == group );
+            if (groupInfo is null) return new( provider, priority, stream, 0, 0, 0 );
+            long pending = groupInfo.Value.PendingMessageCount;
+            return new( provider, priority, stream, pending,
+                pending == 0 ? 0 : await ReadOldestPendingAgeSecondsAsync( db, stream, group ),
+                Math.Max( 0, groupInfo.Value.Lag.GetValueOrDefault( ) ) );
+        } catch {
+            GaugeCollectionFailuresTotal.Add( 1,
+                new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
+            return new( provider, priority, stream, 0, 0, 0 );
+        }
+    }
+
+    private static async Task<long> ReadOldestPendingAgeSecondsAsync( IDatabase db, string stream, string group ) {
+        StreamPendingMessageInfo? oldest = (await db.StreamPendingMessagesAsync(
+            stream, group, 1, RedisValue.Null )).FirstOrDefault( );
+        return oldest is null ? 0 : Math.Max( 0, oldest.Value.IdleTimeInMilliseconds / 1000 );
     }
 
     #endregion
@@ -285,13 +483,22 @@ public static class QueueMetrics {
     /// </summary>
     /// <param name="provider">The provider the request was enqueued for.</param>
     /// <param name="priority">The priority lane the request was enqueued to.</param>
-    public static void RecordEnqueue( SupportedProviders provider, QueuePriority priority ) {
+    /// <param name="origin">The enqueue origin.</param>
+    public static void RecordEnqueue( SupportedProviders provider, QueuePriority priority, QueueEnqueueOrigin origin = QueueEnqueueOrigin.New ) {
+        string originName = origin switch { QueueEnqueueOrigin.Requeue => "requeue", QueueEnqueueOrigin.RefreshSweep => "refresh_sweep", _ => "new" };
         EnqueuedTotal.Add(
             1,
             new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
-            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) )
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Origin, originName )
         );
     }
+
+    /// <summary>Records a refresh provider leg accepted for enqueue.</summary>
+    public static void RecordRefreshLegEnqueued( SupportedProviders provider, bool reselected ) =>
+        RefreshLegEnqueuedTotal.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Reselected, reselected ) );
 
     /// <summary>
     /// Records a queue dequeue event: increments <see cref="DequeuedTotal"/> with standard tags.
@@ -306,16 +513,66 @@ public static class QueueMetrics {
         );
     }
 
+    /// <summary>Records one completed saga leg with its authoritative saga state.</summary>
+    public static void RecordSagaLegCompleted( SupportedProviders provider, QueuePriority priority, string sagaState ) {
+        SagaLegCompletedTotal.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.SagaState, sagaState ) );
+    }
+
     /// <summary>
-    /// Records a message acknowledgment event: increments <see cref="AcknowledgedTotal"/> with standard tags.
+    /// Records removal of a source delivery: increments <see cref="DeliveryRemovedTotal"/> with standard tags.
     /// </summary>
     /// <param name="provider">The provider the message was acknowledged for.</param>
-    public static void RecordAcknowledge( SupportedProviders provider ) {
-        AcknowledgedTotal.Add(
+    /// <param name="priority">The source priority lane.</param>
+    public static void RecordDeliveryRemoved( SupportedProviders provider, QueuePriority priority ) {
+        DeliveryRemovedTotal.Add(
             1,
-            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) )
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) )
         );
     }
+
+    /// <summary>Records one dead-letter move.</summary>
+    public static void RecordDlq( SupportedProviders provider, QueuePriority priority ) =>
+        DlqTotal.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ) );
+
+    /// <summary>Records one terminal delivery outcome.</summary>
+    public static void RecordTerminalOutcome( SupportedProviders provider, QueuePriority priority, string outcome ) =>
+        TerminalOutcomeTotal.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, outcome ) );
+
+    /// <summary>Records one saga lifecycle outcome.</summary>
+    public static void RecordSagaLifecycleOutcome( string outcome ) =>
+        SagaLifecycleTotal.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, outcome ) );
+
+    /// <summary>Records one maintenance record outcome.</summary>
+    public static void RecordMaintenanceOutcome( string outcome, SupportedProviders? provider = null ) {
+        TagList tags = new( ) { { QueueMetricTags.Outcome, outcome } };
+        if (provider is { } value) {
+            tags.Add( QueueMetricTags.Provider, value.ToString( ).ToLowerInvariant( ) );
+        }
+        MaintenanceOutcomeTotal.Add( 1, tags );
+    }
+
+    /// <summary>Records queue waiting time when a delivery is returned to a worker.</summary>
+    public static void RecordQueueSojourn( SupportedProviders provider, QueuePriority priority, DateTimeOffset enqueuedAt ) {
+        double seconds = Math.Max( 0, (DateTimeOffset.UtcNow - enqueuedAt).TotalSeconds );
+        QueueSojournDuration.Record( seconds,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ) );
+    }
+
+    /// <summary>Records active rate-limit discovery duration.</summary>
+    public static void RecordRateLimitDiscoveryDuration( SupportedProviders provider, double seconds ) =>
+        RateLimitDiscoveryDuration.Record( seconds,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ) );
 
     /// <summary>
     /// Records a message requeue event: increments <see cref="RequeuedTotal"/> with standard tags.
@@ -359,36 +616,40 @@ public static class QueueMetrics {
     }
 
     /// <summary>
-    /// Records the processing duration for a queued request on <see cref="ProcessingDuration"/>.
+    /// Records the post-dequeue processing duration for a queued request on
+    /// <see cref="ProcessingDuration"/>. The stopwatch begins after <c>DequeueAsync</c>; dequeue
+    /// and PEL-scan time are excluded. Use <c>queue.message.wall.duration</c> for end-to-end time.
     /// </summary>
     /// <param name="provider">The provider that processed the request.</param>
     /// <param name="lookupType">The type of lookup that was performed.</param>
-    /// <param name="status">The processing status (success, failure, rate_limited).</param>
+    /// <param name="status">The processing status (success, failure, rate_limited, stale).</param>
     /// <param name="durationSeconds">The processing duration, in seconds.</param>
+    /// <param name="priority">The actual queue lane from which the message was delivered.</param>
     public static void RecordProcessingDuration(
         SupportedProviders provider,
         LookupRequestType lookupType,
         string status,
-        double durationSeconds
+        double durationSeconds,
+        QueuePriority priority
     ) {
         ProcessingDuration.Record(
             durationSeconds,
             new KeyValuePair<string, object?>( QueueMetricTags.Provider, provider.ToString( ).ToLowerInvariant( ) ),
             new KeyValuePair<string, object?>( QueueMetricTags.LookupType, lookupType.ToString( ) ),
-            new KeyValuePair<string, object?>( QueueMetricTags.Status, status )
+            new KeyValuePair<string, object?>( QueueMetricTags.Status, status ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) )
         );
     }
 
     /// <summary>
-    /// Records an interactive-origin deferral event — an interactive lookup that was rate-limited
-    /// and requeued at Background priority — by incrementing <see cref="InteractiveDeferredTotal"/>.
+    /// Records an interactive-origin lookup preserved on the interactive retry lane.
     /// </summary>
     /// <param name="provider">The provider that encountered the rate limit.</param>
     /// <param name="endpoint">The endpoint that was rate limited.</param>
-    public static void RecordInteractiveDeferral( SupportedProviders provider, string endpoint ) {
+    public static void RecordInteractiveRetry( SupportedProviders provider, string endpoint ) {
         string providerName = provider.ToString( ).ToLowerInvariant( );
 
-        InteractiveDeferredTotal.Add(
+        InteractiveRetryTotal.Add(
             1,
             new KeyValuePair<string, object?>( QueueMetricTags.Provider, providerName ),
             new KeyValuePair<string, object?>( QueueMetricTags.Endpoint, endpoint )

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisRateLimitTracker.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisRateLimitTracker.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
@@ -35,6 +37,22 @@ public sealed partial class RedisRateLimitTracker(
 
     /// <summary>Key prefix for all rate-limit entries. Literal value: <c>"ratelimit:"</c>.</summary>
     private const string RateLimitPrefix = "ratelimit:";
+    private const string RateLimitIndexPrefix = "ratelimit:active:";
+    private const string SetRateLimitScript = """
+        redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])
+        redis.call('ZADD', KEYS[2], ARGV[4], ARGV[3])
+        return 1
+        """;
+    private const string ClearRateLimitScript = """
+        local deleted = redis.call('DEL', KEYS[1])
+        redis.call('ZREM', KEYS[2], ARGV[1])
+        return deleted
+        """;
+    private static readonly TimeSpan s_activeEndpointCacheDuration = TimeSpan.FromMilliseconds( 250 );
+    private readonly ConcurrentDictionary<SupportedProviders, ActiveEndpointCache> _activeEndpointCache = [];
+    private sealed record ActiveEndpointCache(
+        DateTimeOffset ValidUntil,
+        IReadOnlyList<RateLimitedEndpoint> Endpoints );
 
     /// <summary>
     /// Reads the current rate-limit state for one provider endpoint.
@@ -70,7 +88,11 @@ public sealed partial class RedisRateLimitTracker(
 
         if (!DateTimeOffset.TryParse( value.ToString( ), out DateTimeOffset retryAfter )) {
             // Invalid value, clean it up
-            _ = await db.KeyDeleteAsync( key );
+            _ = await db.ScriptEvaluateAsync(
+                ClearRateLimitScript,
+                [key, GetIndexKey( provider )],
+                [NormalizeEndpoint( endpoint )] );
+            _ = _activeEndpointCache.TryRemove( provider, out _ );
             LogInvalidValueRemoved( _logger, provider, endpoint );
 
             return new RateLimitState(
@@ -84,7 +106,11 @@ public sealed partial class RedisRateLimitTracker(
 
         if (remaining <= TimeSpan.Zero) {
             // Expired but TTL hasn't cleaned up yet, remove manually
-            _ = await db.KeyDeleteAsync( key );
+            _ = await db.ScriptEvaluateAsync(
+                ClearRateLimitScript,
+                [key, GetIndexKey( provider )],
+                [NormalizeEndpoint( endpoint )] );
+            _ = _activeEndpointCache.TryRemove( provider, out _ );
 
             return new RateLimitState(
                 IsRateLimited: false,
@@ -132,7 +158,13 @@ public sealed partial class RedisRateLimitTracker(
         string key = GetKey( provider, endpoint );
         IDatabase db = _redis.GetDatabase( );
 
-        _ = await db.StringSetAsync( key, retryAfter.ToString( "O" ), ttl );
+        string normalizedEndpoint = NormalizeEndpoint( endpoint );
+        _ = await db.ScriptEvaluateAsync(
+            SetRateLimitScript,
+            [key, GetIndexKey( provider )],
+            [retryAfter.ToString( "O" ), Math.Max( 1L, (long)ttl.TotalMilliseconds ),
+                normalizedEndpoint, retryAfter.ToUnixTimeMilliseconds( )] );
+        _ = _activeEndpointCache.TryRemove( provider, out _ );
 
         // Record rate limit metrics
         QueueMetrics.RecordRateLimitEvent( provider, endpoint, ttl.TotalSeconds );
@@ -158,7 +190,12 @@ public sealed partial class RedisRateLimitTracker(
         string key = GetKey( provider, endpoint );
         IDatabase db = _redis.GetDatabase( );
 
-        bool deleted = await db.KeyDeleteAsync( key );
+        RedisResult result = await db.ScriptEvaluateAsync(
+            ClearRateLimitScript,
+            [key, GetIndexKey( provider )],
+            [NormalizeEndpoint( endpoint )] );
+        bool deleted = (int)result == 1;
+        _ = _activeEndpointCache.TryRemove( provider, out _ );
 
         if (deleted) {
             LogRateLimitCleared( _logger, provider, endpoint );
@@ -168,54 +205,44 @@ public sealed partial class RedisRateLimitTracker(
     /// <summary>
     /// Returns every currently rate-limited endpoint for a provider.
     /// </summary>
-    /// <param name="provider">The provider to scan.</param>
+    /// <param name="provider">The provider to query.</param>
     /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
     /// <returns>The endpoints that are still within their Retry-After window, with their retry times.</returns>
     /// <remarks>
-    /// Implemented with a pattern key scan (<c>ratelimit:{provider}:*</c>) on the first available
-    /// server. The rate-limit-aware dequeue calls this once per dequeue cycle to refresh the set
-    /// of blocked endpoints, so the scan runs frequently; treat it as a scaling consideration as
-    /// the keyspace grows. Keys whose value is missing, unparseable, or already expired are skipped.
+    /// Reads a provider-scoped sorted-set index rather than scanning the Redis keyspace. Expired
+    /// members are pruned before the active range is returned, keeping dequeue cost proportional
+    /// to the number of throttled endpoints rather than the total Redis key count.
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown when no Redis server is available to scan.</exception>
     public async Task<IReadOnlyList<RateLimitedEndpoint>> GetAllRateLimitedAsync(
         SupportedProviders provider,
         CancellationToken cancellationToken = default
     ) {
-        IDatabase db = _redis.GetDatabase( );
-        IServer server = _redis.GetServers( ).FirstOrDefault( )
-            ?? throw new InvalidOperationException( "No Redis servers available" );
-
-        string pattern = $"{RateLimitPrefix}{provider}:*";
-        List<RateLimitedEndpoint> endpoints = [];
-
-        // Use SCAN to find all rate limit keys for this provider
-        await foreach (RedisKey redisKey in server.KeysAsync( pattern: pattern )) {
-            string key = redisKey.ToString( );
-            RedisValue value = await db.StringGetAsync( key );
-
-            if (value.IsNullOrEmpty) {
-                continue;
+        cancellationToken.ThrowIfCancellationRequested( );
+        Stopwatch stopwatch = Stopwatch.StartNew( );
+        try {
+            DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
+            if (_activeEndpointCache.TryGetValue( provider, out ActiveEndpointCache? cached )
+                && cached.ValidUntil > nowUtc) {
+                return cached.Endpoints;
             }
 
-            if (!DateTimeOffset.TryParse( value.ToString( ), out DateTimeOffset retryAfter )) {
-                continue;
-            }
+            IDatabase db = _redis.GetDatabase( );
+            string indexKey = GetIndexKey( provider );
+            long now = nowUtc.ToUnixTimeMilliseconds( );
+            _ = await db.SortedSetRemoveRangeByScoreAsync( indexKey, double.NegativeInfinity, now );
+            SortedSetEntry[] active = await db.SortedSetRangeByScoreWithScoresAsync(
+                indexKey, now, double.PositiveInfinity );
 
-            if (retryAfter <= DateTimeOffset.UtcNow) {
-                // Expired, skip (will be cleaned up by TTL)
-                continue;
-            }
-
-            // Extract endpoint from key: ratelimit:{provider}:{endpoint}
-            string prefix = $"{RateLimitPrefix}{provider}:";
-            if (key.StartsWith( prefix, StringComparison.OrdinalIgnoreCase )) {
-                string endpoint = key[prefix.Length..];
-                endpoints.Add( new RateLimitedEndpoint( endpoint, retryAfter ) );
-            }
+            IReadOnlyList<RateLimitedEndpoint> endpoints = [.. active.Select( entry => new RateLimitedEndpoint(
+                entry.Element.ToString( ),
+                DateTimeOffset.FromUnixTimeMilliseconds( checked((long)entry.Score) ) ) )];
+            _activeEndpointCache[provider] = new ActiveEndpointCache(
+                nowUtc + s_activeEndpointCacheDuration, endpoints );
+            return endpoints;
+        } finally {
+            stopwatch.Stop( );
+            QueueMetrics.RecordRateLimitDiscoveryDuration( provider, stopwatch.Elapsed.TotalSeconds );
         }
-
-        return endpoints;
     }
 
     /// <summary>Builds the Redis key for a provider endpoint: <c>ratelimit:{provider}:{endpoint}</c> (endpoint trimmed and lower-cased).</summary>
@@ -223,7 +250,12 @@ public sealed partial class RedisRateLimitTracker(
     /// <param name="endpoint">The endpoint component of the key.</param>
     /// <returns>The composed rate-limit key.</returns>
     private static string GetKey( SupportedProviders provider, string endpoint ) =>
-        $"{RateLimitPrefix}{provider}:{endpoint.Trim( ).ToLowerInvariant( )}";
+        $"{RateLimitPrefix}{provider}:{NormalizeEndpoint( endpoint )}";
+
+    private static string GetIndexKey( SupportedProviders provider ) =>
+        $"{RateLimitIndexPrefix}{provider.ToString( ).ToLowerInvariant( )}";
+
+    private static string NormalizeEndpoint( string endpoint ) => endpoint.Trim( ).ToLowerInvariant( );
 
     #region LoggerMessage Methods
 

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisRefreshReviewStore.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisRefreshReviewStore.cs
@@ -16,9 +16,53 @@ public sealed partial class RedisRefreshReviewStore(
     ILogger<RedisRefreshReviewStore> logger
 ) : IRefreshReviewStore {
     private const string PendingPrefix = "cache:refresh:pending:";
+    private const string PendingSagaIndexKey = "cache:refresh:pending:sagas";
+    private const string PendingSagaSetPrefix = "cache:refresh:pending:saga:";
     private const string UnresolvedKey = "cache:refresh:unresolved";
     private const string UnresolvedSagaIndexKey = "cache:refresh:unresolved:sagas";
     private const string CorruptKey = "cache:refresh:unresolved:corrupt";
+    private const string SweepAttemptsPrefix = "cache:refresh:attempts:";
+    private const string IncrementSweepAttemptScript = """
+        local value = redis.call('INCR', KEYS[1])
+        redis.call('PEXPIRE', KEYS[1], ARGV[1])
+        return value
+        """;
+    private const string RegisterPendingScript = """
+        local previous = redis.call('GET', KEYS[1])
+        if previous then
+            local previousOk, previousEntry = pcall(cjson.decode, previous)
+            if previousOk then
+                local previousCreatedAt = tonumber(previousEntry['createdAtUnixMilliseconds'])
+                local incomingCreatedAt = tonumber(ARGV[5])
+                if previousCreatedAt and incomingCreatedAt and previousCreatedAt > incomingCreatedAt then
+                    return 0
+                end
+                if previousEntry['sagaId'] and previousEntry['sagaId'] ~= ARGV[2] then
+                    if redis.call('HGET', KEYS[2], previousEntry['sagaId']) == ARGV[3] then
+                        redis.call('HDEL', KEYS[2], previousEntry['sagaId'])
+                    end
+                end
+            end
+        end
+        redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[4])
+        redis.call('HSETNX', KEYS[2], ARGV[2], ARGV[3])
+        redis.call('SADD', KEYS[3], ARGV[3])
+        redis.call('PEXPIRE', KEYS[3], ARGV[4])
+        return 1
+        """;
+    private const string PromoteDirectScript = """
+        local previous = redis.call('HGET', KEYS[1], ARGV[1])
+        if previous then
+            local ok, decoded = pcall(cjson.decode, previous)
+            if ok and decoded['sagaId'] and decoded['sagaId'] ~= ARGV[3] then
+                redis.call('HDEL', KEYS[2], decoded['sagaId'])
+            end
+        end
+        redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+        redis.call('HSET', KEYS[2], ARGV[3], ARGV[1])
+        redis.call('DEL', KEYS[3])
+        return 1
+        """;
     private const string DeleteUnresolvedScript = """
         local json = redis.call('HGET', KEYS[1], ARGV[1])
         if not json then
@@ -35,6 +79,55 @@ public sealed partial class RedisRefreshReviewStore(
         redis.call('HDEL', KEYS[2], ARGV[2])
         return 1
         """;
+    private const string MarkUnresolvedRecordScript = """
+        local pending = redis.call('GET', KEYS[1])
+        if not pending then return 0 end
+        local ok, entry = pcall(cjson.decode, pending)
+        if not ok or entry['sagaId'] ~= ARGV[1] or entry['instanceToken'] ~= ARGV[2] then return 0 end
+        local previous = redis.call('HGET', KEYS[2], ARGV[3])
+        local shouldPromote = true
+        if previous then
+            local previousOk, previousEntry = pcall(cjson.decode, previous)
+            local sameInstance = previousOk and previousEntry['sagaId'] == ARGV[1] and previousEntry['instanceToken'] == ARGV[2]
+            local previousCreatedAt = previousOk and tonumber(previousEntry['createdAtUnixMilliseconds'])
+            local olderAttempt = previousCreatedAt and previousCreatedAt < tonumber(ARGV[5])
+            shouldPromote = sameInstance or olderAttempt
+            if shouldPromote and previousOk and previousEntry['sagaId'] then
+                redis.call('HDEL', KEYS[3], previousEntry['sagaId'])
+            end
+        end
+        if shouldPromote then
+            redis.call('HSET', KEYS[2], ARGV[3], ARGV[4])
+            redis.call('HSET', KEYS[3], ARGV[1], ARGV[3])
+        end
+        redis.call('DEL', KEYS[1])
+        if redis.call('HGET', KEYS[4], ARGV[1]) == ARGV[3] then redis.call('HDEL', KEYS[4], ARGV[1]) end
+        redis.call('SREM', KEYS[5], ARGV[3])
+        redis.call('DEL', KEYS[6])
+        return shouldPromote and 1 or 0
+        """;
+    private const string CompleteRecordScript = """
+        local pending = redis.call('GET', KEYS[1])
+        if not pending then return 0 end
+        local ok, entry = pcall(cjson.decode, pending)
+        if not ok or entry['sagaId'] ~= ARGV[1] or entry['instanceToken'] ~= ARGV[2] then return 0 end
+        local unresolved = redis.call('HGET', KEYS[2], ARGV[3])
+        if unresolved then
+            local unresolvedOk, unresolvedEntry = pcall(cjson.decode, unresolved)
+            local sameInstance = unresolvedOk and unresolvedEntry['sagaId'] == ARGV[1] and unresolvedEntry['instanceToken'] == ARGV[2]
+            local unresolvedCreatedAt = unresolvedOk and tonumber(unresolvedEntry['createdAtUnixMilliseconds'])
+            local olderAttempt = unresolvedCreatedAt and unresolvedCreatedAt < tonumber(ARGV[4])
+            if sameInstance or olderAttempt then
+                redis.call('HDEL', KEYS[2], ARGV[3])
+                if redis.call('HGET', KEYS[3], unresolvedEntry['sagaId']) == ARGV[3] then redis.call('HDEL', KEYS[3], unresolvedEntry['sagaId']) end
+            end
+        end
+        redis.call('DEL', KEYS[1])
+        if redis.call('HGET', KEYS[4], ARGV[1]) == ARGV[3] then redis.call('HDEL', KEYS[4], ARGV[1]) end
+        redis.call('SREM', KEYS[5], ARGV[3])
+        redis.call('DEL', KEYS[6])
+        return 1
+        """;
 
     private static readonly JsonSerializerOptions s_jsonOptions = new( JsonSerializerDefaults.Web );
     private readonly IConnectionMultiplexer _redis = redis ?? throw new ArgumentNullException( nameof( redis ) );
@@ -47,76 +140,133 @@ public sealed partial class RedisRefreshReviewStore(
     /// <inheritdoc/>
     public async Task RegisterPendingAsync( RefreshReviewEntry entry, CancellationToken cancellationToken = default ) {
         ArgumentNullException.ThrowIfNull( entry );
+        ArgumentException.ThrowIfNullOrWhiteSpace( entry.InstanceToken );
         cancellationToken.ThrowIfCancellationRequested( );
 
         string json = JsonSerializer.Serialize( entry, s_jsonOptions );
-        _ = await _redis.GetDatabase( ).StringSetAsync( PendingPrefix + entry.SagaId, json, _pendingTtl );
+        _ = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            RegisterPendingScript,
+            [PendingPrefix + entry.SourceRecordUri, PendingSagaIndexKey, PendingSagaSetPrefix + entry.SagaId],
+            [json, entry.SagaId, entry.SourceRecordUri, Math.Max( 1L, (long)_pendingTtl.TotalMilliseconds ),
+                entry.CreatedAtUnixMilliseconds] );
     }
 
     /// <inheritdoc/>
-    public async Task MarkUnresolvedAsync( string sagaId, string reason, CancellationToken cancellationToken = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-        ArgumentException.ThrowIfNullOrWhiteSpace( reason );
+    public async Task<RefreshReviewEntry?> GetPendingAsync( string sourceRecordUri, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sourceRecordUri );
         cancellationToken.ThrowIfCancellationRequested( );
-
-        IDatabase db = _redis.GetDatabase( );
-        RedisValue pendingJson = await db.StringGetAsync( PendingPrefix + sagaId );
-        if (pendingJson.IsNullOrEmpty) {
-            return;
-        }
-
-        RefreshReviewEntry? pending = JsonSerializer.Deserialize<RefreshReviewEntry>( pendingJson.ToString( ), s_jsonOptions );
-        if (pending is null) {
-            return;
-        }
-
-        RefreshReviewEntry unresolved = pending with {
-            FailedAt = DateTimeOffset.UtcNow,
-            FailureReason = reason
-        };
-        string unresolvedJson = JsonSerializer.Serialize( unresolved, s_jsonOptions );
-
-        RedisValue previousJson = await db.HashGetAsync( UnresolvedKey, unresolved.SourceRecordUri );
-        RefreshReviewEntry? previous = TryDeserialize( previousJson );
-        if (previous is not null && !string.Equals( previous.SagaId, sagaId, StringComparison.Ordinal )) {
-            _ = await db.HashDeleteAsync( UnresolvedSagaIndexKey, previous.SagaId );
-        }
-        _ = await db.HashSetAsync( UnresolvedKey, unresolved.SourceRecordUri, unresolvedJson );
-        _ = await db.HashSetAsync( UnresolvedSagaIndexKey, unresolved.SagaId, unresolved.SourceRecordUri );
-        _ = await db.KeyDeleteAsync( PendingPrefix + sagaId );
+        return TryDeserialize( await _redis.GetDatabase( ).StringGetAsync( PendingPrefix + sourceRecordUri ) );
     }
 
     /// <inheritdoc/>
-    public async Task CompleteAsync( string sagaId, CancellationToken cancellationToken = default ) {
+    public async Task<IReadOnlyList<RefreshReviewEntry>> GetPendingForSagaAsync( string sagaId, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
         cancellationToken.ThrowIfCancellationRequested( );
         IDatabase db = _redis.GetDatabase( );
-        RedisValue pendingJson = await db.StringGetAsync( PendingPrefix + sagaId );
-        RefreshReviewEntry? pending = TryDeserialize( pendingJson );
-        RedisValue indexedSourceRecordUri = await db.HashGetAsync( UnresolvedSagaIndexKey, sagaId );
-        string? sourceRecordUri = pending?.SourceRecordUri;
-        bool matchedByPendingContext = sourceRecordUri is not null;
-        sourceRecordUri ??= indexedSourceRecordUri.IsNullOrEmpty
-            ? null
-            : indexedSourceRecordUri.ToString( );
-
-        if (sourceRecordUri is not null) {
-            RedisValue currentJson = await db.HashGetAsync( UnresolvedKey, sourceRecordUri );
-            RefreshReviewEntry? current = TryDeserialize( currentJson );
-
-            // A successful actively-pending refresh supersedes any older review for the same
-            // source URI. Without pending context, an old saga index may only clear its own entry.
-            if (matchedByPendingContext
-                || string.Equals( current?.SagaId, sagaId, StringComparison.Ordinal )) {
-                _ = await db.HashDeleteAsync( UnresolvedKey, sourceRecordUri );
-                if (current is not null
-                    && !string.Equals( current.SagaId, sagaId, StringComparison.Ordinal )) {
-                    _ = await db.HashDeleteAsync( UnresolvedSagaIndexKey, current.SagaId );
+        RedisValue[] uris = await db.SetMembersAsync( PendingSagaSetPrefix + sagaId ) ?? [];
+        List<RefreshReviewEntry> entries = [];
+        foreach (RedisValue uri in uris) {
+            RefreshReviewEntry? entry = TryDeserialize( await db.StringGetAsync( PendingPrefix + uri ) );
+            if (entry is not null && string.Equals( entry.SagaId, sagaId, StringComparison.Ordinal )) {
+                entries.Add( entry );
+            } else {
+                // Payload TTLs can expire before the saga-set/hash metadata. Prune those
+                // tombstones lazily so retry scans do not retain unbounded stale membership.
+                _ = await db.SetRemoveAsync( PendingSagaSetPrefix + sagaId, uri );
+                RedisValue indexed = await db.HashGetAsync( PendingSagaIndexKey, sagaId );
+                if (indexed == uri) {
+                    _ = await db.HashDeleteAsync( PendingSagaIndexKey, sagaId );
                 }
             }
         }
-        _ = await db.HashDeleteAsync( UnresolvedSagaIndexKey, sagaId );
-        _ = await db.KeyDeleteAsync( PendingPrefix + sagaId );
+        if (entries.Count == 0) {
+            _ = await db.HashDeleteAsync( PendingSagaIndexKey, sagaId );
+            _ = await db.KeyDeleteAsync( PendingSagaSetPrefix + sagaId );
+        }
+        return entries;
+    }
+
+    /// <inheritdoc/>
+    public Task MarkUnresolvedAsync( RefreshReviewEntry entry, string reason, CancellationToken cancellationToken = default ) {
+        ArgumentNullException.ThrowIfNull( entry );
+        ArgumentException.ThrowIfNullOrWhiteSpace( entry.InstanceToken );
+        return MarkUnresolvedRecordAsync( entry, reason, cancellationToken );
+    }
+
+    /// <inheritdoc/>
+    public async Task PromoteDirectAsync( RefreshReviewEntry entry, string reason, CancellationToken cancellationToken = default ) {
+        ArgumentNullException.ThrowIfNull( entry );
+        ArgumentException.ThrowIfNullOrWhiteSpace( reason );
+        cancellationToken.ThrowIfCancellationRequested( );
+
+        RefreshReviewEntry unresolved = entry with {
+            FailedAt = DateTimeOffset.UtcNow,
+            FailureReason = reason
+        };
+        string json = JsonSerializer.Serialize( unresolved, s_jsonOptions );
+        _ = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            PromoteDirectScript,
+            keys: [UnresolvedKey, UnresolvedSagaIndexKey, SweepAttemptsPrefix + entry.SourceRecordUri],
+            values: [entry.SourceRecordUri, json, entry.SagaId] );
+        QueueMetrics.RecordMaintenanceOutcome( "promoted_to_review" );
+    }
+
+    private async Task MarkUnresolvedRecordAsync( RefreshReviewEntry entry, string reason, CancellationToken cancellationToken ) {
+        ArgumentNullException.ThrowIfNull( entry );
+        ArgumentException.ThrowIfNullOrWhiteSpace( reason );
+        cancellationToken.ThrowIfCancellationRequested( );
+        RefreshReviewEntry unresolved = entry with { FailedAt = DateTimeOffset.UtcNow, FailureReason = reason };
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            MarkUnresolvedRecordScript,
+            [PendingPrefix + entry.SourceRecordUri, UnresolvedKey, UnresolvedSagaIndexKey, PendingSagaIndexKey,
+                PendingSagaSetPrefix + entry.SagaId, SweepAttemptsPrefix + entry.SourceRecordUri],
+            [entry.SagaId, entry.InstanceToken, entry.SourceRecordUri, JsonSerializer.Serialize( unresolved, s_jsonOptions ),
+                entry.CreatedAtUnixMilliseconds] );
+        if ((int)result == 1) {
+            QueueMetrics.RecordMaintenanceOutcome( "promoted_to_review" );
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task CompleteAsync( RefreshReviewEntry entry, CancellationToken cancellationToken = default ) {
+        ArgumentNullException.ThrowIfNull( entry );
+        ArgumentException.ThrowIfNullOrWhiteSpace( entry.InstanceToken );
+        cancellationToken.ThrowIfCancellationRequested( );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            CompleteRecordScript,
+            [PendingPrefix + entry.SourceRecordUri, UnresolvedKey, UnresolvedSagaIndexKey, PendingSagaIndexKey,
+                PendingSagaSetPrefix + entry.SagaId, SweepAttemptsPrefix + entry.SourceRecordUri],
+            [entry.SagaId, entry.InstanceToken, entry.SourceRecordUri, entry.CreatedAtUnixMilliseconds] );
+        if ((int)result == 1) {
+            QueueMetrics.RecordMaintenanceOutcome( "terminal_completion" );
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task CompleteAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        IReadOnlyList<RefreshReviewEntry> entries = await GetPendingForSagaAsync( sagaId, cancellationToken );
+        foreach (RefreshReviewEntry entry in entries.Where( e => e.InstanceToken == expectedInstanceToken )) {
+            await CompleteAsync( entry, cancellationToken );
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> IncrementSweepAttemptAsync( string sourceRecordUri, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sourceRecordUri );
+        cancellationToken.ThrowIfCancellationRequested( );
+        RedisResult value = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            IncrementSweepAttemptScript,
+            [SweepAttemptsPrefix + sourceRecordUri],
+            [Math.Max( 1L, (long)_pendingTtl.TotalMilliseconds )] );
+        return (int)value;
+    }
+
+    /// <inheritdoc/>
+    public async Task ClearSweepAttemptsAsync( string sourceRecordUri, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sourceRecordUri );
+        cancellationToken.ThrowIfCancellationRequested( );
+        _ = await _redis.GetDatabase( ).KeyDeleteAsync( SweepAttemptsPrefix + sourceRecordUri );
     }
 
     /// <inheritdoc/>
@@ -138,10 +288,11 @@ public sealed partial class RedisRefreshReviewStore(
             }
         }
 
-        return results
-            .OrderByDescending( entry => entry.FailedAt )
-            .ThenBy( entry => entry.SourceRecordUri, StringComparer.Ordinal )
-            .ToArray( );
+        return [..
+            results
+                .OrderByDescending( entry => entry.FailedAt )
+                .ThenBy( entry => entry.SourceRecordUri, StringComparer.Ordinal )
+        ];
     }
 
     /// <inheritdoc/>

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestQueue.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisRequestQueue.cs
@@ -1,5 +1,9 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
@@ -38,12 +42,14 @@ internal static partial class RedisQueuePatterns {
 /// <c>:background</c>, <c>:bulk</c>, and <c>:dlq</c> (provider name lower-cased). Messages are read
 /// through a per-provider consumer group (<c>{provider}-workers</c>) by a per-process consumer
 /// (<c>{provider}-worker-{guid}</c>). Two behaviors are easy to misread and are called out here:
-/// acknowledgement does XACK followed by XDEL, so a processed message is deleted and cannot be
-/// replayed from the stream; and the delayed form of requeue is a logged stub that requeues
-/// immediately, so the requested delay is not honored. The unit other components pass around is
-/// the composite message id <c>{streamName}:{redisId}</c>.
+/// acknowledgement atomically performs XACK and XDEL, so a processed message is deleted and cannot be
+/// replayed from the stream. Requeue atomically creates the replacement and removes the original;
+/// ordinary transient retries carry a <c>NotBefore</c> timestamp, while provider rate-limit state
+/// controls endpoint eligibility. Idle consumers wake through Redis Pub/Sub or the earliest known
+/// retry/reclaim deadline. The unit other components pass around is the composite
+/// message id <c>{streamName}:{redisId}</c>.
 /// </remarks>
-public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : class, IQueueableRequest {
+public sealed partial class RedisRequestQueue<T> : IRequestQueue<T>, IConsumerGroupAssurance, IQueueDeliveryTracker, IQueueWorkSignal where T : class, IQueueableRequest {
 
     /// <summary>Redis connection used for all stream operations.</summary>
     private readonly IConnectionMultiplexer _redis;
@@ -79,6 +85,12 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
 
     /// <summary>Stream key for the dead-letter queue.</summary>
     private readonly string _dlqStream;
+    private readonly RedisChannel _workSignalChannel;
+    private readonly SemaphoreSlim _workSignalInitialization = new( 1, 1 );
+    private TaskCompletionSource _workSignal = CreateWorkSignal( );
+    private long _workVersion;
+    private bool _workSignalInitialized;
+    private DateTimeOffset? _nextScheduledWake;
 
     /// <summary>
     /// Effective aging interval (validated in constructor; N ≤ 1 falls back to default). Every
@@ -93,6 +105,14 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// </summary>
     private int _dequeueCounter;
 
+    /// <summary>Per-stream XAUTOCLAIM cursor retained between bounded dequeue calls.</summary>
+    private readonly ConcurrentDictionary<string, RedisValue> _autoClaimCursors = [];
+
+    /// <summary>Per-stream own-consumer XPENDING cursor retained between bounded dequeue calls.</summary>
+    private readonly ConcurrentDictionary<string, RedisValue> _pendingCursors = [];
+    /// <summary>Deliveries handed to processing tasks but not yet acknowledged or abandoned.</summary>
+    private readonly ConcurrentDictionary<string, byte> _activeDeliveries = [];
+
     // Track which stream a message came from for ack/requeue
 
     /// <summary>Dead-letter field holding the reason a message was dead-lettered. Literal: <c>"dlqReason"</c>.</summary>
@@ -103,6 +123,71 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
 
     /// <summary>Dead-letter field holding the stream the message came from. Literal: <c>"originalStream"</c>.</summary>
     private const string DlqOriginalStreamField = "originalStream";
+    private const int AutoClaimMinIdleMs = 15 * 60 * 1000;
+    private const string EnqueueDeliveryScript = """
+        local messageId = redis.call(
+            'XADD', KEYS[1], '*', ARGV[1], ARGV[2], ARGV[3], ARGV[4])
+        redis.call('PUBLISH', ARGV[5], messageId)
+        return messageId
+        """;
+    private const string RequeueDeliveryScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local replacement = redis.call(
+            'XADD', KEYS[1], '*', ARGV[3], ARGV[4], ARGV[5], ARGV[6])
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        redis.call('PUBLISH', ARGV[7], replacement)
+        return replacement
+        """;
+    private const string RequeueDlqDeliveryScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local replacement = redis.call(
+            'XADD', KEYS[2], '*', ARGV[2], ARGV[3], ARGV[4], ARGV[5])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        redis.call('PUBLISH', ARGV[6], replacement)
+        return replacement
+        """;
+    private const string MoveToDlqDeliveryScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local values = source[1][2]
+        local payload = false
+        local enqueuedAt = false
+        for i = 1, #values, 2 do
+            if values[i] == ARGV[3] then payload = values[i + 1] end
+            if values[i] == ARGV[4] then enqueuedAt = values[i + 1] end
+        end
+        if not payload or not enqueuedAt then return false end
+        local replacement = redis.call(
+            'XADD', KEYS[2], '*', ARGV[3], payload, ARGV[4], enqueuedAt,
+            ARGV[5], KEYS[1], ARGV[6], ARGV[7], ARGV[8], ARGV[9])
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        return replacement
+        """;
+    private const string RemoveDeliveryScript = """
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        return redis.call('XDEL', KEYS[1], ARGV[1])
+        """;
+    private const string MovePoisonToDlqScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local values = source[1][2]
+        local payload = ''
+        local enqueuedAt = ARGV[9]
+        for i = 1, #values, 2 do
+            if values[i] == ARGV[3] then payload = values[i + 1] end
+            if values[i] == ARGV[4] then enqueuedAt = values[i + 1] end
+        end
+        local replacement = redis.call(
+            'XADD', KEYS[2], '*', ARGV[3], payload, ARGV[4], enqueuedAt,
+            ARGV[5], KEYS[1], ARGV[6], ARGV[7], ARGV[8], ARGV[9])
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        return replacement
+        """;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisRequestQueue{T}"/> class for one provider,
@@ -151,21 +236,78 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         }
 
         string providerName = provider.ToString( ).ToLowerInvariant( );
-        string queuePrefix = string.IsNullOrEmpty( keyPrefix )
-            ? $"queue:{providerName}"
-            : $"queue:{keyPrefix}:{providerName}";
-        _interactiveStream = $"{queuePrefix}:interactive";
-        _backgroundStream = $"{queuePrefix}:background";
-        _bulkStream = $"{queuePrefix}:bulk";
-        _dlqStream = $"{queuePrefix}:dlq";
+        _interactiveStream = QueueStreamKeys.For( provider, QueuePriority.Interactive, keyPrefix );
+        _backgroundStream = QueueStreamKeys.For( provider, QueuePriority.Background, keyPrefix );
+        _bulkStream = QueueStreamKeys.For( provider, QueuePriority.Bulk, keyPrefix );
+        _dlqStream = QueueStreamKeys.DlqFor( provider, keyPrefix );
+        _workSignalChannel = RedisChannel.Literal( QueueStreamKeys.WorkSignalFor( provider, keyPrefix ) );
 
-        _consumerGroup = $"{providerName}-workers";
+        _consumerGroup = provider == SupportedProviders.Spotify
+            ? SpotifyConstants.ConsumerGroup
+            : $"{providerName}-workers";
         _consumerId = $"{providerName}-worker-{Guid.NewGuid( ):N}";
 
         _jsonOptions = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = false
         };
+    }
+
+    private static TaskCompletionSource CreateWorkSignal( ) =>
+        new( TaskCreationOptions.RunContinuationsAsynchronously );
+
+    /// <inheritdoc/>
+    public async Task InitializeWorkSignalAsync( CancellationToken cancellationToken = default ) {
+        if (_workSignalInitialized) return;
+        await _workSignalInitialization.WaitAsync( cancellationToken );
+        try {
+            if (_workSignalInitialized) return;
+            await _redis.GetSubscriber( ).SubscribeAsync( _workSignalChannel,
+                ( _, _ ) => NotifyWorkAvailable( ) );
+            _workSignalInitialized = true;
+        } finally {
+            _ = _workSignalInitialization.Release( );
+        }
+    }
+
+    /// <inheritdoc/>
+    public long CaptureWorkVersion( ) => Interlocked.Read( ref _workVersion );
+
+    /// <inheritdoc/>
+    public async Task WaitForWorkAsync(
+        long observedVersion,
+        DateTimeOffset? scheduledWake,
+        CancellationToken cancellationToken = default
+    ) {
+        scheduledWake = Earliest( scheduledWake, _nextScheduledWake );
+        while (Interlocked.Read( ref _workVersion ) == observedVersion) {
+            Task signal = Volatile.Read( ref _workSignal ).Task;
+            if (Interlocked.Read( ref _workVersion ) != observedVersion) return;
+
+            if (scheduledWake is null) {
+                await signal.WaitAsync( cancellationToken );
+                return;
+            }
+
+            TimeSpan remaining = scheduledWake.Value - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero) return;
+
+            TaskCompletionSource timerElapsed = CreateWorkSignal( );
+            using Timer timer = new(
+                static state => ((TaskCompletionSource)state!).TrySetResult( ),
+                timerElapsed,
+                remaining,
+                Timeout.InfiniteTimeSpan );
+            Task completed = await Task.WhenAny( signal, timerElapsed.Task ).WaitAsync( cancellationToken );
+            await completed;
+            return;
+        }
+    }
+
+    private void NotifyWorkAvailable( ) {
+        _ = Interlocked.Increment( ref _workVersion );
+        TaskCompletionSource previous = Interlocked.Exchange( ref _workSignal, CreateWorkSignal( ) );
+        _ = previous.TrySetResult( );
     }
 
     /// <summary>
@@ -187,7 +329,7 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
                 _ = await db.StreamCreateConsumerGroupAsync(
                     stream,
                     _consumerGroup,
-                    StreamPosition.NewMessages,
+                    StreamPosition.Beginning,
                     createStream: true
                 );
                 LogConsumerGroupCreated( _logger, _consumerGroup, stream );
@@ -222,10 +364,24 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
             new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
         ];
 
-        RedisValue messageId = await db.StreamAddAsync( stream, fields );
+        RedisResult enqueueResult = await db.ScriptEvaluateAsync(
+            EnqueueDeliveryScript,
+            [stream],
+            [
+                QueueStreamFieldNames.Payload,
+                fields[0].Value,
+                QueueStreamFieldNames.EnqueuedAt,
+                fields[1].Value,
+                _workSignalChannel.ToString( )
+            ] );
+        RedisValue messageId = (RedisValue)enqueueResult;
+        if (!messageId.HasValue) {
+            throw new InvalidOperationException( $"Redis did not return a message id for enqueue to '{stream}'." );
+        }
 
-        // Record enqueue metric
-        QueueMetrics.RecordEnqueue( _provider, priority );
+        NotifyWorkAvailable( );
+
+        QueueMetrics.RecordEnqueue( _provider, priority, request is QueuedLookupRequest q ? q.EnqueueOrigin : QueueEnqueueOrigin.New );
 
         if (_logger.IsEnabled( LogLevel.Debug )) {
             string msgId = messageId!;
@@ -245,33 +401,74 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// </remarks>
     public async Task<QueuedMessage<T>?> DequeueAsync( CancellationToken cancellationToken = default ) {
         IDatabase db = _redis.GetDatabase( );
+        Stopwatch dequeueTimer = Stopwatch.StartNew( );
+        Activity? dequeueActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue" );
+        _ = (dequeueActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+        QueuePriority? dequeuedPriority = null;
 
-        // Determine stream order: interactive-first with aging and bulk gating.
-        unchecked { _dequeueCounter++; }
-        string[] streamOrder = await GetWeightedStreamOrderWithBulkGatingAsync( _dequeueCounter );
+        try {
+            unchecked { _dequeueCounter++; }
+            Stopwatch depthTimer = Stopwatch.StartNew( );
+            Activity? depthActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue.depth_probe" );
+            _ = (depthActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+            string[] streamOrder;
+            try {
+                streamOrder = await GetWeightedStreamOrderWithBulkGatingAsync( _dequeueCounter );
+            } finally {
+                depthTimer.Stop( );
+                depthActivity?.Stop( );
+                QueueMetrics.DepthProbeDuration.Record( depthTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ) );
+            }
 
-        foreach (string stream in streamOrder) {
-            StreamEntry[] entries = await db.StreamReadGroupAsync(
-                stream,
-                _consumerGroup,
-                _consumerId,
-                count: 1,
-                noAck: false
-            );
-
-            if (entries.Length > 0) {
-                StreamEntry entry = entries[0];
-                QueuedMessage<T>? message = ParseStreamEntry( entry, stream );
-                if (message is not null) {
-                    // Record dequeue metric based on stream priority
-                    QueuePriority priority = GetPriorityFromStream( stream );
-                    QueueMetrics.RecordDequeue( _provider, priority );
+            foreach (string stream in streamOrder) {
+                Stopwatch readTimer = Stopwatch.StartNew( );
+                Activity? readActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue.read_group" );
+                _ = (readActivity?.SetTag( QueueMetricTags.Stream, stream ));
+                StreamEntry[] entries;
+                try {
+                    entries = await db.StreamReadGroupAsync(
+                        stream,
+                        _consumerGroup,
+                        _consumerId,
+                        count: 1,
+                        noAck: false
+                    );
+                } finally {
+                    readTimer.Stop( );
+                    readActivity?.Stop( );
+                    QueueMetrics.ReadGroupDuration.Record( readTimer.Elapsed.TotalSeconds,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
                 }
-                return message;
+
+                if (entries.Length > 0) {
+                    StreamEntry entry = entries[0];
+                    QueuedMessage<T>? message = ParseStreamEntry( entry, stream );
+                    if (message is not null) {
+                        if (TryActivateDelivery( message )) {
+                            dequeuedPriority = GetPriorityFromStream( stream );
+                            QueueMetrics.RecordDequeue( _provider, dequeuedPriority.Value );
+                            QueueMetrics.RecordQueueSojourn( _provider, dequeuedPriority.Value, message.EnqueuedAt );
+                            return message;
+                        }
+                        continue;
+                    }
+                    await MovePoisonEntryToDlqAsync( db, stream, entry.Id );
+                }
+            }
+            return null;
+        } finally {
+            dequeueTimer.Stop( );
+            dequeueActivity?.Stop( );
+            if (dequeuedPriority is { } priority) {
+                QueueMetrics.DequeueDuration.Record( dequeueTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ) );
+            } else {
+                QueueMetrics.DequeueDuration.Record( dequeueTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ) );
             }
         }
-
-        return null;
     }
 
     /// <summary>
@@ -288,42 +485,75 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="rateLimitTracker"/> is null.</exception>
     public async Task<QueuedMessage<T>?> DequeueAsync( IRateLimitTracker rateLimitTracker, CancellationToken cancellationToken = default ) {
         ArgumentNullException.ThrowIfNull( rateLimitTracker );
+        Stopwatch dequeueTimer = Stopwatch.StartNew( );
+        Activity? dequeueActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue" );
+        _ = (dequeueActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+        QueuePriority? dequeuedPriority = null;
 
         IDatabase db = _redis.GetDatabase( );
+        _nextScheduledWake = null;
 
-        // Get all currently rate-limited endpoints for this provider
-        IReadOnlyList<RateLimitedEndpoint> rateLimitedEndpoints = await rateLimitTracker.GetAllRateLimitedAsync( _provider, cancellationToken );
-        HashSet<string> blockedEndpoints = rateLimitedEndpoints.Select( e => e.Endpoint ).ToHashSet( StringComparer.OrdinalIgnoreCase );
+        try {
 
-        // Determine stream order: interactive-first with aging and bulk gating.
-        unchecked { _dequeueCounter++; }
-        string[] streamOrder = await GetWeightedStreamOrderWithBulkGatingAsync( _dequeueCounter );
+            // Get all currently rate-limited endpoints for this provider
+            IReadOnlyList<RateLimitedEndpoint> rateLimitedEndpoints = await rateLimitTracker.GetAllRateLimitedAsync( _provider, cancellationToken );
+            HashSet<string> blockedEndpoints = rateLimitedEndpoints.Select( e => e.Endpoint ).ToHashSet( StringComparer.OrdinalIgnoreCase );
 
-        if (_logger.IsEnabled( LogLevel.Debug )) {
-            LogDequeueStarting( _logger, blockedEndpoints.Count, streamOrder.Length );
-        }
+            // Determine stream order: interactive-first with aging and bulk gating.
+            unchecked { _dequeueCounter++; }
+            Stopwatch depthTimer = Stopwatch.StartNew( );
+            string[] streamOrder;
+            using Activity? depthActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue.depth_probe" );
+            _ = (depthActivity?.SetTag( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ));
+            try {
+                streamOrder = await GetWeightedStreamOrderWithBulkGatingAsync( _dequeueCounter );
+            } finally {
+                depthTimer.Stop( );
+                depthActivity?.Stop( );
+                QueueMetrics.DepthProbeDuration.Record( depthTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ) );
+            }
 
-        foreach (string stream in streamOrder) {
-            // Peek at pending messages to find one that's not rate-limited
-            QueuedMessage<T>? eligibleMessage = await FindEligibleMessageAsync( db, stream, blockedEndpoints, cancellationToken );
-            if (eligibleMessage is not null) {
-                // Record dequeue metric based on stream priority
-                QueuePriority priority = GetPriorityFromStream( stream );
-                QueueMetrics.RecordDequeue( _provider, priority );
-                return eligibleMessage;
+            if (_logger.IsEnabled( LogLevel.Debug )) {
+                LogDequeueStarting( _logger, blockedEndpoints.Count, streamOrder.Length );
+            }
+
+            foreach (string stream in streamOrder) {
+                // Peek at pending messages to find one that's not rate-limited
+                QueuedMessage<T>? eligibleMessage = await FindEligibleMessageAsync( db, stream, blockedEndpoints, cancellationToken );
+                if (eligibleMessage is not null) {
+                    // Record dequeue metric based on stream priority
+                    QueuePriority priority = GetPriorityFromStream( stream );
+                    dequeuedPriority = priority;
+                    QueueMetrics.RecordDequeue( _provider, priority );
+                    QueueMetrics.RecordQueueSojourn( _provider, priority, eligibleMessage.EnqueuedAt );
+                    return eligibleMessage;
+                }
+            }
+
+            if (_logger.IsEnabled( LogLevel.Debug )) {
+                LogDequeueNoEligibleMessages( _logger, streamOrder.Length );
+            }
+
+            RecordScheduledWake( DateTimeOffset.UtcNow.AddMilliseconds( AutoClaimMinIdleMs ) );
+            return null;
+        } finally {
+            dequeueTimer.Stop( );
+            dequeueActivity?.Stop( );
+            if (dequeuedPriority is { } priority) {
+                QueueMetrics.DequeueDuration.Record( dequeueTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ) );
+            } else {
+                QueueMetrics.DequeueDuration.Record( dequeueTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, _provider.ToString( ).ToLowerInvariant( ) ) );
             }
         }
-
-        if (_logger.IsEnabled( LogLevel.Debug )) {
-            LogDequeueNoEligibleMessages( _logger, streamOrder.Length );
-        }
-
-        return null;
     }
 
     /// <summary>
-    /// Finds the first eligible message in the stream that is not rate-limited, checking the
-    /// consumer's pending list before reading new messages via XREADGROUP.
+    /// Finds the first eligible message in the stream that is not rate-limited. It scans abandoned
+    /// entries via XAUTOCLAIM, then this consumer's pending list, then new messages via XREADGROUP.
     /// </summary>
     /// <param name="db">The Redis database to read from.</param>
     /// <param name="stream">The stream to scan.</param>
@@ -331,9 +561,9 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
     /// <returns>The first eligible message, or null if none found within the scan caps.</returns>
     /// <remarks>
-    /// Pending messages already claimed by this consumer are checked first (up to 50, recovery
-    /// scenario), then up to 50 new messages are read. Blocked messages are left in place to be
-    /// retried once their endpoint clears. The scan caps bound the per-stream work each dequeue does.
+    /// Each stage is independently bounded to 50 entries and returns at most one eligible message.
+    /// Blocked messages are left in place to be retried once their endpoint clears. The scan caps
+    /// bound the per-stream work each dequeue does.
     /// </remarks>
     private async Task<QueuedMessage<T>?> FindEligibleMessageAsync(
         IDatabase db,
@@ -341,112 +571,236 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         HashSet<string> blockedEndpoints,
         CancellationToken cancellationToken
     ) {
+        return await FindEligibleMessageCoreAsync( db, stream, blockedEndpoints, cancellationToken );
+    }
+
+    private async Task<QueuedMessage<T>?> FindEligibleMessageCoreAsync(
+        IDatabase db,
+        string stream,
+        HashSet<string> blockedEndpoints,
+        CancellationToken cancellationToken
+    ) {
         _ = cancellationToken; // Reserved for future async cancellation support
-        int pendingCount = 0;
-        int blockedPendingCount = 0;
-        int newMessagesRead = 0;
-        int blockedNewCount = 0;
-
-        // First, check for any pending messages already claimed by this consumer
-        // that may need to be processed (recovery scenario)
-        StreamPendingMessageInfo[]? pendingMessages = null;
-        try {
-            pendingMessages = await db.StreamPendingMessagesAsync(
-                stream,
-                _consumerGroup,
-                count: 50, // Check a reasonable batch
-                _consumerId
-            );
-            pendingCount = pendingMessages.Length;
-        } catch (RedisServerException) {
-            // Consumer group may not exist yet or no pending messages
+        Stopwatch pelTimer = Stopwatch.StartNew( );
+        Activity? pelActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue.pel_scan" );
+        _ = (pelActivity?.SetTag( QueueMetricTags.Stream, stream ));
+        bool pelStopped = false;
+        void StopPelScan( ) {
+            if (pelStopped) return;
+            pelStopped = true;
+            pelTimer.Stop( );
+            pelActivity?.Stop( );
+            QueueMetrics.PelScanDuration.Record( pelTimer.Elapsed.TotalSeconds,
+                new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
         }
+        try {
+            int pendingCount = 0;
+            int blockedPendingCount = 0;
+            int newMessagesRead = 0;
+            int blockedNewCount = 0;
 
-        // Process pending messages first (already claimed)
-        if (pendingMessages is { Length: > 0 }) {
-            foreach (StreamPendingMessageInfo pending in pendingMessages) {
-                // Read the message content
-                StreamEntry[] entries = await db.StreamRangeAsync( stream, pending.MessageId, pending.MessageId, count: 1 );
-                if (entries.Length == 0) { continue; }
+            // Reclaim entries abandoned by a dead consumer. A fifteen-minute idle threshold avoids
+            // stealing a legitimately slow provider request while allowing restart recovery.
+            try {
+                RedisValue autoClaimStart = _autoClaimCursors.TryGetValue( stream, out RedisValue cursor ) ? cursor : "0-0";
+                StreamAutoClaimResult claimed = await db.StreamAutoClaimAsync(
+                stream, _consumerGroup, _consumerId, AutoClaimMinIdleMs, autoClaimStart, 50);
+                _autoClaimCursors[stream] = claimed.NextStartId.HasValue && claimed.NextStartId != "0-0"
+                    ? claimed.NextStartId
+                    : "0-0";
+                foreach (RedisValue deletedId in claimed.DeletedIds) {
+                    _ = await db.StreamAcknowledgeAsync( stream, _consumerGroup, deletedId );
+                    _ = await db.StreamDeleteAsync( stream, [deletedId] );
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "missing" ) );
+                }
+                foreach (StreamEntry claimedEntry in claimed.ClaimedEntries) {
+                    QueuedMessage<T>? reclaimed = ParseStreamEntry(claimedEntry, stream);
+                    if (reclaimed is null) {
+                        await MovePoisonEntryToDlqAsync( db, stream, claimedEntry.Id );
+                        continue;
+                    }
+                    bool reclaimedBlocked = IsMessageBlocked( reclaimed.Payload, blockedEndpoints );
+                    if (!reclaimedBlocked && TryActivateDelivery( reclaimed )) {
+                        QueueMetrics.PelScanEntries.Add( 1,
+                            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "eligible" ) );
+                        return reclaimed;
+                    }
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome,
+                            reclaimedBlocked ? "blocked" : "active" ) );
+                }
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )) {
+                throw;
+            } catch (RedisServerException ex) when (IsAutoClaimUnsupported( ex )) {
+                // Redis versions before 6.2 lack XAUTOCLAIM; continue with own-PEL and new reads.
+            } catch (RedisServerException) {
+                throw;
+            }
 
-                StreamEntry entry = entries[0];
+            // Next, check for any pending messages already claimed by this consumer that may need
+            // to be processed (recovery scenario) after the XAUTOCLAIM stage above.
+            StreamEntry[]? pendingEntries = null;
+            try {
+                RedisValue pendingCursor = _pendingCursors.TryGetValue( stream, out RedisValue cursor )
+                    ? cursor
+                    : "0-0";
+                pendingEntries = await db.StreamReadGroupAsync(
+                    stream,
+                    _consumerGroup,
+                    _consumerId,
+                    position: pendingCursor,
+                    count: 50,
+                    noAck: false );
+                if (pendingEntries.Length < 50) {
+                    _ = _pendingCursors.TryRemove( stream, out _ );
+                } else {
+                    // XREADGROUP history returns IDs strictly greater than the supplied ID, so
+                    // the final entry is the next page's cursor without XPENDING's '(' syntax.
+                    _pendingCursors[stream] = pendingEntries[^1].Id;
+                }
+                pendingCount = pendingEntries.Length;
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )) {
+                throw;
+            } catch (RedisServerException) {
+                throw;
+            }
+
+            // XREADGROUP with an explicit history ID returns this consumer's pending entries and
+            // their bodies in one round trip. The prior XPENDING + one XRANGE per entry path made
+            // every dequeue up to 51 sequential Redis calls under a large PEL.
+            if (pendingEntries is { Length: > 0 }) {
+                foreach (StreamEntry entry in pendingEntries) {
+                    if (entry.Values.Length == 0) {
+                        // Redis returns an empty body when a PEL row outlives its stream entry.
+                        _ = await db.StreamAcknowledgeAsync( stream, _consumerGroup, entry.Id );
+                        _ = await db.StreamDeleteAsync( stream, [entry.Id] );
+                        QueueMetrics.PelScanEntries.Add( 1,
+                            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "missing" ) );
+                        continue;
+                    }
+
+                    QueuedMessage<T>? message = ParseStreamEntry( entry, stream );
+                    if (message is null) {
+                        await MovePoisonEntryToDlqAsync( db, stream, entry.Id );
+                        continue;
+                    }
+
+                    // Check if this message's endpoint is blocked
+                    bool messageBlocked = IsMessageBlocked( message.Payload, blockedEndpoints );
+                    if (!messageBlocked && TryActivateDelivery( message )) {
+                        if (_logger.IsEnabled( LogLevel.Debug )) {
+                            string msgId = entry.Id.ToString( );
+                            LogFoundEligibleMessage( _logger, msgId, stream );
+                        }
+                        QueueMetrics.PelScanEntries.Add( 1,
+                            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "eligible" ) );
+                        return message;
+                    }
+
+                    if (messageBlocked) blockedPendingCount++;
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome,
+                            messageBlocked ? "blocked" : "active" ) );
+                    // A blocked message remains pending. An active message is already owned by
+                    // another local processing task and must not be handed out again.
+                    if (messageBlocked && _logger.IsEnabled( LogLevel.Debug )) {
+                        string msgIdString = entry.Id.ToString( );
+                        LogSkippingBlockedMessage( _logger, msgIdString, stream );
+                    }
+                }
+            }
+
+            // No eligible pending messages, read new messages using XREADGROUP. The PEL span ends
+            // before the first read so its duration cannot hide the read-group latency.
+            StopPelScan( );
+
+            // No eligible pending messages, read new messages using XREADGROUP
+            // This properly claims messages from the stream (unlike XCLAIM which only works for pending messages)
+            // Read a batch and check each for rate limiting
+            const int MaxNewMessagesToRead = 50;
+            int messagesChecked = 0;
+
+            while (messagesChecked < MaxNewMessagesToRead) {
+                // Read one message at a time so we can check rate limits and leave blocked ones pending
+                Stopwatch readTimer = Stopwatch.StartNew( );
+                using Activity? readActivity = QueueMetrics.ActivitySource.StartActivity( "queue.dequeue.read_group" );
+                _ = (readActivity?.SetTag( QueueMetricTags.Stream, stream ));
+                StreamEntry[] newEntries;
+                try {
+                    newEntries = await db.StreamReadGroupAsync(
+                        stream,
+                        _consumerGroup,
+                        _consumerId,
+                        position: StreamPosition.NewMessages,
+                        count: 1,
+                        noAck: false );
+                } finally {
+                    readTimer.Stop( );
+                    readActivity?.Stop( );
+                    QueueMetrics.ReadGroupDuration.Record( readTimer.Elapsed.TotalSeconds,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
+                }
+
+                if (newEntries.Length == 0) {
+                    // No more new messages in stream
+                    if (messagesChecked == 0 && _logger.IsEnabled( LogLevel.Debug )) {
+                        LogNoNewMessagesInStream( _logger, stream );
+                    }
+                    break;
+                }
+
+                newMessagesRead++;
+                messagesChecked++;
+
+                StreamEntry entry = newEntries[0];
                 QueuedMessage<T>? message = ParseStreamEntry( entry, stream );
-                if (message is null) { continue; }
+                if (message is null) {
+                    await MovePoisonEntryToDlqAsync( db, stream, entry.Id );
+                    continue;
+                }
 
                 // Check if this message's endpoint is blocked
-                if (!IsMessageBlocked( message.Payload, blockedEndpoints )) {
+                if (!IsMessageBlocked( message.Payload, blockedEndpoints )
+                    && TryActivateDelivery( message )) {
                     if (_logger.IsEnabled( LogLevel.Debug )) {
-                        string msgId = pending.MessageId.ToString( );
+                        string msgId = entry.Id.ToString( );
                         LogFoundEligibleMessage( _logger, msgId, stream );
                     }
                     return message;
                 }
 
-                blockedPendingCount++;
-                // Message is blocked - leave it pending, don't acknowledge
+                // Message is blocked by rate limiting - leave it pending for later retry
+                blockedNewCount++;
                 if (_logger.IsEnabled( LogLevel.Debug )) {
-                    string msgIdString = pending.MessageId.ToString( );
-                    LogSkippingBlockedMessage( _logger, msgIdString, stream );
+                    string entryIdString = entry.Id.ToString( );
+                    LogSkippingRateLimitedMessage( _logger, entryIdString, stream );
                 }
+                // Continue to check next message
             }
+
+            // Log summary of what we scanned
+            if (_logger.IsEnabled( LogLevel.Debug ) && (pendingCount > 0 || newMessagesRead > 0)) {
+                LogStreamScanSummary( _logger, stream, pendingCount, newMessagesRead, blockedPendingCount + blockedNewCount );
+            }
+
+            return null;
+        } finally {
+            StopPelScan( );
         }
+    }
 
-        // No eligible pending messages, read new messages using XREADGROUP
-        // This properly claims messages from the stream (unlike XCLAIM which only works for pending messages)
-        // Read a batch and check each for rate limiting
-        const int MaxNewMessagesToRead = 50;
-        int messagesChecked = 0;
-
-        while (messagesChecked < MaxNewMessagesToRead) {
-            // Read one message at a time so we can check rate limits and leave blocked ones pending
-            StreamEntry[] newEntries = await db.StreamReadGroupAsync(
-                stream,
-                _consumerGroup,
-                _consumerId,
-                position: StreamPosition.NewMessages, // ">" - only new messages
-                count: 1,
-                noAck: false // Message becomes pending until acknowledged
-            );
-
-            if (newEntries.Length == 0) {
-                // No more new messages in stream
-                if (messagesChecked == 0 && _logger.IsEnabled( LogLevel.Debug )) {
-                    LogNoNewMessagesInStream( _logger, stream );
-                }
-                break;
-            }
-
-            newMessagesRead++;
-            messagesChecked++;
-
-            StreamEntry entry = newEntries[0];
-            QueuedMessage<T>? message = ParseStreamEntry( entry, stream );
-            if (message is null) { continue; }
-
-            // Check if this message's endpoint is blocked
-            if (!IsMessageBlocked( message.Payload, blockedEndpoints )) {
-                if (_logger.IsEnabled( LogLevel.Debug )) {
-                    string msgId = entry.Id.ToString( );
-                    LogFoundEligibleMessage( _logger, msgId, stream );
-                }
-                return message;
-            }
-
-            // Message is blocked by rate limiting - leave it pending for later retry
-            blockedNewCount++;
-            if (_logger.IsEnabled( LogLevel.Debug )) {
-                string entryIdString = entry.Id.ToString( );
-                LogSkippingRateLimitedMessage( _logger, entryIdString, stream );
-            }
-            // Continue to check next message
-        }
-
-        // Log summary of what we scanned
-        if (_logger.IsEnabled( LogLevel.Debug ) && (pendingCount > 0 || newMessagesRead > 0)) {
-            LogStreamScanSummary( _logger, stream, pendingCount, newMessagesRead, blockedPendingCount + blockedNewCount );
-        }
-
-        return null;
+    private static bool IsAutoClaimUnsupported( RedisServerException exception ) {
+        string message = exception.Message;
+        return message.Contains( "XAUTOCLAIM", StringComparison.OrdinalIgnoreCase )
+            && (message.Contains( "unknown command", StringComparison.OrdinalIgnoreCase )
+                || message.Contains( "not supported", StringComparison.OrdinalIgnoreCase ));
     }
 
     /// <summary>
@@ -459,9 +813,13 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// True if the request is a lookup request whose lookup type matches a blocked endpoint;
     /// otherwise false. Non-lookup request types are never treated as blocked.
     /// </returns>
-    private static bool IsMessageBlocked( T request, HashSet<string> blockedEndpoints ) {
-        // Extract the lookup type from the request if it's a QueuedLookupRequest
+    private bool IsMessageBlocked( T request, HashSet<string> blockedEndpoints ) {
+        // Extract the lookup type from the request if it's a QueuedLookupRequest.
         if (request is QueuedLookupRequest lookupRequest) {
+            if (lookupRequest.NotBefore is { } notBefore && notBefore > DateTimeOffset.UtcNow) {
+                RecordScheduledWake( notBefore );
+                return true;
+            }
             // Use the LookupType as the endpoint key for rate limiting
             string endpointKey = lookupRequest.LookupType.ToString( );
             return blockedEndpoints.Contains( endpointKey );
@@ -469,6 +827,28 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
 
         // For other request types, don't block
         return false;
+    }
+
+    private void RecordScheduledWake( DateTimeOffset candidate ) {
+        if (_nextScheduledWake is null || candidate < _nextScheduledWake) {
+            _nextScheduledWake = candidate;
+        }
+    }
+
+    private static DateTimeOffset? Earliest( DateTimeOffset? left, DateTimeOffset? right ) =>
+        left is null ? right : right is null || left <= right ? left : right;
+
+    private bool TryActivateDelivery( QueuedMessage<T> message ) =>
+        _activeDeliveries.TryAdd( message.MessageId, 0 );
+
+    /// <inheritdoc/>
+    public void ReleaseDelivery( string messageId ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( messageId );
+        if (_activeDeliveries.TryRemove( messageId, out _ )) {
+            // A locally fenced PEL entry is eligible again. Wake the dequeue producer even when
+            // no new Redis stream entry was added (for example after capped ACK recovery).
+            NotifyWorkAvailable( );
+        }
     }
 
     /// <summary>
@@ -489,13 +869,14 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         (string stream, string id) = ParseMessageId( messageId );
 
         IDatabase db = _redis.GetDatabase( );
-        _ = await db.StreamAcknowledgeAsync( stream, _consumerGroup, id );
-
-        // Also delete the message from the stream (cleanup)
-        _ = await db.StreamDeleteAsync( stream, [id] );
+        _ = await db.ScriptEvaluateAsync(
+            RemoveDeliveryScript,
+            [stream],
+            [id, _consumerGroup] );
+        ReleaseDelivery( messageId );
 
         // Record acknowledge metric
-        QueueMetrics.RecordAcknowledge( _provider );
+        QueueMetrics.RecordDeliveryRemoved( _provider, GetPriorityFromStream( stream ) );
 
         LogAcknowledged( _logger, id, stream );
     }
@@ -505,15 +886,14 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
     /// </summary>
     /// <param name="messageId">The composite message id to requeue.</param>
     /// <param name="delay">
-    /// Requested delay before the message becomes available again. <b>Not honored:</b> a non-zero
-    /// delay is logged and then ignored, and the message is requeued immediately.
+    /// An explicit provider eligibility delay. When omitted, the queue applies the ordinary
+    /// transient-failure 1/2/4/8-second backoff and increments the attempt count.
     /// </param>
     /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
     /// <returns>A task that completes once the message is requeued, or immediately if the original entry no longer exists.</returns>
     /// <remarks>
-    /// Reads the original entry, acknowledges and deletes it, then re-adds the same payload with a
-    /// new <c>enqueuedAt</c>. The delayed-requeue path is a known stub: it only logs that delay is
-    /// not implemented and proceeds with an immediate requeue. A requeue metric is recorded.
+    /// Reads the original entry, adds a replacement, then acknowledges and deletes the original
+    /// so an XADD failure cannot lose the delivery.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="messageId"/> is null or whitespace, or is not a valid composite id.</exception>
     public async Task RequeueAsync( string messageId, TimeSpan? delay = null, CancellationToken cancellationToken = default ) {
@@ -527,28 +907,55 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
 
         if (entries.Length == 0) {
             LogMessageNotFoundForRequeue( _logger, id, stream );
+            ReleaseDelivery( messageId );
             return;
         }
 
         StreamEntry original = entries[0];
 
-        // Acknowledge and delete the original
-        _ = await db.StreamAcknowledgeAsync( stream, _consumerGroup, id );
-        _ = await db.StreamDeleteAsync( stream, [id] );
-
-        if (delay.HasValue && delay.Value > TimeSpan.Zero) {
-            // For delayed requeue, we'd need a separate delay mechanism (e.g., sorted set with score = delivery time)
-            // For now, add immediately with a note. Workers can implement delay checking later.
-            LogDelayedRequeueNotImplemented( _logger );
-        }
-
         // Re-add with updated enqueued time
+        RedisValue payload = original[QueueStreamFieldNames.Payload];
+        if (typeof( T ) == typeof( QueuedLookupRequest )) {
+            QueuedLookupRequest? queued = JsonSerializer.Deserialize<QueuedLookupRequest>( payload.ToString( ), _jsonOptions );
+            if (queued is not null) {
+                TimeSpan retryDelay = delay ?? TimeSpan.FromSeconds( 1 << Math.Min( queued.AttemptCount, 3 ) );
+                payload = JsonSerializer.Serialize( queued with {
+                    EnqueueOrigin = QueueEnqueueOrigin.Requeue,
+                    AttemptCount = delay is null ? queued.AttemptCount + 1 : queued.AttemptCount,
+                    NotBefore = DateTimeOffset.UtcNow + retryDelay
+                }, _jsonOptions );
+            }
+        }
         NameValueEntry[] fields = [
-            new NameValueEntry( QueueStreamFieldNames.Payload, original[QueueStreamFieldNames.Payload] ),
+            new NameValueEntry( QueueStreamFieldNames.Payload, payload ),
             new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
         ];
 
-        _ = await db.StreamAddAsync( stream, fields );
+        RedisResult moveResult = await db.ScriptEvaluateAsync(
+            RequeueDeliveryScript,
+            [stream],
+            [
+                id,
+                _consumerGroup,
+                QueueStreamFieldNames.Payload,
+                payload,
+                QueueStreamFieldNames.EnqueuedAt,
+                fields[1].Value,
+                _workSignalChannel.ToString( )
+            ] );
+        RedisValue replacementId = (RedisValue)moveResult;
+        if (!replacementId.HasValue) {
+            ReleaseDelivery( messageId );
+            return;
+        }
+        NotifyWorkAvailable( );
+
+        // An accepted replacement is counted at the XADD boundary, even if cleanup of the
+        // original PEL entry subsequently fails.
+        QueueMetrics.RecordEnqueue( _provider, GetPriorityFromStream( stream ), QueueEnqueueOrigin.Requeue );
+
+        ReleaseDelivery( messageId );
+        QueueMetrics.RecordDeliveryRemoved( _provider, GetPriorityFromStream( stream ) );
 
         // Record requeue metric
         QueueMetrics.RecordRequeue( _provider );
@@ -630,15 +1037,36 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         string targetStream = GetStreamForPriority( priority );
 
         // Add to target stream
+        RedisValue payload = original[QueueStreamFieldNames.Payload];
+        if (typeof( T ) == typeof( QueuedLookupRequest )) {
+            QueuedLookupRequest? queued = JsonSerializer.Deserialize<QueuedLookupRequest>( payload.ToString( ), _jsonOptions );
+            if (queued is not null) {
+                payload = JsonSerializer.Serialize( queued with { EnqueueOrigin = QueueEnqueueOrigin.Requeue }, _jsonOptions );
+            }
+        }
         NameValueEntry[] fields = [
-            new NameValueEntry( QueueStreamFieldNames.Payload, original[QueueStreamFieldNames.Payload] ),
+            new NameValueEntry( QueueStreamFieldNames.Payload, payload ),
             new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
         ];
 
-        _ = await db.StreamAddAsync( targetStream, fields );
+        RedisResult moveResult = await db.ScriptEvaluateAsync(
+            RequeueDlqDeliveryScript,
+            [_dlqStream, targetStream],
+            [
+                id,
+                QueueStreamFieldNames.Payload,
+                fields[0].Value,
+                QueueStreamFieldNames.EnqueuedAt,
+                fields[1].Value,
+                _workSignalChannel.ToString( )
+            ] );
+        RedisValue replacementId = (RedisValue)moveResult;
+        if (!replacementId.HasValue) {
+            throw new InvalidOperationException( $"DLQ entry '{_dlqStream}:{id}' was no longer available to requeue." );
+        }
+        NotifyWorkAvailable( );
 
-        // Delete from DLQ
-        _ = await db.StreamDeleteAsync( _dlqStream, [id] );
+        QueueMetrics.RecordEnqueue( _provider, priority, QueueEnqueueOrigin.Requeue );
 
         LogMovedFromDlq( _logger, id, targetStream, priority );
     }
@@ -662,30 +1090,28 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         (string stream, string id) = ParseMessageId( messageId );
         IDatabase db = _redis.GetDatabase( );
 
-        // Read the original message
-        StreamEntry[] entries = await db.StreamRangeAsync( stream, id, id, count: 1 );
-
-        if (entries.Length == 0) {
+        RedisResult moveResult = await db.ScriptEvaluateAsync(
+            MoveToDlqDeliveryScript,
+            [stream, _dlqStream],
+            [
+                id,
+                _consumerGroup,
+                QueueStreamFieldNames.Payload,
+                QueueStreamFieldNames.EnqueuedAt,
+                DlqOriginalStreamField,
+                DlqReasonField,
+                reason,
+                DlqMovedAtField,
+                DateTimeOffset.UtcNow.ToString( "O" )
+            ] );
+        RedisValue replacementId = (RedisValue)moveResult;
+        ReleaseDelivery( messageId );
+        if (!replacementId.HasValue) {
             LogMessageNotFoundForDlqMove( _logger, id, stream );
             return;
         }
-
-        StreamEntry original = entries[0];
-
-        // Add to DLQ with metadata
-        NameValueEntry[] dlqFields = [
-            new NameValueEntry( QueueStreamFieldNames.Payload, original[QueueStreamFieldNames.Payload] ),
-            new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, original[QueueStreamFieldNames.EnqueuedAt] ),
-            new NameValueEntry( DlqOriginalStreamField, stream ),
-            new NameValueEntry( DlqReasonField, reason ),
-            new NameValueEntry( DlqMovedAtField, DateTimeOffset.UtcNow.ToString( "O" ) )
-        ];
-
-        _ = await db.StreamAddAsync( _dlqStream, dlqFields );
-
-        // Acknowledge and delete from original stream
-        _ = await db.StreamAcknowledgeAsync( stream, _consumerGroup, id );
-        _ = await db.StreamDeleteAsync( stream, [id] );
+        QueueMetrics.RecordDeliveryRemoved( _provider, GetPriorityFromStream( stream ) );
+        QueueMetrics.RecordDlq( _provider, GetPriorityFromStream( stream ) );
 
         LogMovedToDlq( _logger, id, stream, reason );
     }
@@ -734,6 +1160,10 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         if (stream == _interactiveStream) { return QueuePriority.Interactive; }
         if (stream == _backgroundStream) { return QueuePriority.Background; }
         if (stream == _bulkStream) { return QueuePriority.Bulk; }
+        if (_provider == SupportedProviders.Spotify
+            && stream is SpotifyConstants.BulkTrackIdStream or SpotifyConstants.BulkAlbumIdStream) {
+            return QueuePriority.Bulk;
+        }
         return QueuePriority.Background; // Default fallback
     }
 
@@ -826,17 +1256,49 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
             }
 
             DateTimeOffset enqueuedAt = !string.IsNullOrEmpty( enqueuedAtStr )
-                ? DateTimeOffset.Parse( enqueuedAtStr )
+                ? DateTimeOffset.Parse(
+                    enqueuedAtStr,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind )
                 : DateTimeOffset.UtcNow;
 
             // Composite message ID includes stream for ack/requeue
             string compositeId = $"{stream}:{entry.Id}";
 
-            return new QueuedMessage<T>( compositeId, request, enqueuedAt );
+            return new QueuedMessage<T>( compositeId, request, enqueuedAt ) {
+                Priority = GetPriorityFromStream( stream )
+            };
         } catch (JsonException ex) {
             LogDeserializationError( _logger, ex, entry.Id.ToString( ), stream );
             return null;
+        } catch (FormatException ex) {
+            LogDeserializationError( _logger, ex, entry.Id.ToString( ), stream );
+            return null;
         }
+    }
+
+    private async Task MovePoisonEntryToDlqAsync( IDatabase db, string stream, RedisValue id ) {
+        RedisResult result = await db.ScriptEvaluateAsync(
+            MovePoisonToDlqScript,
+            [stream, _dlqStream],
+            [
+                id,
+                _consumerGroup,
+                QueueStreamFieldNames.Payload,
+                QueueStreamFieldNames.EnqueuedAt,
+                DlqOriginalStreamField,
+                DlqReasonField,
+                "Unreadable queue payload.",
+                DlqMovedAtField,
+                DateTimeOffset.UtcNow.ToString( "O", CultureInfo.InvariantCulture )
+            ] );
+        if (!((RedisValue)result).HasValue) return;
+        QueueMetrics.PelScanEntries.Add( 1,
+            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "poison" ) );
+        QueueMetrics.RecordDeliveryRemoved( _provider, GetPriorityFromStream( stream ) );
+        QueueMetrics.RecordDlq( _provider, GetPriorityFromStream( stream ) );
+        QueueMetrics.RecordTerminalOutcome( _provider, GetPriorityFromStream( stream ), "poison_dlq" );
     }
 
     /// <summary>
@@ -939,14 +1401,6 @@ public sealed partial class RedisRequestQueue<T> : IRequestQueue<T> where T : cl
         Level = LogLevel.Warning,
         Message = "Message {MessageId} not found in {Stream} for requeue" )]
     internal static partial void LogMessageNotFoundForRequeue( ILogger logger, string messageId, string stream );
-
-    /// <summary>Logs that a delayed requeue was requested but the delay is not implemented (the message is requeued immediately).</summary>
-    /// <param name="logger">The logger to write to.</param>
-    [LoggerMessage(
-        EventId = LogEventIds.Infrastructure.Queue.RedisRequestQueueDelayedRequeueNotImplemented,
-        Level = LogLevel.Debug,
-        Message = "Delayed requeue requested but not yet implemented. Adding immediately." )]
-    internal static partial void LogDelayedRequeueNotImplemented( ILogger logger );
 
     /// <summary>Logs that a message was requeued.</summary>
     /// <param name="logger">The logger to write to.</param>

--- a/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/RedisSagaStateManager.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using BridgeBeats.Contracts.Enums;
+using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Infrastructure.Logging;
@@ -85,9 +87,59 @@ public sealed partial class RedisSagaStateManager(
 
     /// <summary>Core hash field: single-winner marker that finalization has been claimed. Literal: <c>"finalizeClaimed"</c>.</summary>
     private const string FieldFinalizeClaimed = "finalizeClaimed";
+    private const string FieldFinalizeClaimedAt = "finalizeClaimedAt";
 
     /// <summary>Core hash field: the highest provider-count already durably written to the PDS. Literal: <c>"writeGeneration"</c>.</summary>
     private const string FieldWriteGeneration = "writeGeneration";
+    private const string FieldInstanceToken = "instanceToken";
+    private const string TokenGuardedUriScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "redis.call('hset', KEYS[1], ARGV[3], ARGV[4]); redis.call('expire', KEYS[1], tonumber(ARGV[5])); return 1";
+    private const string TokenGuardedFinalUriScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "local current = redis.call('hget', KEYS[1], ARGV[3]); " +
+        "if current and current ~= '' then if current == ARGV[4] then return 2 else return -1 end end; " +
+        "redis.call('hset', KEYS[1], ARGV[3], ARGV[4], ARGV[5], 'False'); " +
+        "redis.call('expire', KEYS[1], tonumber(ARGV[6])); return 1";
+    private const string TokenGuardedDeleteScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "for i = 1, #KEYS - 1 do redis.call('del', KEYS[i]) end; redis.call('srem', KEYS[#KEYS], ARGV[3]); return 1";
+    private const string TokenGuardedReleaseScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "local removed = redis.call('hdel', KEYS[1], ARGV[3]); redis.call('hdel', KEYS[1], ARGV[4]); " +
+        "if removed == 1 then redis.call('expire', KEYS[1], tonumber(ARGV[5])) end; return removed";
+    private const string TokenGuardedResetScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[4]) ~= ARGV[5] then return 0 end; " +
+        "local cur = tonumber(redis.call('hget', KEYS[1], ARGV[1]) or '0'); if cur == tonumber(ARGV[2]) then " +
+        "redis.call('hset', KEYS[1], ARGV[1], ARGV[3]); redis.call('expire', KEYS[1], tonumber(ARGV[6])); return 1 end; return 0";
+    private const string CreateSagaScript =
+        "if redis.call('exists', KEYS[1]) == 1 then " +
+        "if ARGV[6] ~= '' and redis.call('hexists', KEYS[1], 'originPriority') == 0 then redis.call('hset', KEYS[1], 'originPriority', ARGV[6]) end; " +
+        "redis.call('expire', KEYS[1], tonumber(ARGV[7])); return 0; end; " +
+        "redis.call('hset', KEYS[1], 'lookupKey', ARGV[1], 'lookupType', ARGV[2], 'lookupValue', ARGV[3], 'createdAt', ARGV[4], 'partialResultUri', '', 'instanceToken', ARGV[5]); " +
+        "if ARGV[6] ~= '' then redis.call('hset', KEYS[1], 'originPriority', ARGV[6]) end; " +
+        "redis.call('expire', KEYS[1], tonumber(ARGV[7])); redis.call('sadd', KEYS[2], ARGV[8]); return 1";
+    private const string TokenGuardedProviderInitScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "if redis.call('exists', KEYS[2]) == 0 then redis.call('hset', KEYS[2], 'isComplete', 'False', 'isSuccess', 'False', 'resultJson', '', 'completedAt', '', 'errorMessage', ''); end; " +
+        "redis.call('expire', KEYS[1], tonumber(ARGV[3])); redis.call('expire', KEYS[2], tonumber(ARGV[3])); return 1";
+    private const string TokenGuardedProviderUpdateScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "redis.call('hset', KEYS[2], 'isComplete', ARGV[3], 'isSuccess', ARGV[4], 'resultJson', ARGV[5], 'completedAt', ARGV[6], 'errorMessage', ARGV[7]); " +
+        "redis.call('expire', KEYS[1], tonumber(ARGV[8])); redis.call('expire', KEYS[2], tonumber(ARGV[8])); return 1";
+    private const string TokenGuardedInitialProviderScript =
+        "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+        "redis.call('hset', KEYS[1], ARGV[3], ARGV[4]); redis.call('expire', KEYS[1], tonumber(ARGV[5])); return 1";
+    private const string ReplaceLeftoverScript =
+        "if redis.call('exists', KEYS[1]) == 0 then return 0 end; " +
+        "if redis.call('hget', KEYS[1], 'finalizeClaimed') ~= 'True' and redis.call('hget', KEYS[1], 'finalizeClaimed') ~= 'true' then return 0 end; " +
+        "local final = redis.call('hget', KEYS[1], 'finalResultUri'); if final and final ~= '' then return 0 end; " +
+        "local claimedAt = redis.call('hget', KEYS[1], 'finalizeClaimedAt'); local claimedAtMs = tonumber(claimedAt or ''); if claimedAtMs and claimedAtMs > tonumber(ARGV[10]) then return 0 end; " +
+        "local current = redis.call('hget', KEYS[1], ARGV[1]); if not current or current == '' or current ~= ARGV[2] then return 0 end; " +
+        "for i = 2, #KEYS - 1 do redis.call('del', KEYS[i]) end; " +
+        "local token = ARGV[3]; redis.call('del', KEYS[1]); redis.call('hset', KEYS[1], 'lookupKey', ARGV[4], 'lookupType', ARGV[5], 'lookupValue', ARGV[6], 'createdAt', ARGV[7], 'partialResultUri', '', 'instanceToken', token); " +
+        "if ARGV[8] ~= '' then redis.call('hset', KEYS[1], 'originPriority', ARGV[8]) end; redis.call('expire', KEYS[1], tonumber(ARGV[9])); redis.call('sadd', KEYS[#KEYS], ARGV[11]); return token";
+    private static readonly TimeSpan s_finalizerLease = TimeSpan.FromMinutes( 15 );
 
     // Hash field names for provider state
 
@@ -137,19 +189,25 @@ public sealed partial class RedisSagaStateManager(
         IDatabase db = _redis.GetDatabase( );
         TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
 
-        // Check if saga already exists
-        bool exists = await db.KeyExistsAsync( key );
+        string instanceToken = Guid.NewGuid( ).ToString( "N" );
+        RedisResult created = await db.ScriptEvaluateAsync(
+            CreateSagaScript,
+            [key, PendingSagaSetKey],
+            [lookupKey, lookupType.ToString( ), lookupValue, DateTimeOffset.UtcNow.ToString( "O" ), instanceToken,
+                originPriority?.ToString( ) ?? "", (long)ttl.TotalSeconds, sagaId] );
 
-        if (exists) {
-            // Extend TTL and return existing state
-            _ = await db.KeyExpireAsync( key, ttl );
-
-            // Record the origin priority if none has been recorded yet (first writer wins).
-            // Sagas created by the orchestrator before a worker processes the first request
-            // have no origin priority field; the first request's priority becomes the origin.
-            if (originPriority.HasValue &&
-                await db.HashSetAsync( key, FieldOriginPriority, originPriority.Value.ToString( ), When.NotExists )) {
-                LogOriginPrioritySet( _logger, originPriority.Value, sagaId );
+        if ((int)created == 0) {
+            RedisKey[] replacementKeys = [key, .. Enum.GetValues<SupportedProviders>( ).Select( provider => (RedisKey)GetProviderKey( sagaId, provider ) ), PendingSagaSetKey];
+            string replacementToken = Guid.NewGuid( ).ToString( "N" );
+            RedisResult replacement = await db.ScriptEvaluateAsync(
+                ReplaceLeftoverScript,
+                replacementKeys,
+                [FieldInstanceToken, (RedisValue)(await db.HashGetAsync( key, FieldInstanceToken )), replacementToken,
+                    lookupKey, lookupType.ToString( ), lookupValue, DateTimeOffset.UtcNow.ToString( "O" ),
+                    originPriority?.ToString( ) ?? "", (long)ttl.TotalSeconds,
+                    DateTimeOffset.UtcNow.Subtract( s_finalizerLease ).ToUnixTimeMilliseconds( ), sagaId] );
+            if (string.Equals( replacement.ToString( ), replacementToken, StringComparison.Ordinal )) {
+                QueueMetrics.RecordSagaLifecycleOutcome( "stale_saga_replaced" );
             }
 
             LookupSagaState? existingState = await GetAsync( sagaId, cancellationToken );
@@ -161,45 +219,20 @@ public sealed partial class RedisSagaStateManager(
         }
 
         // Create new saga. finalResultUri is intentionally not pre-populated so the
-        // When.NotExists guard in SetFinalResultUriAsync can enforce first-writer-wins.
-        List<HashEntry> sagaHashEntries = [
-            new HashEntry( FieldLookupKey, lookupKey ),
-            new HashEntry( FieldLookupType, lookupType.ToString() ),
-            new HashEntry( FieldLookupValue, lookupValue ),
-            new HashEntry( FieldCreatedAt, DateTimeOffset.UtcNow.ToString( "O" ) ),
-            new HashEntry( FieldPartialResultUri, RedisValue.EmptyString ),
-        ];
-
-        if (originPriority.HasValue) {
-            sagaHashEntries.Add( new HashEntry( FieldOriginPriority, originPriority.Value.ToString( ) ) );
-        }
-
-        await db.HashSetAsync( key, [.. sagaHashEntries] );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        // Add to pending index for efficient polling
-        await AddToPendingIndexAsync( sagaId, cancellationToken );
-
+        // final URI compare-and-set can enforce first-writer-wins.
+        // CreateSagaScript returned "already exists" or created a hash that became unreadable
+        // before the hot read. Either way, retrying the same deterministic delivery cannot
+        // repair the persisted state and would pin the provider's PEL forever.
+        LookupSagaState? createdState = await GetAsync( sagaId, cancellationToken ) ?? throw new UnreadableSagaStateException( sagaId );
         LogSagaCreated( _logger, sagaId, lookupType, lookupValue );
-
-        return new LookupSagaState {
-            SagaId = sagaId,
-            LookupKey = lookupKey,
-            LookupType = lookupType,
-            LookupValue = lookupValue,
-            CreatedAt = DateTimeOffset.UtcNow,
-            ProviderStates = [],
-            PartialResultUri = null,
-            FinalResultUri = null,
-            OriginPriority = originPriority ?? QueuePriority.Background
-        };
+        return createdState;
     }
 
     /// <summary>
     /// Reads a saga's full state, including each provider's progress.
     /// </summary>
     /// <param name="sagaId">The saga id to read.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>
     /// The reconstructed <see cref="LookupSagaState"/>, or null if the saga hash is absent or its
     /// required core fields are missing or invalid.
@@ -232,12 +265,12 @@ public sealed partial class RedisSagaStateManager(
             !fields.TryGetValue( FieldLookupType, out string? lookupTypeStr ) ||
             !fields.TryGetValue( FieldLookupValue, out string? lookupValue )) {
             LogIncompleteCoreState( _logger, sagaId );
-            return null;
+            throw new UnreadableSagaStateException( sagaId );
         }
 
         if (!Enum.TryParse<LookupRequestType>( lookupTypeStr, out LookupRequestType lookupType )) {
             LogInvalidLookupType( _logger, sagaId, lookupTypeStr );
-            return null;
+            throw new UnreadableSagaStateException( sagaId );
         }
 
         _ = fields.TryGetValue( FieldCreatedAt, out string? createdAtStr );
@@ -248,10 +281,22 @@ public sealed partial class RedisSagaStateManager(
         _ = fields.TryGetValue( FieldRateLimitInfo, out string? rateLimitInfoJson );
         _ = fields.TryGetValue( FieldOriginPriority, out string? originPriorityStr );
         _ = fields.TryGetValue( FieldWriteGeneration, out string? writeGenerationStr );
+        if (!fields.TryGetValue( FieldInstanceToken, out string? instanceToken )
+            || string.IsNullOrWhiteSpace( instanceToken )) {
+            LogIncompleteCoreState( _logger, sagaId );
+            throw new UnreadableSagaStateException( sagaId );
+        }
 
-        DateTimeOffset createdAt = !string.IsNullOrEmpty( createdAtStr )
-            ? DateTimeOffset.Parse( createdAtStr )
-            : DateTimeOffset.UtcNow;
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        if (!string.IsNullOrEmpty( createdAtStr )
+            && !DateTimeOffset.TryParse(
+                createdAtStr,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out createdAt )) {
+            LogIncompleteCoreState( _logger, sagaId );
+            throw new UnreadableSagaStateException( sagaId );
+        }
 
         _ = bool.TryParse( isPartialStr, out bool isPartial );
 
@@ -279,6 +324,7 @@ public sealed partial class RedisSagaStateManager(
         Dictionary<SupportedProviders, ProviderLookupState> providerStates = await LoadProviderStatesAsync( db, sagaId );
 
         return new LookupSagaState {
+            InstanceToken = instanceToken,
             SagaId = sagaId,
             LookupKey = lookupKey,
             LookupType = lookupType,
@@ -295,296 +341,198 @@ public sealed partial class RedisSagaStateManager(
         };
     }
 
-    /// <summary>
-    /// Writes one provider's progress into its provider hash and refreshes both the provider and
-    /// saga TTLs.
-    /// </summary>
-    /// <param name="sagaId">The saga the provider belongs to.</param>
-    /// <param name="state">The provider state to persist.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the provider hash is written.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="state"/> is null.</exception>
-    public async Task UpdateProviderStateAsync(
-        string sagaId,
-        ProviderLookupState state,
-        CancellationToken cancellationToken = default
-    ) {
+    /// <inheritdoc/>
+    public async Task<bool> TryUpdateProviderStateAsync( string sagaId, ProviderLookupState state, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
         ArgumentNullException.ThrowIfNull( state );
-
-        string key = GetProviderKey( sagaId, state.Provider );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        HashEntry[] providerHash = [
-            new HashEntry( FieldIsComplete, state.IsComplete.ToString() ),
-            new HashEntry( FieldIsSuccess, state.IsSuccess.ToString() ),
-            new HashEntry( FieldResultJson, state.ResultJson ?? string.Empty ),
-            new HashEntry( FieldCompletedAt, state.CompletedAt?.ToString( "O" ) ?? string.Empty ),
-            new HashEntry( FieldErrorMessage, state.ErrorMessage ?? string.Empty )
-        ];
-
-        await db.HashSetAsync( key, providerHash );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        // Also extend the main saga key TTL
-        _ = await db.KeyExpireAsync( GetSagaKey( sagaId ), ttl );
-
-        LogProviderStateUpdated( _logger, sagaId, state.Provider, state.IsComplete, state.IsSuccess );
+        long ttl = (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds;
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedProviderUpdateScript,
+            [GetSagaKey( sagaId ), GetProviderKey( sagaId, state.Provider )],
+            [FieldInstanceToken, expectedInstanceToken, state.IsComplete.ToString( ), state.IsSuccess.ToString( ), state.ResultJson ?? "", state.CompletedAt?.ToString( "O" ) ?? "", state.ErrorMessage ?? "", ttl] );
+        return (int)result == 1;
     }
 
-    /// <summary>
-    /// Stores the URI of a partial result written while the saga awaits remaining providers.
-    /// </summary>
-    /// <param name="sagaId">The saga to update.</param>
-    /// <param name="uri">The partial-result URI.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the field is written and the TTL refreshed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> or <paramref name="uri"/> is null or whitespace.</exception>
-    public async Task SetPartialResultUriAsync(
+    /// <summary>Stores a partial URI only when the saga instance token still matches.</summary>
+    public async Task<bool> TrySetPartialResultUriAsync( string sagaId, string uri, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( uri );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedUriScript,
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldPartialResultUri, uri,
+                (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds] );
+        return (int)result == 1;
+    }
+
+    /// <summary>Stores a final URI only when the saga instance token still matches.</summary>
+    public async Task<SagaFinalResultWriteOutcome> TrySetFinalResultUriAsync(
         string sagaId,
         string uri,
+        string expectedInstanceToken,
         CancellationToken cancellationToken = default
     ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
         ArgumentException.ThrowIfNullOrWhiteSpace( uri );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        _ = await db.HashSetAsync( key, FieldPartialResultUri, uri );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogPartialResultUriSet( _logger, sagaId, uri );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedFinalUriScript,
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldFinalResultUri, uri, FieldIsPartial,
+                (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds] );
+        SagaFinalResultWriteOutcome outcome = (SagaFinalResultWriteOutcome)(int)result;
+        if (outcome is SagaFinalResultWriteOutcome.Stored or SagaFinalResultWriteOutcome.Idempotent) {
+            LogFinalResultUriSet( _logger, sagaId, uri );
+        }
+        return outcome;
     }
 
-    /// <summary>
-    /// Stores the URI of the final result and removes the saga from the pending index.
-    /// </summary>
-    /// <param name="sagaId">The saga to finalize.</param>
-    /// <param name="uri">The final-result URI (a PDS record URI).</param>
-    /// <param name="cancellationToken">Token forwarded to the pending-index removal.</param>
-    /// <returns>A task that completes once the field is written and the saga de-indexed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> or <paramref name="uri"/> is null or whitespace.</exception>
-    public async Task SetFinalResultUriAsync(
+    /// <summary>Deletes a saga only when its instance token still matches.</summary>
+    public async Task<bool> TryDeleteAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        RedisKey[] keys = [GetSagaKey( sagaId ), .. Enum.GetValues<SupportedProviders>( ).Select( provider => (RedisKey)GetProviderKey( sagaId, provider ) ), PendingSagaSetKey];
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedDeleteScript,
+            keys,
+            [FieldInstanceToken, expectedInstanceToken, sagaId] );
+        return (int)result == 1;
+    }
+
+    /// <summary>Sets partial state only when the saga instance token still matches.</summary>
+    public async Task<bool> TrySetIsPartialAsync( string sagaId, bool isPartial, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedUriScript,
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldIsPartial, isPartial.ToString( ),
+                (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds] );
+        return (int)result == 1;
+    }
+
+    /// <summary>Sets the initial provider only while the saga instance token still owns the hash.</summary>
+    public async Task<bool> TrySetInitialProviderAsync(
         string sagaId,
-        string uri,
+        SupportedProviders provider,
+        string expectedInstanceToken,
         CancellationToken cancellationToken = default
     ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-        ArgumentException.ThrowIfNullOrWhiteSpace( uri );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        _ = await db.HashSetAsync( key, FieldFinalResultUri, uri, When.NotExists );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        // Remove from pending index since saga is now finalized
-        await RemoveFromPendingIndexAsync( sagaId, cancellationToken );
-
-        LogFinalResultUriSet( _logger, sagaId, uri );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        long ttlSeconds = (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds;
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedInitialProviderScript,
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldInitialProvider, provider.ToString( ), ttlSeconds] );
+        return (int)result == 1;
     }
 
-    /// <summary>
-    /// Deletes a saga: removes it from the pending index, deletes its core hash, and deletes every
-    /// provider hash.
-    /// </summary>
-    /// <param name="sagaId">The saga to delete.</param>
-    /// <param name="cancellationToken">Token forwarded to the pending-index removal.</param>
-    /// <returns>True if the core saga hash existed and was deleted; otherwise false.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task<bool> DeleteAsync( string sagaId, CancellationToken cancellationToken = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-
-        IDatabase db = _redis.GetDatabase( );
-
-        // Remove from pending index
-        await RemoveFromPendingIndexAsync( sagaId, cancellationToken );
-
-        // Delete main saga key
-        string sagaKey = GetSagaKey( sagaId );
-        bool sagaDeleted = await db.KeyDeleteAsync( sagaKey );
-
-        // Delete all provider state keys
-        foreach (SupportedProviders provider in Enum.GetValues<SupportedProviders>( )) {
-            string providerKey = GetProviderKey( sagaId, provider );
-            _ = await db.KeyDeleteAsync( providerKey );
-        }
-
-        if (sagaDeleted) {
-            LogSagaDeleted( _logger, sagaId );
-        }
-
-        return sagaDeleted;
-    }
-
-    /// <summary>
-    /// Sets the saga's partial-result flag.
-    /// </summary>
-    /// <param name="sagaId">The saga to update.</param>
-    /// <param name="isPartial">Whether the current result is partial.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the field is written and the TTL refreshed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task SetIsPartialAsync( string sagaId, bool isPartial, CancellationToken cancellationToken = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        _ = await db.HashSetAsync( key, FieldIsPartial, isPartial.ToString( ) );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogIsPartialSet( _logger, isPartial, sagaId );
-    }
-
-    /// <summary>
-    /// Records which provider first resolved the lookup.
-    /// </summary>
-    /// <param name="sagaId">The saga to update.</param>
-    /// <param name="provider">The initial provider.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the field is written and the TTL refreshed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task SetInitialProviderAsync( string sagaId, SupportedProviders provider, CancellationToken cancellationToken = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        _ = await db.HashSetAsync( key, FieldInitialProvider, provider.ToString( ) );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogInitialProviderSet( _logger, provider, sagaId );
-    }
-
-    /// <summary>
-    /// Stores the saga's per-provider rate-limit information as JSON.
-    /// </summary>
-    /// <param name="sagaId">The saga to update.</param>
-    /// <param name="rateLimitInfo">The rate-limit entries to persist.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the field is written and the TTL refreshed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rateLimitInfo"/> is null.</exception>
-    public async Task SetRateLimitInfoAsync( string sagaId, List<ProviderRateLimitInfo> rateLimitInfo, CancellationToken cancellationToken = default ) {
+    /// <summary>Stores rate-limit information only when the saga instance token still matches.</summary>
+    public async Task<bool> TrySetRateLimitInfoAsync( string sagaId, List<ProviderRateLimitInfo> rateLimitInfo, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
         ArgumentNullException.ThrowIfNull( rateLimitInfo );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
         string json = System.Text.Json.JsonSerializer.Serialize( rateLimitInfo );
-        _ = await db.HashSetAsync( key, FieldRateLimitInfo, json );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogRateLimitInfoSet( _logger, sagaId, rateLimitInfo.Count );
+        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; redis.call('hset', KEYS[1], ARGV[3], ARGV[4]); redis.call('expire', KEYS[1], ARGV[5]); return 1",
+            [GetSagaKey( sagaId )], [FieldInstanceToken, expectedInstanceToken, FieldRateLimitInfo, json, (long)ttl.TotalSeconds] );
+        bool updated = (int)result == 1;
+        if (updated) LogRateLimitInfoSet( _logger, sagaId, rateLimitInfo.Count );
+        return updated;
     }
 
-    /// <summary>
-    /// Atomically claims the right to queue secondary lookups for a saga, so only one concurrent
-    /// handler fans them out.
-    /// </summary>
-    /// <param name="sagaId">The saga to mark.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>True if this caller set the marker (and should queue secondaries); false if another caller already did.</returns>
-    /// <remarks>Uses a hash set with "when not exists" semantics (HSETNX) so exactly one caller wins.</remarks>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, CancellationToken cancellationToken = default ) {
+    /// <summary>Marks secondary fan-out only when the saga instance token still matches.</summary>
+    public async Task<bool> TryMarkSecondariesQueuedAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        long ttlSeconds = (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds;
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+            "if redis.call('hexists', KEYS[1], ARGV[3]) == 1 then return 0 end; " +
+            "redis.call('hset', KEYS[1], ARGV[3], 'True'); redis.call('expire', KEYS[1], tonumber(ARGV[4])); return 1",
+            [GetSagaKey( sagaId )], [FieldInstanceToken, expectedInstanceToken, FieldSecondariesQueued, ttlSeconds] );
+        return (int)result == 1;
+    }
 
+    /// <inheritdoc/>
+    public async Task<bool> TryPromoteToInteractiveAsync(
+        string sagaId,
+        string expectedInstanceToken,
+        CancellationToken cancellationToken = default
+    ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            "if redis.call('exists', KEYS[1]) == 0 or redis.call('hget', KEYS[1], ARGV[1]) ~= ARGV[2] then return 0 end; " +
+            "if redis.call('hget', KEYS[1], ARGV[3]) == ARGV[4] then return 0 end; " +
+            "redis.call('hset', KEYS[1], ARGV[3], ARGV[4]); redis.call('expire', KEYS[1], ARGV[5]); return 1",
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldOriginPriority,
+                QueuePriority.Interactive.ToString( ),
+                (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds] );
+        return (int)result == 1;
+    }
+
+    /// <summary>Claims finalization against an expected saga instance token.</summary>
+    public async Task<bool> TryClaimFinalizeAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        return await TryClaimFinalizeCoreAsync( sagaId, expectedInstanceToken, cancellationToken );
+    }
+
+    private async Task<bool> TryClaimFinalizeCoreAsync( string sagaId, RedisValue token, CancellationToken cancellationToken ) {
+        cancellationToken.ThrowIfCancellationRequested( );
         string key = GetSagaKey( sagaId );
         IDatabase db = _redis.GetDatabase( );
         TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        // HSETNX: only the first caller creates the field, making the
-        // queue-secondaries decision atomic across racing coordinator handlers.
-        bool acquired = await db.HashSetAsync( key, FieldSecondariesQueued, true.ToString( ), When.NotExists );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogSecondariesQueuedMarker( _logger, sagaId, acquired );
-
-        return acquired;
-    }
-
-    /// <summary>
-    /// Atomically claims the exclusive right to finalize a saga, so exactly one concurrent
-    /// trigger performs the PDS write.
-    /// </summary>
-    /// <param name="sagaId">The saga to claim finalization for.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>True if this caller won the claim (and must finalize); false if another caller already holds it.</returns>
-    /// <remarks>Uses a hash set with "when not exists" semantics (HSETNX) so exactly one caller wins.</remarks>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task<bool> TryClaimFinalizeAsync( string sagaId, CancellationToken cancellationToken = default ) {
-        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        bool acquired = await db.HashSetAsync( key, FieldFinalizeClaimed, true.ToString( ), When.NotExists );
-        _ = await db.KeyExpireAsync( key, ttl );
+        RedisResult claimResult = await db.ScriptEvaluateAsync(
+            "if redis.call('exists', KEYS[1]) == 0 then return 0 end; " +
+            "local current = redis.call('hget', KEYS[1], ARGV[1]); if not current or current == '' or current ~= ARGV[2] then return 0 end; " +
+            "if redis.call('hexists', KEYS[1], ARGV[3]) == 1 then return 0 end; " +
+            "redis.call('hset', KEYS[1], ARGV[3], 'True'); redis.call('hset', KEYS[1], ARGV[4], ARGV[5]); " +
+            "redis.call('expire', KEYS[1], ARGV[6]); return 1",
+            [key], [FieldInstanceToken, token, FieldFinalizeClaimed, FieldFinalizeClaimedAt,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), (long)ttl.TotalSeconds]);
+        bool acquired = (int)claimResult == 1;
 
         LogFinalizeClaimMarker( _logger, sagaId, acquired );
 
         return acquired;
     }
 
-    /// <summary>
-    /// Releases a finalize claim so a legitimate retry can re-finalize after a failed PDS write.
-    /// Must only be called on the failure path; successful finalizations leave the claim set until TTL expiry.
-    /// </summary>
-    /// <param name="sagaId">The saga whose finalize claim should be released.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once the claim field has been deleted.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    public async Task ReleaseFinalizeClaimAsync( string sagaId, CancellationToken cancellationToken = default ) {
+    /// <summary>Releases finalization only when the saga instance token still matches.</summary>
+    public async Task<bool> TryReleaseFinalizeClaimAsync( string sagaId, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-
-        string key = GetSagaKey( sagaId );
-        IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        _ = await db.HashDeleteAsync( key, FieldFinalizeClaimed );
-        _ = await db.KeyExpireAsync( key, ttl );
-
-        LogFinalizeClaimReleased( _logger, sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        long ttlSeconds = (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds;
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            TokenGuardedReleaseScript,
+            [GetSagaKey( sagaId )],
+            [FieldInstanceToken, expectedInstanceToken, FieldFinalizeClaimed, FieldFinalizeClaimedAt, ttlSeconds] );
+        return (int)result == 1;
     }
 
-    /// <summary>
-    /// Atomically advances the write generation to <paramref name="generation"/> only when the
-    /// stored generation is strictly less than <paramref name="generation"/>, using a Lua
-    /// compare-and-set so the advancement is exactly one winner per generation level even under
-    /// concurrent callers. Refreshes the saga TTL after a successful advance.
-    /// </summary>
-    /// <param name="sagaId">The saga to advance.</param>
-    /// <param name="generation">The generation to advance to.</param>
-    /// <param name="ct">A cancellation token (not currently observed).</param>
-    /// <returns>
-    /// <see langword="true"/> when this caller advanced the generation (and must perform the PDS
-    /// write); <see langword="false"/> when the stored generation was already at or above
-    /// <paramref name="generation"/> and the write should be skipped.
-    /// </returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, CancellationToken ct = default ) {
-    ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-    ArgumentOutOfRangeException.ThrowIfLessThan( generation, 1 );
+    /// <summary>Advances write generation against an expected saga instance token.</summary>
+    public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int generation, string expectedInstanceToken, CancellationToken cancellationToken = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        ArgumentOutOfRangeException.ThrowIfLessThan( generation, 1 );
+        return await TryAdvanceWriteGenerationCoreAsync( sagaId, generation, expectedInstanceToken, cancellationToken );
+    }
 
-    string key = GetSagaKey( sagaId );
-    IDatabase db = _redis.GetDatabase( );
-    TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
+    private async Task<bool> TryAdvanceWriteGenerationCoreAsync( string sagaId, int generation, RedisValue token, CancellationToken ct ) {
+        ct.ThrowIfCancellationRequested( );
+        string key = GetSagaKey(sagaId);
+        IDatabase db = _redis.GetDatabase( );
+        TimeSpan ttl = TimeSpan.FromMinutes(_settings.JobExpirationMinutes);
         RedisResult result = await db.ScriptEvaluateAsync(
             AdvanceWriteGenerationScript,
             keys: [key],
-            values: [FieldWriteGeneration, generation]
+            values: [FieldWriteGeneration, generation, FieldInstanceToken, token]
         );
 
         bool advanced = (int)result == 1;
@@ -603,112 +551,48 @@ public async Task<bool> TryAdvanceWriteGenerationAsync( string sagaId, int gener
     /// already at or above the requested generation.
     /// </summary>
     private const string AdvanceWriteGenerationScript =
+        "if redis.call('exists', KEYS[1]) == 0 then return 0 end; " +
+        "local token = redis.call('hget', KEYS[1], ARGV[3]); if not token or token == '' or token ~= ARGV[4] then return 0 end; " +
         "local cur = tonumber(redis.call('hget', KEYS[1], ARGV[1]) or '0'); " +
         "if cur < tonumber(ARGV[2]) then redis.call('hset', KEYS[1], ARGV[1], ARGV[2]); return 1 " +
         "else return 0 end";
 
-    /// <summary>
-    /// Lua script that resets the write-generation field from <c>ARGV[2]</c> back to <c>ARGV[3]</c>
-    /// only when the stored value still equals <c>ARGV[2]</c> (the value this caller advanced to).
-    /// Returns 1 when the reset took effect, 0 when a concurrent handler has already advanced
-    /// beyond the caller's generation and the reset is skipped to avoid clobbering a later write.
-    /// </summary>
-    private const string ResetWriteGenerationScript =
-        "local cur = tonumber(redis.call('hget', KEYS[1], ARGV[1]) or '0'); " +
-        "if cur == tonumber(ARGV[2]) then redis.call('hset', KEYS[1], ARGV[1], ARGV[3]); return 1 " +
-        "else return 0 end";
-
-    /// <summary>
-    /// Conditionally resets the write generation from <paramref name="advancedTo"/> back to
-    /// <paramref name="priorGeneration"/> after a non-terminal pre-durability PDS write failure,
-    /// so the next retry can re-advance and re-write. The reset only takes effect when the stored
-    /// generation still equals <paramref name="advancedTo"/>; if a concurrent handler has already
-    /// advanced the generation further, the stored value is left untouched. Refreshes the TTL on
-    /// a successful reset.
-    /// </summary>
-    /// <param name="sagaId">The saga whose write generation should be reset.</param>
-    /// <param name="advancedTo">The generation this caller advanced to; the stored value must equal this for the reset to take effect.</param>
-    /// <param name="priorGeneration">The generation to restore; typically <c>advancedTo - 1</c>.</param>
-    /// <param name="ct">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes when the conditional reset attempt has been made and the TTL optionally refreshed.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, CancellationToken ct = default ) {
-    ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
-    ArgumentOutOfRangeException.ThrowIfLessThan( advancedTo, 1 );
-    ArgumentOutOfRangeException.ThrowIfLessThan( priorGeneration, 0 );
-    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual( priorGeneration, advancedTo );
-
-    string key = GetSagaKey( sagaId );
-    IDatabase db = _redis.GetDatabase( );
-    TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-        RedisResult result = await db.ScriptEvaluateAsync(
-            ResetWriteGenerationScript,
-            keys: [key],
-            values: [FieldWriteGeneration, advancedTo, priorGeneration]
-        );
-
-        bool reset = (int)result == 1;
-
-        if (reset) {
-            _ = await db.KeyExpireAsync( key, ttl );
-        }
-
-        LogWriteGenerationReset( _logger, sagaId, advancedTo, priorGeneration, reset );
+    /// <summary>Resets write generation only when the saga instance token still matches.</summary>
+    public async Task<bool> TryResetWriteGenerationAsync( string sagaId, int advancedTo, int priorGeneration, string expectedInstanceToken, CancellationToken ct = default ) {
+        ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
+        ArgumentOutOfRangeException.ThrowIfLessThan( advancedTo, 1 );
+        ArgumentOutOfRangeException.ThrowIfLessThan( priorGeneration, 0 );
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+        TokenGuardedResetScript,
+        [GetSagaKey( sagaId )],
+        [FieldWriteGeneration, advancedTo, priorGeneration, FieldInstanceToken, expectedInstanceToken,
+            (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds] );
+        return (int)result == 1;
     }
 
-    /// <summary>
-    /// Initializes each provider's state hash to a not-complete, not-success baseline without
-    /// clobbering any state already in flight.
-    /// </summary>
-    /// <param name="sagaId">The saga whose providers are being initialized.</param>
-    /// <param name="providers">The providers to initialize.</param>
-    /// <param name="cancellationToken">A cancellation token (not currently observed).</param>
-    /// <returns>A task that completes once all providers are initialized.</returns>
-    /// <remarks>
-    /// Each provider hash is written inside a transaction guarded by a key-not-exists condition, so
-    /// a re-initialization never overwrites a provider that already has progress; for those, only
-    /// the TTL is refreshed.
-    /// </remarks>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="sagaId"/> is null or whitespace.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="providers"/> is null.</exception>
-    public async Task InitializeProviderStatesAsync( string sagaId, IEnumerable<SupportedProviders> providers, CancellationToken cancellationToken = default ) {
+    /// <inheritdoc/>
+    public async Task<bool> TryInitializeProviderStatesAsync(
+        string sagaId,
+        IEnumerable<SupportedProviders> providers,
+        string expectedInstanceToken,
+        CancellationToken cancellationToken = default
+    ) {
         ArgumentException.ThrowIfNullOrWhiteSpace( sagaId );
+        ArgumentException.ThrowIfNullOrWhiteSpace( expectedInstanceToken );
         ArgumentNullException.ThrowIfNull( providers );
-
         IDatabase db = _redis.GetDatabase( );
-        TimeSpan ttl = TimeSpan.FromMinutes( _settings.JobExpirationMinutes );
-
-        foreach (SupportedProviders provider in providers) {
-            string key = GetProviderKey( sagaId, provider );
-
-            // Idempotent: never overwrite existing provider state. A resumed saga may
-            // already have completed or in-progress providers that must be preserved.
-            // The KeyNotExists condition makes the pending-state write commit atomically
-            // only when no state exists yet, so a concurrent UpdateProviderStateAsync
-            // cannot be regressed back to pending.
-            HashEntry[] providerHash = [
-                new HashEntry( FieldIsComplete, false.ToString() ),
-                new HashEntry( FieldIsSuccess, false.ToString() ),
-                new HashEntry( FieldResultJson, string.Empty ),
-                new HashEntry( FieldCompletedAt, string.Empty ),
-                new HashEntry( FieldErrorMessage, string.Empty )
-            ];
-
-            ITransaction transaction = db.CreateTransaction( );
-            _ = transaction.AddCondition( Condition.KeyNotExists( key ) );
-            _ = transaction.HashSetAsync( key, providerHash );
-            _ = transaction.KeyExpireAsync( key, ttl );
-
-            if (!await transaction.ExecuteAsync( )) {
-                // Provider state already exists — leave it untouched and refresh the TTL.
-                _ = await db.KeyExpireAsync( key, ttl );
+        long ttlSeconds = (long)TimeSpan.FromMinutes( _settings.JobExpirationMinutes ).TotalSeconds;
+        foreach (SupportedProviders provider in providers.Distinct( )) {
+            RedisResult result = await db.ScriptEvaluateAsync(
+                TokenGuardedProviderInitScript,
+                [GetSagaKey( sagaId ), GetProviderKey( sagaId, provider )],
+                [FieldInstanceToken, expectedInstanceToken, ttlSeconds] );
+            if ((int)result != 1) {
+                return false;
             }
         }
-
-        if (_logger.IsEnabled( LogLevel.Debug )) {
-            int providerCount = providers.Count( );
-            LogProviderStatesInitialized( _logger, sagaId, providerCount );
-        }
+        return true;
     }
 
     /// <summary>
@@ -743,9 +627,17 @@ public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int 
             string? completedAtStr = fields.GetValueOrDefault( FieldCompletedAt );
             string? errorMessage = fields.GetValueOrDefault( FieldErrorMessage );
 
-            DateTimeOffset? completedAt = !string.IsNullOrEmpty( completedAtStr )
-                ? DateTimeOffset.Parse( completedAtStr )
-                : null;
+            DateTimeOffset? completedAt = null;
+            if (!string.IsNullOrEmpty( completedAtStr )) {
+                if (!DateTimeOffset.TryParse(
+                    completedAtStr,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out DateTimeOffset parsedCompletedAt )) {
+                    throw new UnreadableSagaStateException( sagaId );
+                }
+                completedAt = parsedCompletedAt;
+            }
 
             states[provider] = new ProviderLookupState(
                 Provider: provider,
@@ -771,9 +663,10 @@ public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int 
     /// <remarks>
     /// This is the coordinator's safety net for completion events dropped by Redis Pub/Sub (which is
     /// at-most-once). Index entries whose saga hash no longer exists, and entries that are already
-    /// finalized, are removed from the index during the sweep (self-healing).
+    /// no longer exist are removed during the sweep. Finalized sagas remain indexed until durable
+    /// waiter notification succeeds, so that post-durability recovery is independently retryable.
     /// </remarks>
-    public async Task<IReadOnlyList<LookupSagaState>> GetCompletedButUnfinalizedAsync(
+    public async Task<IReadOnlyList<LookupSagaState>> GetPendingReconciliationAsync(
         TimeSpan minimumAge,
         int limit = 100,
         CancellationToken cancellationToken = default
@@ -791,7 +684,16 @@ public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int 
             }
 
             string sagaId = sagaIdValue.ToString( );
-            LookupSagaState? saga = await GetAsync( sagaId, cancellationToken );
+            LookupSagaState? saga;
+            try {
+                saga = await GetAsync( sagaId, cancellationToken );
+            } catch (UnreadableSagaStateException) {
+                // A poison hash cannot be reconciled, but it must not abort the remainder of the
+                // safety-net sweep. GetAsync already logs the malformed state; remove only the
+                // index membership so healthy sagas continue to make progress.
+                _ = await db.SetRemoveAsync( PendingSagaSetKey, sagaId );
+                continue;
+            }
 
             if (saga is null) {
                 // Saga expired or was deleted - clean up the index
@@ -799,10 +701,13 @@ public async Task ResetWriteGenerationAsync( string sagaId, int advancedTo, int 
                 continue;
             }
 
-            // Skip if already finalized
+            // A finalized saga intentionally remains indexed until its deduplication completion
+            // notification has been published. Returning it lets the coordinator retry that
+            // independently idempotent post-durability step after a crash or Redis interruption.
             if (!string.IsNullOrEmpty( saga.FinalResultUri )) {
-                // Already finalized - remove from pending index
-                _ = await db.SetRemoveAsync( PendingSagaSetKey, sagaId );
+                if (saga.CreatedAt <= cutoff) {
+                    result.Add( saga );
+                }
                 continue;
             }
 

--- a/src/BridgeBeats.Core/Infrastructure/Queue/SpotifyBulkQueueDecorator.cs
+++ b/src/BridgeBeats.Core/Infrastructure/Queue/SpotifyBulkQueueDecorator.cs
@@ -24,7 +24,14 @@ namespace BridgeBeats.Core.Infrastructure.Queue;
 /// Interactive-priority requests and every other lookup type pass straight through to the inner
 /// queue, and all queue operations other than enqueue delegate to the inner queue unchanged.
 /// </remarks>
-public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLookupRequest> {
+public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLookupRequest>, IConsumerGroupAssurance, IQueueDeliveryTracker, IQueueWorkSignal {
+
+    private const string EnqueueBulkDeliveryScript = """
+        local messageId = redis.call(
+            'XADD', KEYS[1], '*', ARGV[1], ARGV[2], ARGV[3], ARGV[4])
+        redis.call('PUBLISH', ARGV[5], messageId)
+        return messageId
+        """;
 
     /// <summary>The wrapped queue that handles normal (non-bulk-routed) operations.</summary>
     private readonly IRequestQueue<QueuedLookupRequest> _inner;
@@ -34,6 +41,9 @@ public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLook
 
     /// <summary>Logger for bulk-routing diagnostics.</summary>
     private readonly ILogger<SpotifyBulkQueueDecorator> _logger;
+    private readonly string _bulkTrackStream;
+    private readonly string _bulkAlbumStream;
+    private readonly string _bulkWorkSignalChannel;
 
     /// <summary>Camel-case, non-indented options used to serialize the request payload.</summary>
     private readonly JsonSerializerOptions _jsonOptions;
@@ -45,15 +55,20 @@ public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLook
     /// <param name="inner">The underlying Spotify request queue, which handles non-bulk operations.</param>
     /// <param name="redis">The Redis connection multiplexer, used to write bulk-stream entries.</param>
     /// <param name="logger">Logger for bulk-routing diagnostics.</param>
+    /// <param name="keyPrefix">Optional isolated queue-key prefix shared with the bulk consumer.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
     public SpotifyBulkQueueDecorator(
         IRequestQueue<QueuedLookupRequest> inner,
         IConnectionMultiplexer redis,
-        ILogger<SpotifyBulkQueueDecorator> logger
+        ILogger<SpotifyBulkQueueDecorator> logger,
+        string? keyPrefix = null
     ) {
         _inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
         _redis = redis ?? throw new ArgumentNullException( nameof( redis ) );
         _logger = logger ?? throw new ArgumentNullException( nameof( logger ) );
+        _bulkTrackStream = QueueStreamKeys.SpotifyBulkFor( isTrack: true, keyPrefix );
+        _bulkAlbumStream = QueueStreamKeys.SpotifyBulkFor( isTrack: false, keyPrefix );
+        _bulkWorkSignalChannel = QueueStreamKeys.SpotifyBulkWorkSignal( keyPrefix );
 
         _jsonOptions = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -86,11 +101,12 @@ public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLook
         CancellationToken cancellationToken = default
     ) {
         if (request.LookupType is LookupRequestType.SongIdLookup or LookupRequestType.AlbumIdLookup
-            && priority != QueuePriority.Interactive) {
+            && priority != QueuePriority.Interactive
+            && !request.BypassBulkRouting) {
 
             string stream = request.LookupType == LookupRequestType.SongIdLookup
-                ? SpotifyConstants.BulkTrackIdStream
-                : SpotifyConstants.BulkAlbumIdStream;
+                ? _bulkTrackStream
+                : _bulkAlbumStream;
 
             string payload = JsonSerializer.Serialize( request, _jsonOptions );
 
@@ -100,11 +116,24 @@ public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLook
                 new NameValueEntry( QueueFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
             ];
 
-            _ = await db.StreamAddAsync( stream, fields );
+            RedisResult enqueueResult = await db.ScriptEvaluateAsync(
+                EnqueueBulkDeliveryScript,
+                [stream],
+                [
+                    QueueFieldNames.Payload,
+                    fields[0].Value,
+                    QueueFieldNames.EnqueuedAt,
+                    fields[1].Value,
+                    _bulkWorkSignalChannel
+                ] );
+            RedisValue messageId = (RedisValue)enqueueResult;
+            if (!messageId.HasValue) {
+                throw new InvalidOperationException( $"Redis did not return a message id for enqueue to '{stream}'." );
+            }
 
             // Record enqueue metric with QueuePriority.Bulk so dashboards can distinguish
             // bulk-stream enqueues from generic interactive/background ones.
-            QueueMetrics.RecordEnqueue( SupportedProviders.Spotify, QueuePriority.Bulk );
+            QueueMetrics.RecordEnqueue( SupportedProviders.Spotify, QueuePriority.Bulk, request.EnqueueOrigin );
 
             LogRoutedToBulkStream( _logger, request.LookupType, request.SagaId, stream );
 
@@ -179,6 +208,46 @@ public sealed partial class SpotifyBulkQueueDecorator : IRequestQueue<QueuedLook
     /// <returns>True if a message was deleted; otherwise false.</returns>
     public Task<bool> DeleteFromDlqAsync( string messageId, CancellationToken cancellationToken = default )
         => _inner.DeleteFromDlqAsync( messageId, cancellationToken );
+
+    /// <inheritdoc/>
+    public void ReleaseDelivery( string messageId ) {
+        if (_inner is IQueueDeliveryTracker tracker) tracker.ReleaseDelivery( messageId );
+    }
+
+    /// <inheritdoc/>
+    public Task InitializeWorkSignalAsync( CancellationToken cancellationToken = default ) =>
+        _inner is IQueueWorkSignal signal ? signal.InitializeWorkSignalAsync( cancellationToken ) : Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public long CaptureWorkVersion( ) =>
+        _inner is IQueueWorkSignal signal ? signal.CaptureWorkVersion( ) : 0;
+
+    /// <inheritdoc/>
+    public Task WaitForWorkAsync(
+        long observedVersion,
+        DateTimeOffset? scheduledWake,
+        CancellationToken cancellationToken = default
+    ) => _inner is IQueueWorkSignal signal
+        ? signal.WaitForWorkAsync( observedVersion, scheduledWake, cancellationToken )
+        : Task.CompletedTask;
+
+    /// <summary>Repairs the generic queue groups and both bulk-stream groups.</summary>
+    public async Task EnsureConsumerGroupsAsync( CancellationToken cancellationToken = default ) {
+        if (_inner is IConsumerGroupAssurance innerAssurance) {
+            await innerAssurance.EnsureConsumerGroupsAsync( cancellationToken );
+        }
+
+        IDatabase db = _redis.GetDatabase( );
+        foreach (string stream in new[] { _bulkTrackStream, _bulkAlbumStream }) {
+            cancellationToken.ThrowIfCancellationRequested( );
+            try {
+                _ = await db.StreamCreateConsumerGroupAsync(
+                    stream, SpotifyConstants.ConsumerGroup, StreamPosition.Beginning, createStream: true );
+            } catch (RedisServerException ex) when (ex.Message.Contains( "BUSYGROUP", StringComparison.OrdinalIgnoreCase )) {
+                // Idempotent repair: the required group already exists.
+            }
+        }
+    }
 
     #region LoggerMessage Methods
 

--- a/src/BridgeBeats.Core/packages.lock.json
+++ b/src/BridgeBeats.Core/packages.lock.json
@@ -167,12 +167,12 @@
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Direct",
-        "requested": "[3.0.4, )",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "requested": "[3.0.5, )",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "AspNetCore.HealthChecks.Redis": {
@@ -217,35 +217,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "Microsoft.Bcl.Cryptography": {
@@ -433,32 +433,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.VisualStudio.SolutionPersistence": {
@@ -607,33 +607,33 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -728,8 +728,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       }
     }

--- a/src/BridgeBeats.Web/Controllers/RefreshReviewController.cs
+++ b/src/BridgeBeats.Web/Controllers/RefreshReviewController.cs
@@ -1,10 +1,10 @@
+using System.Security.Claims;
 using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
+using BridgeBeats.Web.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
-using BridgeBeats.Web.Services;
 
 namespace BridgeBeats.Web.Controllers;
 

--- a/src/BridgeBeats.Web/Controllers/StatisticsController.cs
+++ b/src/BridgeBeats.Web/Controllers/StatisticsController.cs
@@ -64,8 +64,9 @@ public partial class StatisticsController(
 
             // Overlay live bootstrap status so the page reflects the current run state
             // without waiting for the full statistics cache to expire.
-            CacheBootstrapStatus? liveStatus =
-                await statisticsService.GetLiveBootstrapStatusAsync( HttpContext?.RequestAborted ?? CancellationToken.None );
+            CacheBootstrapStatus? liveStatus = User.IsInRole(Roles.AspireDashboardAccess)
+                ? await statisticsService.GetLiveBootstrapStatusAsync( HttpContext?.RequestAborted ?? CancellationToken.None )
+                : null;
             LookupStatistics displayStats = snapshot.WithBootstrapStatus( liveStatus );
 
             ViewBag.IsRefreshing = isRunning;

--- a/src/BridgeBeats.Web/Views/RefreshReview/Index.cshtml
+++ b/src/BridgeBeats.Web/Views/RefreshReview/Index.cshtml
@@ -40,7 +40,7 @@
                     {
                         <tr>
                             <td>@entry.FailedAt?.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</td>
-                            <td>@(entry.IsAlbum ? "Album" : "Track")</td>
+                            <td>@(entry.IsAlbum is null ? "Unknown" : entry.IsAlbum.Value ? "Album" : "Track")</td>
                             <td><code>@entry.LookupValue</code></td>
                             <td>
                                 @if (entry.SourceResult?.Results.Count > 0)

--- a/src/BridgeBeats.Web/Views/Statistics/Index.cshtml
+++ b/src/BridgeBeats.Web/Views/Statistics/Index.cshtml
@@ -148,6 +148,8 @@
         </div>
     </div>
 
+    @if (User.IsInRole(BridgeBeats.Contracts.Constants.Roles.AspireDashboardAccess))
+    {
     <!-- Cache Bootstrap Status -->
     <div class="row g-4 mt-2">
         <div class="col-12">
@@ -251,6 +253,7 @@
             </div>
         </div>
     </div>
+    }
 
     <!-- Recent Entries -->
     <div class="card mt-4">

--- a/src/BridgeBeats.Web/packages.lock.json
+++ b/src/BridgeBeats.Web/packages.lock.json
@@ -74,35 +74,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -274,32 +274,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -500,42 +500,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -598,8 +598,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -618,7 +618,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"
@@ -631,10 +631,10 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -651,10 +651,10 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -671,10 +671,10 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -691,10 +691,10 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",
@@ -711,10 +711,10 @@
         "resolved": "6.0.0",
         "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "System.Drawing.Common": {
         "type": "Transitive",

--- a/src/BridgeBeats.Worker.AppleMusic/packages.lock.json
+++ b/src/BridgeBeats.Worker.AppleMusic/packages.lock.json
@@ -56,35 +56,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -251,32 +251,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -477,42 +477,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -554,8 +554,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -574,7 +574,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.Discord/BridgeBeats.Worker.Discord.csproj
+++ b/src/BridgeBeats.Worker.Discord/BridgeBeats.Worker.Discord.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-    <PackageReference Include="NetCord.Hosting" Version="1.0.0-beta.11" />
+    <PackageReference Include="NetCord.Hosting" Version="1.0.0-beta.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Worker.Discord/packages.lock.json
+++ b/src/BridgeBeats.Worker.Discord/packages.lock.json
@@ -14,11 +14,11 @@
       },
       "NetCord.Hosting": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.11, )",
-        "resolved": "1.0.0-beta.11",
-        "contentHash": "81v1p+ns7Z/ky822idTHKEGy4tt8trC6MY+hB2i0k0rKqguCsSxo8syXMNlvksYBk+TLiQzJgHkfQ+aA+VmXJA==",
+        "requested": "[1.0.0-beta.12, )",
+        "resolved": "1.0.0-beta.12",
+        "contentHash": "6f2Tv3juHFu9jNh+jK9sGGAmQ4AtsGgy6qGPVccghJXGMowzBl4DtMa8D/fieQF6l5xjs3btRf92RkAGEiwDVg==",
         "dependencies": {
-          "NetCord": "1.0.0-beta.11"
+          "NetCord": "1.0.0-beta.12"
         }
       },
       "Aspire.StackExchange.Redis": {
@@ -75,35 +75,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -261,32 +261,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -296,8 +296,8 @@
       },
       "NetCord": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.11",
-        "contentHash": "1mzToSQ3J6wtHt1NirCJ4O9Dt1Ou/G9sSiLrFpub3KwWFpUWZqi/bncjAeCCMymosBYTasbqI+M5r6m/3DoLHg=="
+        "resolved": "1.0.0-beta.12",
+        "contentHash": "FpHP7AABQ0dvr3+sYAaMPMDMsfzzdtdpuLAmEfnZU7N+eyOmEK//cnYk0RAkEoj2jDHH4O1+xCUDn5zIBYbRsw=="
       },
       "OpenTelemetry": {
         "type": "Transitive",
@@ -492,42 +492,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -569,8 +569,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -589,7 +589,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.JetStreamWatcher/BridgeBeats.Worker.JetStreamWatcher.csproj
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/BridgeBeats.Worker.JetStreamWatcher.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="idunno.AtProto" Version="3.0.0" />
-    <PackageReference Include="idunno.Bluesky" Version="3.0.0" />
+    <PackageReference Include="idunno.AtProto" Version="3.1.0" />
+    <PackageReference Include="idunno.Bluesky" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/JetStreamWatcherService.cs
@@ -31,9 +31,11 @@ namespace BridgeBeats.Worker.JetStreamWatcher;
 /// </summary>
 /// <param name="logger">The logger for connection lifecycle and processing diagnostics.</param>
 /// <param name="queueResolver">Resolves the per-provider queue a discovered link is enqueued to.</param>
+/// <param name="sagaManager">Creates the fenced saga before its queue delivery is published.</param>
 public sealed partial class JetStreamWatcherService(
     ILogger<JetStreamWatcherService> logger,
-    IProviderQueueResolver<QueuedLookupRequest> queueResolver
+    IProviderQueueResolver<QueuedLookupRequest> queueResolver,
+    ISagaStateManager sagaManager
 ) : BackgroundService {
 
     /// <summary>
@@ -354,6 +356,8 @@ public sealed partial class JetStreamWatcherService(
             ? LookupKeyBuilder.TypedKey( lookupType, provider.Value, lookupValue )
             : LookupKeyBuilder.UrlKey( lookupValue );
         string sagaId = ISagaStateManager.GenerateSagaId( lookupKey );
+        LookupSagaState saga = await sagaManager.GetOrCreateAsync(
+            sagaId, lookupKey, lookupType, lookupValue, QueuePriority.Bulk, cancellationToken );
 
         // Create the lookup request with a saga ID for coordinating cross-provider lookups.
         // Bulk origin priority is persisted into the saga so secondary lookups spawned by
@@ -364,6 +368,7 @@ public sealed partial class JetStreamWatcherService(
             LookupType = lookupType,
             LookupValue = lookupValue,
             SagaId = sagaId,
+            SagaInstanceToken = saga.InstanceToken,
             IsAlbum = isAlbum,
             OriginPriority = QueuePriority.Bulk
         };

--- a/src/BridgeBeats.Worker.JetStreamWatcher/packages.lock.json
+++ b/src/BridgeBeats.Worker.JetStreamWatcher/packages.lock.json
@@ -4,29 +4,29 @@
     "net10.0": {
       "idunno.AtProto": {
         "type": "Direct",
-        "requested": "[3.0.0, )",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.Bluesky": {
         "type": "Direct",
-        "requested": "[3.0.0, )",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "Aspire.StackExchange.Redis": {
@@ -83,10 +83,10 @@
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Security.Ssrf": {
@@ -253,32 +253,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -479,42 +479,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -556,8 +556,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -576,7 +576,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.Maintenance/StaleCacheRefreshBackgroundService.cs
+++ b/src/BridgeBeats.Worker.Maintenance/StaleCacheRefreshBackgroundService.cs
@@ -4,6 +4,7 @@ using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Domain.Utilities;
+using BridgeBeats.Core.Infrastructure.Queue;
 using BridgeBeats.Core.Infrastructure.Utilities;
 using BridgeBeats.Worker.Maintenance.Logging;
 using StackExchange.Redis;
@@ -45,6 +46,9 @@ public sealed partial class StaleCacheRefreshBackgroundService(
 
     /// <summary>Redis key that records the UTC instant the most recent refresh pass started.</summary>
     private const string LastRunMarkerKey = "cache:refresh:last-run";
+
+    /// <summary>Number of stale selections without a completed refresh before direct review quarantine.</summary>
+    internal const int MaxRefreshSweepAttemptsBeforeReview = 3;
 
     /// <summary>Fixed grace period at startup before the first scan is allowed to run.</summary>
     private static readonly TimeSpan s_startupGrace = TimeSpan.FromSeconds( 120 );
@@ -151,11 +155,37 @@ public sealed partial class StaleCacheRefreshBackgroundService(
         int errors = 0;
 
         foreach ((string atUri, MediaLinkResult result) in selected) {
+            QueueMetrics.RecordMaintenanceOutcome( "selected" );
             try {
                 IReadOnlyList<RefreshLeg> legs = DeriveRefreshLegs( result, enabledProviders );
 
                 if (legs.Count == 0) {
+                    int sweepAttempt = await refreshReviewStore.IncrementSweepAttemptAsync( atUri, cancellationToken );
+                    if (sweepAttempt >= MaxRefreshSweepAttemptsBeforeReview) {
+                        string lookupKey = LookupKeyBuilder.UrlKey( atUri );
+                        string? sourceRecordCid = await atProtoStorage.GetMediaLinkRecordCidAsync( atUri, cancellationToken );
+                        bool anchorResolved = TryResolveAnchor(
+                            result, out _, out bool resolvedIsAlbum, out _, out _ );
+                        bool? recordIsAlbum = anchorResolved
+                            ? resolvedIsAlbum
+                            : result.Results.Values
+                                .Select( value => value.IsAlbum )
+                                .FirstOrDefault( value => value.HasValue );
+                        await refreshReviewStore.PromoteDirectAsync(
+                            new RefreshReviewEntry {
+                                SourceRecordUri = atUri,
+                                SourceRecordCid = sourceRecordCid,
+                                SagaId = ISagaStateManager.GenerateSagaId( lookupKey ),
+                                LookupType = LookupRequestType.UriLookup,
+                                LookupValue = atUri,
+                                IsAlbum = recordIsAlbum,
+                                SourceResult = result
+                            },
+                            "No completed refresh after three sweeps.",
+                            cancellationToken );
+                    }
                     LogRefreshRecordSkipped( logger, atUri );
+                    QueueMetrics.RecordMaintenanceOutcome( "no_legs" );
                     skipped++;
                     continue;
                 }
@@ -163,6 +193,7 @@ public sealed partial class StaleCacheRefreshBackgroundService(
                 bool didEnqueue = await EnqueueRecordAsync( atUri, result, legs, cancellationToken );
                 if (didEnqueue) {
                     enqueued++;
+                    QueueMetrics.RecordMaintenanceOutcome( "dispatched" );
                 } else {
                     skipped++;
                 }
@@ -170,6 +201,7 @@ public sealed partial class StaleCacheRefreshBackgroundService(
                 throw;
             } catch (Exception ex) {
                 errors++;
+                QueueMetrics.RecordMaintenanceOutcome( "enqueue_error" );
                 LogRefreshEnqueueError( logger, ex, atUri );
             }
         }
@@ -258,9 +290,15 @@ public sealed partial class StaleCacheRefreshBackgroundService(
         LookupRequestType sagaLookupType;
         string sagaLookupValue;
 
-        if (TryResolveAnchor( result, out string recordExternalId, out bool recordIsAlbum, out _, out _ )
+        bool anchorResolved = TryResolveAnchor(
+            result, out string recordExternalId, out bool resolvedIsAlbum, out _, out _ );
+        bool? recordIsAlbum = anchorResolved
+            ? resolvedIsAlbum
+            : result.Results.Values.Select( value => value.IsAlbum ).FirstOrDefault( value => value.HasValue );
+
+        if (anchorResolved
             && !string.IsNullOrEmpty( recordExternalId )) {
-            if (recordIsAlbum) {
+            if (resolvedIsAlbum) {
                 sagaLookupValue = recordExternalId;
                 sagaLookupKey = $"{LookupRequestType.UpcLookup}:{sagaLookupValue}";
                 sagaLookupType = LookupRequestType.UpcLookup;
@@ -281,8 +319,61 @@ public sealed partial class StaleCacheRefreshBackgroundService(
         }
 
         string sagaId = ISagaStateManager.GenerateSagaId( sagaLookupKey );
+        string? sourceRecordCid = await atProtoStorage.GetMediaLinkRecordCidAsync( atUri, cancellationToken );
+        RefreshReviewEntry recordContext = new( ) {
+            SourceRecordUri = atUri,
+            SourceRecordCid = sourceRecordCid,
+            SagaId = sagaId,
+            LookupType = sagaLookupType,
+            LookupValue = sagaLookupValue,
+            IsAlbum = recordIsAlbum,
+            SourceResult = result
+        };
 
-        _ = await sagaManager.GetOrCreateAsync(
+        LookupSagaState? activeSaga = await sagaManager.GetAsync( sagaId, cancellationToken );
+        if (activeSaga is { IsComplete: false }) {
+            int activeAttempt = await refreshReviewStore.IncrementSweepAttemptAsync( atUri, cancellationToken );
+            if (activeAttempt > 1) QueueMetrics.RecordMaintenanceOutcome( "reselected" );
+            if (activeAttempt >= MaxRefreshSweepAttemptsBeforeReview) {
+                RefreshReviewEntry? activeContext = await refreshReviewStore.GetPendingAsync( atUri, cancellationToken );
+                if (activeContext is not null
+                    && activeContext.SagaId == sagaId
+                    && activeContext.InstanceToken == activeSaga.InstanceToken) {
+                    // The active owner still has a live refresh attempt. Promote its existing
+                    // context directly so the review entry suppresses reselection without
+                    // deleting the pending slot needed by terminal completion.
+                    await refreshReviewStore.PromoteDirectAsync( activeContext, "No completed refresh after three sweeps.", cancellationToken );
+                } else {
+                    // This record shares an active saga owned by another source record. Promote its
+                    // own context at the threshold, but never delete the shared saga or overwrite the
+                    // owner's pending slot.
+                    await refreshReviewStore.PromoteDirectAsync(
+                        recordContext with { InstanceToken = activeSaga.InstanceToken },
+                        "No completed refresh after three sweeps.",
+                        cancellationToken );
+                }
+            }
+            LogRefreshRecordSkipped( logger, atUri );
+            QueueMetrics.RecordMaintenanceOutcome( "active_saga_suppressed" );
+            return false;
+        }
+
+        int sweepAttempt = await refreshReviewStore.IncrementSweepAttemptAsync( atUri, cancellationToken );
+        if (sweepAttempt > 1) QueueMetrics.RecordMaintenanceOutcome( "reselected" );
+        if (sweepAttempt >= MaxRefreshSweepAttemptsBeforeReview) {
+            RefreshReviewEntry? pending = await refreshReviewStore.GetPendingAsync( atUri, cancellationToken );
+            if (pending is not null && pending.SagaId == sagaId) {
+                await refreshReviewStore.MarkUnresolvedAsync( pending, "No completed refresh after three sweeps.", cancellationToken );
+            } else {
+                await refreshReviewStore.PromoteDirectAsync(
+                    recordContext,
+                    "No completed refresh after three sweeps.",
+                    cancellationToken );
+            }
+            return false;
+        }
+
+        LookupSagaState seededSaga = await sagaManager.GetOrCreateAsync(
             sagaId,
             sagaLookupKey,
             sagaLookupType,
@@ -290,25 +381,24 @@ public sealed partial class StaleCacheRefreshBackgroundService(
             originPriority: QueuePriority.Bulk,
             cancellationToken: cancellationToken
         );
-
-        string? sourceRecordCid = await atProtoStorage.GetMediaLinkRecordCidAsync( atUri, cancellationToken );
-        await refreshReviewStore.RegisterPendingAsync(
-            new RefreshReviewEntry {
-                SourceRecordUri = atUri,
-                SourceRecordCid = sourceRecordCid,
-                SagaId = sagaId,
-                LookupType = sagaLookupType,
-                LookupValue = sagaLookupValue,
-                IsAlbum = recordIsAlbum,
-                SourceResult = result
-            },
-            cancellationToken
-        );
+        if (string.IsNullOrWhiteSpace( seededSaga.InstanceToken )) {
+            LogRefreshRecordSkipped( logger, atUri );
+            return false;
+        }
+        string instanceToken = seededSaga.InstanceToken;
 
         // Initialize exactly the providers we are enqueuing legs for — the mode-B fix.
-        await sagaManager.InitializeProviderStatesAsync(
+        if (!await sagaManager.TryInitializeProviderStatesAsync(
             sagaId,
             legs.Select( l => l.Provider ).Distinct( ),
+            instanceToken,
+            cancellationToken
+        )) {
+            LogRefreshRecordSkipped( logger, atUri );
+            return false;
+        }
+
+        await refreshReviewStore.RegisterPendingAsync( recordContext with { InstanceToken = instanceToken },
             cancellationToken
         );
 
@@ -319,23 +409,27 @@ public sealed partial class StaleCacheRefreshBackgroundService(
                 LookupType = leg.LookupType,
                 LookupValue = leg.LookupValue,
                 SagaId = sagaId,
+                SagaInstanceToken = instanceToken,
                 IsAlbum = leg.IsAlbum,
                 Title = leg.Title,
                 Artist = leg.Artist,
                 OriginPriority = QueuePriority.Bulk,
                 Storefront = leg.Storefront,
                 FallbackLookupType = leg.FallbackLookupType,
-                FallbackLookupValue = leg.FallbackLookupValue
+                FallbackLookupValue = leg.FallbackLookupValue,
+                EnqueueOrigin = QueueEnqueueOrigin.RefreshSweep
             };
 
             IRequestQueue<QueuedLookupRequest> queue = queueResolver.GetQueue( leg.Provider );
             try {
                 await queue.EnqueueAsync( request, QueuePriority.Bulk, cancellationToken );
+                QueueMetrics.RecordRefreshLegEnqueued( leg.Provider, sweepAttempt > 1 );
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
             } catch (Exception ex) {
                 LogRefreshLegEnqueueFailed( logger, ex, atUri, leg.Provider );
-                await sagaManager.UpdateProviderStateAsync(
+                QueueMetrics.RecordMaintenanceOutcome( "leg_enqueue_failure", leg.Provider );
+                if (!await sagaManager.TryUpdateProviderStateAsync(
                     sagaId,
                     new ProviderLookupState(
                         Provider: leg.Provider,
@@ -345,8 +439,12 @@ public sealed partial class StaleCacheRefreshBackgroundService(
                         CompletedAt: DateTimeOffset.UtcNow,
                         ErrorMessage: $"Refresh leg enqueue failed: {ex.Message}"
                     ),
+                    instanceToken,
                     cancellationToken
-                );
+                )) {
+                    LogRefreshRecordSkipped( logger, atUri );
+                    return false;
+                }
             }
         }
 

--- a/src/BridgeBeats.Worker.Maintenance/packages.lock.json
+++ b/src/BridgeBeats.Worker.Maintenance/packages.lock.json
@@ -56,35 +56,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -251,32 +251,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -477,42 +477,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -554,8 +554,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -574,7 +574,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
+++ b/src/BridgeBeats.Worker.SagaCoordinator/SagaCoordinatorBackgroundService.cs
@@ -4,6 +4,7 @@ using BridgeBeats.Contracts.Enums;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Domain.Services.Queue;
+using BridgeBeats.Core.Infrastructure.Queue;
 using BridgeBeats.Worker.SagaCoordinator.Logging;
 using StackExchange.Redis;
 
@@ -40,9 +41,11 @@ namespace BridgeBeats.Worker.SagaCoordinator;
 /// When the first provider returns an external id (an ISRC for tracks or a UPC for albums), the
 /// coordinator fans out secondary lookups to the other enabled providers so the final card spans
 /// every provider. It first consults the ISRC/UPC cache and materializes any cached provider
-/// results straight into the saga; only the still-missing providers are queued. While secondaries
-/// are outstanding it writes an interim partial result so waiters receive something. ISRC/UPC-origin
-/// lookups skip this fan-out because they are already keyed by the canonical id.
+/// results straight into the saga; only the still-missing providers are queued. Interactive sagas
+/// may write an interim result while secondaries are outstanding. Maintenance refresh sagas never
+/// do: they retain the currently served PDS record until all provider legs are terminal, then write
+/// one result containing every successful sibling. ISRC/UPC-origin lookups skip this fan-out because
+/// they are already keyed by the canonical id.
 /// </para>
 /// </remarks>
 /// <param name="redis">The shared Redis connection used for Pub/Sub subscriptions.</param>
@@ -336,7 +339,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
 
         try {
             // Query for completed but unfinalized sagas using the pending index
-            IReadOnlyList<LookupSagaState> unfinalizedSagas = await _sagaManager.GetCompletedButUnfinalizedAsync(
+            IReadOnlyList<LookupSagaState> unfinalizedSagas = await _sagaManager.GetPendingReconciliationAsync(
                 s_minimumSagaAge,
                 PollingBatchLimit,
                 ct
@@ -354,6 +357,11 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 ct.ThrowIfCancellationRequested( );
 
                 try {
+                    if (!string.IsNullOrWhiteSpace( saga.FinalResultUri )) {
+                        _ = await ReleaseDurableResultAsync( saga, saga.FinalResultUri, ct );
+                        continue;
+                    }
+
                     // Run the same check as the Pub/Sub handlers - a completion missed by
                     // Pub/Sub must not finalize a one-provider result as complete while
                     // other providers still need secondary lookups
@@ -402,7 +410,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
     /// already at or above the requested generation) the method returns immediately with no write.
     /// </para>
     /// <para>
-    /// On the terminal path, <see cref="ISagaStateManager.TryClaimFinalizeAsync"/> provides the
+    /// On the terminal path, the saga finalize-claim operation provides the
     /// exactly-once guarantee for post-write bookkeeping (URI recording, partial-flag clear, dedup
     /// release). On the non-terminal path the write-generation CAS alone prevents double writes and
     /// no finalize claim is used.
@@ -422,12 +430,46 @@ public sealed partial class SagaCoordinatorBackgroundService(
     /// <param name="ct">A token that cancels the operation.</param>
     /// <returns>A task that completes when the write (or its failure cleanup) is done.</returns>
     private async Task WriteResultAsync( LookupSagaState saga, bool terminal, CancellationToken ct ) {
+        if (string.IsNullOrWhiteSpace( saga.InstanceToken )) {
+            return;
+        }
+        string instanceToken = saga.InstanceToken;
+        // A cache/materialization race may have replaced this saga after the completion trigger
+        // read. Re-check the instance fence before any PDS write so the stale handler stays silent.
+        LookupSagaState? currentSaga = await _sagaManager.GetAsync( saga.SagaId, ct );
+        if (currentSaga is null || currentSaga.InstanceToken != instanceToken) {
+            return;
+        }
+
+        // Background refreshes are finalized through the refresh review lifecycle. A partial
+        // materialization would clear/overwrite the pending context while the refresh is still
+        // in flight, so matching current-instance refresh contexts must wait for terminal state.
+        if (!terminal) {
+            IReadOnlyList<RefreshReviewEntry> pendingRefresh = await _refreshReviewStore.GetPendingForSagaAsync(
+                saga.SagaId, ct ) ?? [];
+            if (pendingRefresh.Any( entry => entry.InstanceToken == instanceToken )) {
+                return;
+            }
+        }
+
         if (terminal) {
             LogAssemblingFinalResult( _logger, saga.SagaId, saga.ProviderStates.Count );
         } else if (_logger.IsEnabled( LogLevel.Information )) {
             int completedCount = saga.ProviderStates.Count( kv => kv.Value.IsComplete );
             int totalCount = saga.ProviderStates.Count;
             LogAssemblingPartialResult( _logger, saga.SagaId, completedCount, totalCount );
+        }
+
+        if (terminal) {
+            // Every terminal path, including the no-result review path, is fenced by the
+            // instance-scoped finalize claim before it can mutate review, deduplication, or saga state.
+            bool claimed = await _sagaManager.TryClaimFinalizeAsync( saga.SagaId, instanceToken, ct );
+            if (!claimed) {
+                LogFinalizationClaimLost( _logger, saga.SagaId );
+                QueueMetrics.RecordSagaLifecycleOutcome( "finalize_claim_lost" );
+                return;
+            }
+
         }
 
         MediaLinkResult? finalResult = _resultCombiner.CombineResults( saga, allowIncomplete: !terminal );
@@ -438,18 +480,38 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 // The store is idempotent, so the polling backstop can safely retry this sequence.
                 LogNoSuccessfulResults( _logger, saga.SagaId );
                 try {
-                    await _refreshReviewStore.MarkUnresolvedAsync(
-                        saga.SagaId,
-                        "All provider refresh legs completed without a result.",
-                        ct
-                    );
+                    IReadOnlyList<RefreshReviewEntry> pending = [.. (await _refreshReviewStore.GetPendingForSagaAsync( saga.SagaId, ct ) ?? [])
+                        .Where( entry => entry.InstanceToken == instanceToken )];
+                    foreach (RefreshReviewEntry entry in pending) {
+                        await _refreshReviewStore.MarkUnresolvedAsync(
+                            entry,
+                            "All provider refresh legs completed without a result.",
+                            ct );
+                    }
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    _ = await _sagaManager.TryReleaseFinalizeClaimAsync(
+                        saga.SagaId, instanceToken, CancellationToken.None );
+                    throw;
                 } catch (Exception reviewEx) {
                     // Review persistence is operational bookkeeping. A Redis outage must not
                     // strand a terminal saga or leave its deduplication waiters blocked.
                     LogRefreshReviewPersistenceFailed( _logger, reviewEx, saga.SagaId );
                 }
-                await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
-                _ = await _sagaManager.DeleteAsync( saga.SagaId, ct );
+                try {
+                    await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    _ = await _sagaManager.TryReleaseFinalizeClaimAsync(
+                        saga.SagaId, instanceToken, CancellationToken.None );
+                    throw;
+                } catch (Exception releaseEx) {
+                    LogFailedToWriteFinal( _logger, releaseEx, saga.SagaId );
+                    QueueMetrics.RecordSagaLifecycleOutcome( "dedup_release_failed" );
+                    _ = await _sagaManager.TryReleaseFinalizeClaimAsync(
+                        saga.SagaId, instanceToken, CancellationToken.None );
+                    return;
+                }
+                _ = await _sagaManager.TryDeleteAsync( saga.SagaId, instanceToken, ct );
+                QueueMetrics.RecordSagaLifecycleOutcome( "terminal_zero_result" );
             } else {
                 // No successful results yet on the non-terminal path: nothing to write.
                 // More providers are still outstanding; wait for the next trigger.
@@ -459,45 +521,65 @@ public sealed partial class SagaCoordinatorBackgroundService(
         }
 
         if (terminal) {
-            // Terminal path: gated by the finalize claim only. The generation CAS is not
+            // Terminal path: gated above by the finalize claim only. The generation CAS is not
             // used here because the generation counts successful providers, and a saga that
             // completes via the last leg failing has the same generation it had when the
             // previous partial was written — the CAS would refuse to advance and the saga
             // would never finalize. The finalize claim (HSETNX) provides the single-winner
             // guarantee for this path.
-            bool claimed = await _sagaManager.TryClaimFinalizeAsync( saga.SagaId, ct );
-            if (!claimed) {
-                LogFinalizationClaimLost( _logger, saga.SagaId );
-                return;
-            }
-
+            bool pdsWritten = false;
             bool uriRecorded = false;
+            string? durableRecordUri = null;
 
             try {
                 string recordUri = await _atProtoStorage.StoreMediaLinkResultAsync( finalResult, ct );
+                durableRecordUri = recordUri;
+                pdsWritten = true;
 
                 LogWroteFinalToAtProto( _logger, saga.SagaId, recordUri );
 
                 // Durability line: once this returns the URI is durably stored. A failure after
                 // this point must NOT release the claim — re-entering would issue a second PDS
                 // write against an already-recorded URI.
-                await _sagaManager.SetFinalResultUriAsync( saga.SagaId, recordUri, ct );
+                SagaFinalResultWriteOutcome writeOutcome = await _sagaManager.TrySetFinalResultUriAsync(
+                    saga.SagaId, recordUri, instanceToken, ct );
+                if (writeOutcome == SagaFinalResultWriteOutcome.InstanceMismatch) {
+                    // The PDS write belongs to the old generation. Never publish it on the shared
+                    // lookup channel: waiters may now belong to the replacement saga.
+                    LogFinalizationClaimLost( _logger, saga.SagaId );
+                    QueueMetrics.RecordSagaLifecycleOutcome( "final_uri_instance_mismatch" );
+                    return;
+                }
+                if (writeOutcome == SagaFinalResultWriteOutcome.Conflict) {
+                    // A same-generation finalizer won with a different URI. Publish only the URI
+                    // Redis says is authoritative; the duplicate PDS record is intentionally orphaned.
+                    LookupSagaState? authoritative = await _sagaManager.GetAsync( saga.SagaId, ct );
+                    if (authoritative?.InstanceToken == instanceToken
+                        && !string.IsNullOrWhiteSpace( authoritative.FinalResultUri )) {
+                        _ = await ReleaseDurableResultAsync(
+                            authoritative, authoritative.FinalResultUri, ct );
+                    }
+                    QueueMetrics.RecordSagaLifecycleOutcome( "final_uri_conflict" );
+                    return;
+                }
                 uriRecorded = true;
 
                 try {
-                    await _refreshReviewStore.CompleteAsync( saga.SagaId, ct );
-                } catch {
+                    await _refreshReviewStore.CompleteAsync( saga.SagaId, instanceToken, ct );
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    throw;
+                } catch (Exception cleanupEx) {
                     // Pending context has the saga TTL and self-expires. A cleanup failure must
                     // not turn an already-durable PDS write into a failed finalization.
+                    LogRefreshReviewPersistenceFailed( _logger, cleanupEx, saga.SagaId );
                 }
 
-                // Clear the partial flag before releasing waiters so the waiter's isFinal read
-                // is already authoritative by the time it wakes.
-                await _sagaManager.SetIsPartialAsync( saga.SagaId, false, ct );
-
-                await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
+                if (!await ReleaseDurableResultAsync( saga, recordUri, ct )) {
+                    return;
+                }
 
                 LogSuccessfullyFinalized( _logger, saga.SagaId, finalResult.Results.Count );
+                QueueMetrics.RecordSagaLifecycleOutcome( "terminal_success" );
 
                 // Best-effort: index after releasing waiters so a cache failure never delays
                 // wakeup. Swallow all exceptions — the result is already durably written.
@@ -512,8 +594,11 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 // re-finalize. After the durability line: retain the claim — re-entering would
                 // issue a second PDS write against an already-recorded URI. The dedup lock is
                 // not released here in either case.
-                if (!uriRecorded) {
-                    await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, CancellationToken.None );
+                if (!pdsWritten) {
+                    _ = await _sagaManager.TryReleaseFinalizeClaimAsync( saga.SagaId, instanceToken, CancellationToken.None );
+                } else if (durableRecordUri is not null) {
+                    _ = await RecoverDurableResultAsync(
+                        saga, durableRecordUri, uriRecorded, CancellationToken.None );
                 }
                 throw;
             } catch (Exception ex) {
@@ -522,9 +607,12 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 // Only release the claim before the durability line. After the URI is recorded,
                 // retaining the claim prevents a re-entrant PDS write; releasing the dedup lock
                 // with null would hand waiters an empty result for a saga that succeeded.
-                if (!uriRecorded) {
-                    await _sagaManager.ReleaseFinalizeClaimAsync( saga.SagaId, ct );
+                if (!pdsWritten) {
+                    _ = await _sagaManager.TryReleaseFinalizeClaimAsync( saga.SagaId, instanceToken, ct );
                     await _deduplicator.ReleaseAsync( saga.LookupKey, null, ct );
+                } else if (durableRecordUri is not null) {
+                    _ = await RecoverDurableResultAsync(
+                        saga, durableRecordUri, uriRecorded, CancellationToken.None );
                 }
             }
         } else {
@@ -533,7 +621,8 @@ public sealed partial class SagaCoordinatorBackgroundService(
             // observed, which is ≤ the number of providers N.
             int generation = finalResult.Results.Count;
 
-            if (!await _sagaManager.TryAdvanceWriteGenerationAsync( saga.SagaId, generation, ct )) {
+            bool advanced = await _sagaManager.TryAdvanceWriteGenerationAsync( saga.SagaId, generation, instanceToken, ct );
+            if (!advanced) {
                 return;
             }
 
@@ -546,7 +635,10 @@ public sealed partial class SagaCoordinatorBackgroundService(
 
                 LogWrotePartialToAtProto( _logger, saga.SagaId, recordUri );
 
-                await _sagaManager.SetPartialResultUriAsync( saga.SagaId, recordUri, ct );
+                bool recorded = await _sagaManager.TrySetPartialResultUriAsync( saga.SagaId, recordUri, instanceToken, ct );
+                if (!recorded) {
+                    return;
+                }
                 uriRecorded = true;
 
                 await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
@@ -566,7 +658,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 // would issue a second partial write against a URI that is already recorded.
                 // The dedup lock is not released in either case.
                 if (!uriRecorded) {
-                    await _sagaManager.ResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, CancellationToken.None );
+                    _ = await _sagaManager.TryResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, instanceToken, CancellationToken.None );
                 }
                 throw;
             } catch (Exception ex) {
@@ -576,9 +668,93 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 // recorded, retaining the generation prevents a re-entrant duplicate partial
                 // write.
                 if (!uriRecorded) {
-                    await _sagaManager.ResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, ct );
+                    _ = await _sagaManager.TryResetWriteGenerationAsync( saga.SagaId, generation, generation - 1, instanceToken, ct );
                 }
             }
+        }
+    }
+
+    private async Task<bool> RecoverDurableResultAsync(
+        LookupSagaState saga,
+        string durableRecordUri,
+        bool uriWasRecorded,
+        CancellationToken ct
+    ) {
+        if (string.IsNullOrWhiteSpace( saga.InstanceToken )) {
+            QueueMetrics.RecordSagaLifecycleOutcome( "durable_release_instance_mismatch" );
+            return false;
+        }
+
+        string instanceToken = saga.InstanceToken;
+        try {
+            LookupSagaState? authoritative = await _sagaManager.GetAsync( saga.SagaId, ct );
+            if (authoritative is null
+                || string.IsNullOrWhiteSpace( authoritative.InstanceToken )
+                || authoritative.InstanceToken != instanceToken) {
+                QueueMetrics.RecordSagaLifecycleOutcome( "durable_release_instance_mismatch" );
+                return false;
+            }
+
+            string? authoritativeUri = authoritative.FinalResultUri;
+            if (string.IsNullOrWhiteSpace( authoritativeUri ) && !uriWasRecorded) {
+                SagaFinalResultWriteOutcome retryOutcome = await _sagaManager.TrySetFinalResultUriAsync(
+                    saga.SagaId, durableRecordUri, instanceToken, ct );
+                if (retryOutcome == SagaFinalResultWriteOutcome.InstanceMismatch) {
+                    QueueMetrics.RecordSagaLifecycleOutcome( "durable_release_instance_mismatch" );
+                    return false;
+                }
+                if (retryOutcome == SagaFinalResultWriteOutcome.Conflict) {
+                    authoritative = await _sagaManager.GetAsync( saga.SagaId, ct );
+                    if (authoritative is null || authoritative.InstanceToken != instanceToken
+                        || string.IsNullOrWhiteSpace( authoritative.FinalResultUri )) {
+                        return false;
+                    }
+                    authoritativeUri = authoritative.FinalResultUri;
+                } else {
+                    authoritativeUri = durableRecordUri;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace( authoritativeUri )) {
+                return false;
+            }
+
+            return await ReleaseDurableResultAsync( authoritative, authoritativeUri, ct );
+        } catch (Exception recoveryEx) {
+            LogFailedToWriteFinal( _logger, recoveryEx, saga.SagaId );
+            QueueMetrics.RecordSagaLifecycleOutcome( "durable_release_recovery_failed" );
+            // The PDS record key is deterministic. Releasing the finalize claim lets the pending
+            // reconciliation sweep safely repeat the PutRecord if Redis was unavailable for the
+            // URI CAS, rather than leaving the saga permanently claimed and undiscoverable.
+            try {
+                _ = await _sagaManager.TryReleaseFinalizeClaimAsync(
+                    saga.SagaId, instanceToken, CancellationToken.None );
+            } catch (Exception claimEx) {
+                LogFailedToWriteFinal( _logger, claimEx, saga.SagaId );
+            }
+            return false;
+        }
+    }
+
+    private async Task<bool> ReleaseDurableResultAsync(
+        LookupSagaState saga,
+        string recordUri,
+        CancellationToken ct,
+        bool removePendingIndex = true
+    ) {
+        try {
+            await _deduplicator.ReleaseAsync( saga.LookupKey, recordUri, ct );
+            if (removePendingIndex) {
+                await _sagaManager.RemoveFromPendingIndexAsync( saga.SagaId, ct );
+            }
+            QueueMetrics.RecordSagaLifecycleOutcome( "dedup_released" );
+            return true;
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) {
+            LogFailedToWriteFinal( _logger, ex, saga.SagaId );
+            QueueMetrics.RecordSagaLifecycleOutcome( "dedup_release_failed" );
+            return false;
         }
     }
 
@@ -628,7 +804,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
     /// other enabled providers too. It checks the ISRC/UPC cache first and materializes any cached
     /// provider results straight into the saga to avoid re-querying; only the providers that are still
     /// missing are queued as secondary <see cref="QueuedLookupRequest"/>s. A single-winner marker
-    /// (<see cref="Contracts.Interfaces.ISagaStateManager.TryMarkSecondariesQueuedAsync(string, CancellationToken)"/>)
+    /// (<see cref="Contracts.Interfaces.ISagaStateManager.TryMarkSecondariesQueuedAsync(string, string, CancellationToken)"/>)
     /// guards against duplicate fan-out by concurrent handlers. ISRC/UPC-origin sagas are skipped
     /// because they are already keyed by the canonical id.
     /// </summary>
@@ -644,6 +820,10 @@ public sealed partial class SagaCoordinatorBackgroundService(
         LookupSagaState originalSaga,
         CancellationToken ct
     ) {
+        if (string.IsNullOrWhiteSpace( originalSaga.InstanceToken )) {
+            return false;
+        }
+        string instanceToken = originalSaga.InstanceToken;
         // Don't trigger secondary lookups from secondary lookups (ISRC/UPC lookups)
         // Only provider-specific lookups (SpotifyLookup, AppleMusicLookup, TidalLookup) should trigger secondary lookups
         if (originalSaga.LookupType is LookupRequestType.IsrcLookup or LookupRequestType.UpcLookup) {
@@ -703,7 +883,13 @@ public sealed partial class SagaCoordinatorBackgroundService(
                         ErrorMessage: null
                     );
 
-                    await _sagaManager.UpdateProviderStateAsync( originalSaga.SagaId, cachedState, ct );
+                    bool cachedWritten = await _sagaManager.TryUpdateProviderStateAsync( originalSaga.SagaId, cachedState, instanceToken, ct );
+                    if (!cachedWritten) {
+                        // The saga instance was replaced while this handler was materializing
+                        // cache data. Defer finalization; the replacement instance owns the next
+                        // completion trigger and must not be overwritten by this stale handler.
+                        return true;
+                    }
 
                     // Keep the in-memory saga consistent so the partial/final result
                     // written by the caller includes the materialized data
@@ -724,6 +910,10 @@ public sealed partial class SagaCoordinatorBackgroundService(
         List<SupportedProviders> providersToQueue = [.. otherProviders.Where(p => !providersWithData.Contains(p))];
 
         if (providersToQueue.Count == 0) {
+            LookupSagaState? proof = await _sagaManager.GetAsync( originalSaga.SagaId, ct );
+            if (proof is null || proof.InstanceToken != instanceToken) {
+                return true;
+            }
             LogAllProvidersInCache( _logger, originalSaga.SagaId, externalId );
             return false;
         }
@@ -737,8 +927,13 @@ public sealed partial class SagaCoordinatorBackgroundService(
         // partial. Otherwise the marker loser could publish while IsPartial is still false
         // and no pending states exist, letting a waiting orchestrator mistake the
         // one-provider result for a final one (isFinal = IsComplete && !IsPartial).
-        await _sagaManager.InitializeProviderStatesAsync( originalSaga.SagaId, providersToQueue, ct );
-        await _sagaManager.SetIsPartialAsync( originalSaga.SagaId, true, ct );
+        bool fenced = await _sagaManager.TryInitializeProviderStatesAsync( originalSaga.SagaId, providersToQueue, instanceToken, ct );
+        if (!fenced) {
+            return false;
+        }
+        if (!await _sagaManager.TrySetIsPartialAsync( originalSaga.SagaId, true, instanceToken, ct )) {
+            return false;
+        }
 
         if (_logger.IsEnabled( LogLevel.Information )) {
             string providerNames = string.Join( ", ", providersToQueue );
@@ -749,7 +944,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
         // The worker publishes both saga:completed and complete:{key}, so both handlers can
         // race through here and would otherwise enqueue every secondary twice. The loser
         // still reports "secondaries pending" so its caller defers finalization.
-        bool markerAcquired = await _sagaManager.TryMarkSecondariesQueuedAsync( originalSaga.SagaId, ct );
+        bool markerAcquired = await _sagaManager.TryMarkSecondariesQueuedAsync( originalSaga.SagaId, instanceToken, ct );
         if (!markerAcquired) {
             LogSecondariesAlreadyQueued( _logger, originalSaga.SagaId );
             return true;
@@ -765,6 +960,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
 
         // Queue lookups for each provider using the ORIGINAL saga ID
         int queuedCount = 0;
+        int failedCount = 0;
         foreach (SupportedProviders provider in providersToQueue) {
             try {
                 // Create and queue the lookup request using the ORIGINAL saga ID
@@ -775,6 +971,7 @@ public sealed partial class SagaCoordinatorBackgroundService(
                     LookupType = lookupType,
                     LookupValue = externalId,
                     SagaId = originalSaga.SagaId,  // Use original saga ID!
+                    SagaInstanceToken = instanceToken,
                     IsAlbum = isAlbum,
                     Title = firstResult.Title,
                     Artist = firstResult.Artist,
@@ -789,27 +986,56 @@ public sealed partial class SagaCoordinatorBackgroundService(
                 string providerStr = provider.ToString( );
                 LogQueuedSecondaryLookup( _logger, lookupTypeStr, providerStr, externalId, originalSaga.SagaId );
                 queuedCount++;
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
             } catch (Exception ex) {
                 string providerStr = provider.ToString( );
                 LogFailedToQueueSecondary( _logger, ex, providerStr, externalId );
-                // Continue with other providers - don't fail the entire operation
+
+                // The one-time fan-out marker has already been claimed. Leaving this initialized
+                // provider incomplete would make the saga permanently non-terminal because no
+                // delivery exists to finish it and the marker prevents another fan-out. Record a
+                // terminal enqueue failure for this leg before continuing with the other providers.
+                ProviderLookupState enqueueFailure = new(
+                    Provider: provider,
+                    IsComplete: true,
+                    IsSuccess: false,
+                    ResultJson: null,
+                    CompletedAt: DateTimeOffset.UtcNow,
+                    ErrorMessage: $"Failed to enqueue {provider} secondary lookup."
+                );
+                if (!await _sagaManager.TryUpdateProviderStateAsync(
+                    originalSaga.SagaId,
+                    enqueueFailure,
+                    instanceToken,
+                    ct )) {
+                    return true;
+                }
+                originalSaga.ProviderStates[provider] = enqueueFailure;
+                failedCount++;
             }
         }
 
+        if (failedCount > 0) {
+            // Wake the coordinator after the failed legs have been made terminal. This is
+            // essential when every enqueue failed because no worker delivery exists to emit a
+            // later progress event; partial failures will also be rechecked safely.
+            ISubscriber subscriber = _redis.GetSubscriber( );
+            _ = await subscriber.PublishAsync(
+                RedisChannel.Literal( SagaCompletedChannel ),
+                originalSaga.SagaId );
+        }
+
         if (queuedCount == 0) {
-            // Every enqueue failed. Pending provider states and the partial flag are already
-            // set, so finalizing now would publish a result that is missing providers as
-            // complete and overwrite richer cached data. Waiters receive the honest partial
-            // instead; the cache marks partial results stale, so the lookup is retried once
-            // the queue backend recovers. Remove the saga from the reconciliation index so
-            // it does not strand as an actionable pending entry until TTL expiry. The saga
-            // record itself remains readable until TTL so late GetAsync calls still resolve.
             LogNoSecondariesEnqueued( _logger, originalSaga.SagaId, externalId );
-            await _sagaManager.RemoveFromPendingIndexAsync( originalSaga.SagaId, ct );
+            // Every secondary leg now has a durable terminal enqueue failure, so no delivery can
+            // produce another event. Let this invocation proceed directly to finalization instead
+            // of writing an unnecessary partial generation first.
+            return false;
         }
 
         // Pending provider states exist and the saga is marked partial, so the caller must
-        // defer finalization even when some (or all) enqueues failed.
+        // defer finalization while the successfully queued providers are still in flight.
         return true;
     }
 

--- a/src/BridgeBeats.Worker.SagaCoordinator/packages.lock.json
+++ b/src/BridgeBeats.Worker.SagaCoordinator/packages.lock.json
@@ -56,35 +56,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -251,32 +251,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -477,42 +477,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -554,8 +554,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -574,7 +574,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.Spotify/SpotifyBatchQueueHelper.cs
+++ b/src/BridgeBeats.Worker.Spotify/SpotifyBatchQueueHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using BridgeBeats.Contracts.Constants;
@@ -18,9 +19,9 @@ namespace BridgeBeats.Worker.Spotify;
 /// multi-id batches. This helper owns the consumer-group lifecycle for those streams, depth and
 /// age inspection (to drive flush decisions), batch dequeue (including reclaiming stalled pending
 /// entries via XAUTOCLAIM), acknowledgement, and bounded requeue. Poison entries (missing or
-/// unparseable payloads) are acknowledged and deleted rather than retried.
+/// unparseable payloads) are removed atomically rather than retried.
 /// </remarks>
-public sealed partial class SpotifyBatchQueueHelper {
+public sealed partial class SpotifyBatchQueueHelper : IQueueWorkSignal {
 
     /// <summary>Redis connection multiplexer used for all stream operations.</summary>
     private readonly IConnectionMultiplexer _redis;
@@ -30,46 +31,171 @@ public sealed partial class SpotifyBatchQueueHelper {
 
     /// <summary>JSON options used to serialize and deserialize queued request payloads (camelCase, compact).</summary>
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _bulkTrackStream;
+    private readonly string _bulkAlbumStream;
+    private readonly string _interactiveStream;
+    private readonly string _backgroundStream;
+    private readonly string _workSignalChannel;
+    private readonly string _bulkWorkSignalChannel;
 
     /// <summary>Name of the Redis consumer group shared by the Spotify bulk streams.</summary>
-    private const string ConsumerGroup = "spotify-workers";
+    private const string ConsumerGroup = SpotifyConstants.ConsumerGroup;
 
     /// <summary>
     /// This process instance's consumer id within <see cref="ConsumerGroup"/>, derived from
-    /// <see cref="Environment.MachineName"/> and a GUID then truncated to 32 characters via
-    /// <c>[..32]</c>. The truncation discards part of the GUID, so this value is <b>not</b>
-    /// guaranteed to be unique across multiple replicas running on the same host.
+    /// <see cref="Environment.MachineName"/> and a full GUID. The GUID is retained even when
+    /// multiple replicas run on the same host.
     /// </summary>
     private readonly string _consumerId;
+    private readonly Dictionary<string, RedisValue> _autoClaimCursors = [];
+    private readonly SemaphoreSlim _workSignalInitialization = new( 1, 1 );
+    private TaskCompletionSource _workSignal = CreateWorkSignal( );
+    private long _workVersion;
+    private bool _workSignalInitialized;
+    private DateTimeOffset? _nextReclaimCheck;
+
+    /// <summary>Internal identity seam used to verify replica uniqueness without touching Redis.</summary>
+    internal string ConsumerId => _consumerId;
 
     /// <summary>
     /// Minimum idle time (ms) before XAUTOCLAIM reclaims a pending entry.
-    /// 60 seconds is long enough that a slow-but-alive processing cycle is
+    /// 15 minutes is long enough that a slow-but-alive processing cycle is
     /// never inadvertently reclaimed, while short enough that a crashed consumer
-    /// does not block the stream for more than one minute.
+    /// does not block the stream for more than 15 minutes.
     /// </summary>
-    private const int AutoClaimMinIdleMs = 60_000;
+    private const int AutoClaimMinIdleMs = 15 * 60 * 1000;
+
+    /// <summary>
+    /// Atomically forwards one live bulk delivery to the appropriate generic single-item stream,
+    /// wakes its consumer, and removes the source. Source existence makes redelivery idempotent.
+    /// </summary>
+    private const string ForwardToSingleItemScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local groupExists = false
+        local groups = redis.call('XINFO', 'GROUPS', KEYS[1])
+        for _, group in ipairs(groups) do
+            for i = 1, #group, 2 do
+                if group[i] == 'name' and group[i + 1] == ARGV[6] then
+                    groupExists = true
+                    break
+                end
+            end
+            if groupExists then break end
+        end
+        if not groupExists then return redis.error_reply('NOGROUP source consumer group is missing') end
+        local replacement = redis.call('XADD', KEYS[2], '*', ARGV[2], ARGV[3], ARGV[4], ARGV[5])
+        redis.call('PUBLISH', ARGV[7], replacement)
+        redis.call('XACK', KEYS[1], ARGV[6], ARGV[1])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        return replacement
+        """;
+
+    private const string RequeueDeliveryScript = """
+        local source = redis.call('XRANGE', KEYS[1], ARGV[1], ARGV[1], 'COUNT', 1)
+        if #source == 0 then return false end
+        local replacement = redis.call(
+            'XADD', KEYS[1], '*', ARGV[3], ARGV[4], ARGV[5], ARGV[6])
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        redis.call('XDEL', KEYS[1], ARGV[1])
+        redis.call('PUBLISH', ARGV[7], replacement)
+        return replacement
+        """;
+
+    private const string RemoveDeliveryScript = """
+        redis.call('XACK', KEYS[1], ARGV[2], ARGV[1])
+        return redis.call('XDEL', KEYS[1], ARGV[1])
+        """;
 
     /// <summary>
     /// Initializes the helper, deriving this process instance's consumer id.
     /// </summary>
     /// <param name="redis">The Redis connection multiplexer.</param>
     /// <param name="logger">The logger for this helper.</param>
+    /// <param name="keyPrefix">Optional isolated queue-key prefix shared with the bulk producer.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="redis"/> or <paramref name="logger"/> is <see langword="null"/>.</exception>
     public SpotifyBatchQueueHelper(
         IConnectionMultiplexer redis,
-        ILogger<SpotifyBatchQueueHelper> logger
+        ILogger<SpotifyBatchQueueHelper> logger,
+        string? keyPrefix = null
     ) {
         _redis = redis ?? throw new ArgumentNullException( nameof( redis ) );
         _logger = logger ?? throw new ArgumentNullException( nameof( logger ) );
+        _bulkTrackStream = QueueStreamKeys.SpotifyBulkFor( isTrack: true, keyPrefix );
+        _bulkAlbumStream = QueueStreamKeys.SpotifyBulkFor( isTrack: false, keyPrefix );
+        _interactiveStream = QueueStreamKeys.For( SupportedProviders.Spotify, QueuePriority.Interactive, keyPrefix );
+        _backgroundStream = QueueStreamKeys.For( SupportedProviders.Spotify, QueuePriority.Background, keyPrefix );
+        _workSignalChannel = QueueStreamKeys.WorkSignalFor( SupportedProviders.Spotify, keyPrefix );
+        _bulkWorkSignalChannel = QueueStreamKeys.SpotifyBulkWorkSignal( keyPrefix );
 
         string uniqueId = Guid.NewGuid( ).ToString( "N" );
-        _consumerId = $"spotify-batch-{Environment.MachineName}-{uniqueId}"[..32];
+        // Redis stream consumer names are not bounded to 32 characters. Keep the full random
+        // suffix so long machine names cannot truncate it away and cause a restart collision.
+        _consumerId = $"spotify-batch-{Environment.MachineName}-{uniqueId}";
 
         _jsonOptions = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = false
         };
+    }
+
+    private static TaskCompletionSource CreateWorkSignal( ) =>
+        new( TaskCreationOptions.RunContinuationsAsynchronously );
+
+    /// <inheritdoc/>
+    public async Task InitializeWorkSignalAsync( CancellationToken cancellationToken = default ) {
+        if (_workSignalInitialized) return;
+        await _workSignalInitialization.WaitAsync( cancellationToken );
+        try {
+            if (_workSignalInitialized) return;
+            await _redis.GetSubscriber( ).SubscribeAsync(
+                RedisChannel.Literal( _bulkWorkSignalChannel ),
+                ( _, _ ) => NotifyWorkAvailable( ) );
+            _workSignalInitialized = true;
+        } finally {
+            _ = _workSignalInitialization.Release( );
+        }
+    }
+
+    /// <inheritdoc/>
+    public long CaptureWorkVersion( ) => Interlocked.Read( ref _workVersion );
+
+    /// <inheritdoc/>
+    public async Task WaitForWorkAsync(
+        long observedVersion,
+        DateTimeOffset? scheduledWake,
+        CancellationToken cancellationToken = default
+    ) {
+        if (_nextReclaimCheck is { } reclaimCheck
+            && (scheduledWake is null || scheduledWake <= DateTimeOffset.UtcNow)) {
+            scheduledWake = reclaimCheck;
+        }
+        while (Interlocked.Read( ref _workVersion ) == observedVersion) {
+            Task signal = Volatile.Read( ref _workSignal ).Task;
+            if (Interlocked.Read( ref _workVersion ) != observedVersion) return;
+            if (scheduledWake is null) {
+                await signal.WaitAsync( cancellationToken );
+                return;
+            }
+
+            TimeSpan remaining = scheduledWake.Value - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero) return;
+            TaskCompletionSource elapsed = CreateWorkSignal( );
+            using Timer timer = new(
+                static state => ((TaskCompletionSource)state!).TrySetResult( ),
+                elapsed,
+                remaining,
+                Timeout.InfiniteTimeSpan );
+            Task completed = await Task.WhenAny( signal, elapsed.Task ).WaitAsync( cancellationToken );
+            await completed;
+            return;
+        }
+    }
+
+    private void NotifyWorkAvailable( ) {
+        _ = Interlocked.Increment( ref _workVersion );
+        TaskCompletionSource previous = Interlocked.Exchange( ref _workSignal, CreateWorkSignal( ) );
+        _ = previous.TrySetResult( );
     }
 
     /// <summary>
@@ -85,7 +211,7 @@ public sealed partial class SpotifyBatchQueueHelper {
     public async Task EnsureConsumerGroupsAsync( CancellationToken cancellationToken = default ) {
         IDatabase db = _redis.GetDatabase( );
 
-        foreach (string stream in new[] { SpotifyConstants.BulkTrackIdStream, SpotifyConstants.BulkAlbumIdStream }) {
+        foreach (string stream in new[] { _bulkTrackStream, _bulkAlbumStream }) {
             if (cancellationToken.IsCancellationRequested) { break; }
             try {
                 _ = await db.StreamCreateConsumerGroupAsync(
@@ -113,8 +239,8 @@ public sealed partial class SpotifyBatchQueueHelper {
         cancellationToken.ThrowIfCancellationRequested( );
         IDatabase db = _redis.GetDatabase( );
 
-        long bulkTrackCount = await db.StreamLengthAsync( SpotifyConstants.BulkTrackIdStream );
-        long bulkAlbumCount = await db.StreamLengthAsync( SpotifyConstants.BulkAlbumIdStream );
+        long bulkTrackCount = await db.StreamLengthAsync( _bulkTrackStream );
+        long bulkAlbumCount = await db.StreamLengthAsync( _bulkAlbumStream );
 
         return new IdLookupDepth(
             TrackIdCount: (int)bulkTrackCount,
@@ -143,7 +269,7 @@ public sealed partial class SpotifyBatchQueueHelper {
             return null;
         }
 
-        string stream = isTracks ? SpotifyConstants.BulkTrackIdStream : SpotifyConstants.BulkAlbumIdStream;
+        string stream = isTracks ? _bulkTrackStream : _bulkAlbumStream;
         IDatabase db = _redis.GetDatabase( );
 
         try {
@@ -181,7 +307,7 @@ public sealed partial class SpotifyBatchQueueHelper {
         CancellationToken cancellationToken = default
     ) {
         int count = maxCount ?? SpotifyConstants.MaxTracksPerBatchLookup;
-        return await DequeueBatchFromStreamAsync( SpotifyConstants.BulkTrackIdStream, count, cancellationToken );
+        return await DequeueBatchFromStreamAsync( _bulkTrackStream, count, cancellationToken );
     }
 
     /// <summary>
@@ -195,22 +321,23 @@ public sealed partial class SpotifyBatchQueueHelper {
         CancellationToken cancellationToken = default
     ) {
         int count = maxCount ?? SpotifyConstants.MaxAlbumsPerBatchLookup;
-        return await DequeueBatchFromStreamAsync( SpotifyConstants.BulkAlbumIdStream, count, cancellationToken );
+        return await DequeueBatchFromStreamAsync( _bulkAlbumStream, count, cancellationToken );
     }
 
     /// <summary>
-    /// Dequeues up to <paramref name="count"/> messages from a bulk stream, first reclaiming
-    /// stalled pending entries via XAUTOCLAIM and then reading new entries for this consumer.
+    /// Dequeues up to <paramref name="count"/> messages in three bounded stages: this consumer's
+    /// pending entries, stalled entries reclaimed via XAUTOCLAIM, then new entries.
     /// </summary>
     /// <param name="stream">The bulk stream key to read from.</param>
     /// <param name="count">Maximum number of messages to return.</param>
     /// <param name="cancellationToken">Token used to stop reading early.</param>
     /// <returns>The decoded messages in claim order; poison entries are dropped, not returned.</returns>
     /// <remarks>
-    /// Reclaimed entries are counted against <paramref name="count"/> so a single call never
-    /// exceeds the requested batch size. Entries with missing or unparseable payloads are
-    /// acknowledged and deleted as poison. If XAUTOCLAIM is unsupported by the server, the reclaim
-    /// step is skipped and only new entries are read.
+    /// Recovered and reclaimed entries are counted against <paramref name="count"/> so a single
+    /// call never exceeds the requested batch size. Entries with missing or unparseable payloads
+    /// are acknowledged and deleted as poison. If XAUTOCLAIM is unsupported by the server, only
+    /// dead-consumer reclaim is skipped; this consumer's pending entries and new entries remain
+    /// readable.
     /// </remarks>
     private async Task<IReadOnlyList<QueuedMessage<QueuedLookupRequest>>> DequeueBatchFromStreamAsync(
         string stream,
@@ -219,131 +346,210 @@ public sealed partial class SpotifyBatchQueueHelper {
     ) {
         IDatabase db = _redis.GetDatabase( );
         List<QueuedMessage<QueuedLookupRequest>> messages = [];
-
-        // XAUTOCLAIM sweep: reclaim any PEL entries idle longer than AutoClaimMinIdleMs,
-        // then immediately deserialize and append them to the result — claimed entries land
-        // in THIS consumer's PEL and XREADGROUP with ">" can never see them again.
-        // Safe here because there is exactly one consumer service (SpotifyBulkProcessorService)
-        // reading these streams — no other consumer group member can be legitimately processing
-        // the entry after 60 seconds of idle time.
-        int remainingCount = count;
+        HashSet<string> scannedEntryIds = [];
+        Stopwatch dequeueTimer = Stopwatch.StartNew( );
+        Activity? dequeueActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.dequeue" );
+        _ = (dequeueActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+        _ = (dequeueActivity?.SetTag( QueueMetricTags.Priority, "bulk" ));
         try {
-            StreamAutoClaimResult claimed = await db.StreamAutoClaimAsync(
+
+            // XAUTOCLAIM sweep: reclaim any PEL entries idle longer than AutoClaimMinIdleMs,
+            // then immediately deserialize and append them to the result — claimed entries land
+            // in THIS consumer's PEL and XREADGROUP with ">" can never see them again.
+            // Safe here because there is exactly one consumer service (SpotifyBulkProcessorService)
+            // reading these streams — no other consumer group member can be legitimately processing
+            // the entry after 15 minutes of idle time.
+            int remainingCount = count;
+            Stopwatch pelTimer = Stopwatch.StartNew( );
+            using Activity? pelActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.dequeue.pel_scan" );
+            _ = (pelActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (pelActivity?.SetTag( QueueMetricTags.Priority, "bulk" ));
+            _ = (pelActivity?.SetTag( QueueMetricTags.Stream, stream ));
+            try {
+                // Recover entries still owned by this consumer before waiting for the idle
+                // threshold. XREADGROUP with an explicit 0-0 position reads this consumer's PEL
+                // without delivering new entries or resetting idle clocks on entries beyond the
+                // bounded batch budget.
+                StreamEntry[] ownPending = await db.StreamReadGroupAsync(
+                    stream,
+                    ConsumerGroup,
+                    _consumerId,
+                    position: "0-0",
+                    count: remainingCount,
+                    noAck: false );
+                remainingCount = await AppendDecodedEntriesAsync(
+                    db, stream, ownPending, messages, remainingCount, scannedEntryIds,
+                    recordPelOutcome: true, cancellationToken: cancellationToken );
+
+                if (remainingCount <= 0) {
+                    RecordBulkDequeues( messages );
+                    return messages;
+                }
+
+                RedisValue autoClaimStart = _autoClaimCursors.TryGetValue( stream, out RedisValue cursor ) ? cursor : "0-0";
+                StreamAutoClaimResult claimed = await db.StreamAutoClaimAsync(
                 stream,
                 ConsumerGroup,
                 _consumerId,
                 AutoClaimMinIdleMs,
-                "0-0",
-                count
+                autoClaimStart,
+                remainingCount
             );
+                _autoClaimCursors[stream] = claimed.NextStartId.HasValue && claimed.NextStartId != "0-0"
+                    ? claimed.NextStartId
+                    : "0-0";
 
-            if (claimed.ClaimedEntries.Length > 0) {
-                LogAutoClaimRecovered( _logger, claimed.ClaimedEntries.Length, stream );
-
-                foreach (StreamEntry entry in claimed.ClaimedEntries) {
-                    if (cancellationToken.IsCancellationRequested || remainingCount <= 0) { break; }
-
-                    string? payload = entry[QueueStreamFieldNames.Payload];
-                    string? enqueuedAtStr = entry[QueueStreamFieldNames.EnqueuedAt];
-
-                    if (string.IsNullOrEmpty( payload )) {
-                        // Poison: no payload field — ACK+XDEL to prevent infinite re-claim loop.
-                        await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
-                        continue;
-                    }
-
-                    try {
-                        QueuedLookupRequest? request = JsonSerializer.Deserialize<QueuedLookupRequest>( payload, _jsonOptions );
-                        if (request is null) {
-                            // Literal JSON null payload — deserializes without throwing but produces
-                            // a null object. Route through AckAndDeletePoisonEntryAsync so this entry
-                            // is removed from the PEL rather than remaining for eternal 60s re-claims.
-                            LogDeserializationError( _logger, new InvalidOperationException( "null payload" ), entry.Id.ToString( ), stream );
-                            await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
-                            continue;
-                        }
-
-                        DateTimeOffset enqueuedAt = DateTimeOffset.UtcNow;
-                        if (!string.IsNullOrEmpty( enqueuedAtStr ) &&
-                            !DateTimeOffset.TryParseExact( enqueuedAtStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out enqueuedAt )) {
-                            LogMalformedEnqueuedAt( _logger, enqueuedAtStr, stream );
-                            enqueuedAt = DateTimeOffset.UtcNow;
-                        }
-
-                        string compositeId = $"{stream}:{entry.Id}";
-                        messages.Add( new QueuedMessage<QueuedLookupRequest>( compositeId, request, enqueuedAt ) );
-                        remainingCount--;
-                    } catch (JsonException ex) {
-                        // Poison message: cannot deserialize even after re-claim — ACK and delete
-                        // to prevent infinite re-claim/re-fail every AutoClaimMinIdleMs.
-                        LogDeserializationError( _logger, ex, entry.Id.ToString( ), stream );
-                        await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
-                    }
+                foreach (RedisValue deletedId in claimed.DeletedIds) {
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "missing" ) );
                 }
+
+                if (claimed.ClaimedEntries.Length > 0) {
+                    LogAutoClaimRecovered( _logger, claimed.ClaimedEntries.Length, stream );
+                    remainingCount = await AppendDecodedEntriesAsync(
+                        db, stream, claimed.ClaimedEntries, messages, remainingCount,
+                        scannedEntryIds, recordPelOutcome: true, cancellationToken: cancellationToken );
+                }
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )) {
+                throw;
+            } catch (RedisServerException ex) when (IsAutoClaimUnsupported( ex )) {
+                // XAUTOCLAIM was added in Redis 6.2; if the server is older, log and continue
+                LogAutoClaimNotSupported( _logger, ex, stream );
+            } finally {
+                pelTimer.Stop( );
+                pelActivity?.Stop( );
+                QueueMetrics.PelScanDuration.Record( pelTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, "bulk" ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
             }
-        } catch (RedisServerException ex) {
-            // XAUTOCLAIM was added in Redis 6.2; if the server is older, log and continue
-            LogAutoClaimNotSupported( _logger, ex, stream );
-        }
 
-        // Skip XREADGROUP if the claimed entries already filled the budget.
-        if (remainingCount <= 0) {
+            // Skip XREADGROUP if the claimed entries already filled the budget.
+            if (remainingCount <= 0) {
+                RecordBulkDequeues( messages );
+                return messages;
+            }
+
+            Stopwatch readTimer = Stopwatch.StartNew( );
+            Activity? readActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.dequeue.read_group" );
+            _ = (readActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (readActivity?.SetTag( QueueMetricTags.Priority, "bulk" ));
+            _ = (readActivity?.SetTag( QueueMetricTags.Stream, stream ));
+            StreamEntry[] entries;
+            try {
+                entries = await db.StreamReadGroupAsync(
+                    stream,
+                    ConsumerGroup,
+                    _consumerId,
+                    count: remainingCount,
+                    noAck: false
+                );
+
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )) {
+                throw;
+            } catch (RedisServerException) {
+                throw;
+            } finally {
+                readTimer.Stop( );
+                readActivity?.Stop( );
+                QueueMetrics.ReadGroupDuration.Record( readTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, "bulk" ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ) );
+            }
+
+            _ = await AppendDecodedEntriesAsync(
+                db, stream, entries, messages, remainingCount, scannedEntryIds,
+                recordPelOutcome: false, cancellationToken: cancellationToken );
+
+            RecordBulkDequeues( messages );
             return messages;
+        } finally {
+            _nextReclaimCheck = messages.Count == 0
+                ? DateTimeOffset.UtcNow.AddMilliseconds( AutoClaimMinIdleMs )
+                : null;
+            dequeueTimer.Stop( );
+            dequeueActivity?.Stop( );
+            QueueMetrics.DequeueDuration.Record( dequeueTimer.Elapsed.TotalSeconds,
+                new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Priority, "bulk" ) );
         }
+    }
 
-        try {
-            StreamEntry[] entries = await db.StreamReadGroupAsync(
-                stream,
-                ConsumerGroup,
-                _consumerId,
-                count: remainingCount,
-                noAck: false
-            );
+    private async Task<int> AppendDecodedEntriesAsync(
+        IDatabase db,
+        string stream,
+        IReadOnlyList<StreamEntry> entries,
+        List<QueuedMessage<QueuedLookupRequest>> messages,
+        int remainingCount,
+        HashSet<string> scannedEntryIds,
+        bool recordPelOutcome,
+        CancellationToken cancellationToken
+    ) {
+        foreach (StreamEntry entry in entries) {
+            if (cancellationToken.IsCancellationRequested || remainingCount <= 0) break;
+            string compositeId = $"{stream}:{entry.Id}";
+            if (!scannedEntryIds.Add( compositeId )) continue;
+            string? payload = entry[QueueStreamFieldNames.Payload];
+            string? enqueuedAtStr = entry[QueueStreamFieldNames.EnqueuedAt];
+            if (string.IsNullOrEmpty( payload )) {
+                await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
+                if (recordPelOutcome) {
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "poison" ) );
+                }
+                continue;
+            }
 
-            foreach (StreamEntry entry in entries) {
-                if (cancellationToken.IsCancellationRequested) { break; }
-                string? payload = entry[QueueStreamFieldNames.Payload];
-                string? enqueuedAtStr = entry[QueueStreamFieldNames.EnqueuedAt];
-
-                if (string.IsNullOrEmpty( payload )) {
-                    // Poison: no payload field — ACK+XDEL to remove from PEL so it cannot be
-                    // re-read by XREADGROUP or re-claimed by XAUTOCLAIM every AutoClaimMinIdleMs.
+            try {
+                QueuedLookupRequest? request = JsonSerializer.Deserialize<QueuedLookupRequest>( payload, _jsonOptions );
+                if (request is null) {
                     await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
+                    if (recordPelOutcome) {
+                        QueueMetrics.PelScanEntries.Add( 1,
+                            new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                            new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "poison" ) );
+                    }
                     continue;
                 }
 
-                try {
-                    QueuedLookupRequest? request = JsonSerializer.Deserialize<QueuedLookupRequest>( payload, _jsonOptions );
-                    if (request is null) {
-                        // Literal JSON null payload — deserializes without throwing but produces
-                        // a null object. Route through AckAndDeletePoisonEntryAsync so this entry
-                        // is removed from the PEL rather than remaining for eternal 60s re-claims.
-                        LogDeserializationError( _logger, new InvalidOperationException( "null payload" ), entry.Id.ToString( ), stream );
-                        await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
-                        continue;
-                    }
+                DateTimeOffset enqueuedAt = DateTimeOffset.UtcNow;
+                if (!string.IsNullOrEmpty( enqueuedAtStr )
+                    && !DateTimeOffset.TryParseExact( enqueuedAtStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out enqueuedAt )) {
+                    LogMalformedEnqueuedAt( _logger, enqueuedAtStr, stream );
+                    enqueuedAt = DateTimeOffset.UtcNow;
+                }
 
-                    DateTimeOffset enqueuedAt = DateTimeOffset.UtcNow;
-                    if (!string.IsNullOrEmpty( enqueuedAtStr ) &&
-                        !DateTimeOffset.TryParseExact( enqueuedAtStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out enqueuedAt )) {
-                        LogMalformedEnqueuedAt( _logger, enqueuedAtStr, stream );
-                        enqueuedAt = DateTimeOffset.UtcNow;
-                    }
-
-                    string compositeId = $"{stream}:{entry.Id}";
-                    messages.Add( new QueuedMessage<QueuedLookupRequest>( compositeId, request, enqueuedAt ) );
-                } catch (JsonException ex) {
-                    // Poison message: ACK and delete to remove it from the PEL so it cannot be
-                    // re-claimed by XAUTOCLAIM and re-fail every AutoClaimMinIdleMs indefinitely.
-                    LogDeserializationError( _logger, ex, entry.Id.ToString( ), stream );
-                    await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
+                messages.Add( new QueuedMessage<QueuedLookupRequest>( compositeId, request, enqueuedAt ) {
+                    Priority = QueuePriority.Bulk
+                } );
+                if (recordPelOutcome) {
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "eligible" ) );
+                }
+                remainingCount--;
+            } catch (JsonException ex) {
+                LogDeserializationError( _logger, ex, entry.Id.ToString( ), stream );
+                await AckAndDeletePoisonEntryAsync( db, stream, entry.Id.ToString( ) );
+                if (recordPelOutcome) {
+                    QueueMetrics.PelScanEntries.Add( 1,
+                        new KeyValuePair<string, object?>( QueueMetricTags.Stream, stream ),
+                        new KeyValuePair<string, object?>( QueueMetricTags.Outcome, "poison" ) );
                 }
             }
-        } catch (RedisServerException ex) {
-            LogStreamReadWarning( _logger, ex, stream );
         }
 
-        return messages;
+        return remainingCount;
+    }
+
+    private static void RecordBulkDequeues( IReadOnlyList<QueuedMessage<QueuedLookupRequest>> messages ) {
+        foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
+            QueueMetrics.RecordDequeue( SupportedProviders.Spotify, QueuePriority.Bulk );
+            QueueMetrics.RecordQueueSojourn( SupportedProviders.Spotify, QueuePriority.Bulk, message.EnqueuedAt );
+        }
     }
 
     /// <summary>
@@ -356,11 +562,22 @@ public sealed partial class SpotifyBatchQueueHelper {
     /// <returns>A task that completes once the entry is removed (Redis errors are logged and swallowed).</returns>
     private async Task AckAndDeletePoisonEntryAsync( IDatabase db, string stream, string id ) {
         try {
-            _ = await db.StreamAcknowledgeAsync( stream, ConsumerGroup, id );
-            _ = await db.StreamDeleteAsync( stream, [id] );
+            _ = await db.ScriptEvaluateAsync(
+                RemoveDeliveryScript,
+                [stream],
+                [id, ConsumerGroup] );
+            QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Spotify, QueuePriority.Bulk );
+            QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, QueuePriority.Bulk, "poison_deleted" );
         } catch (RedisServerException ex) {
             LogStreamReadWarning( _logger, ex, stream );
         }
+    }
+
+    private static bool IsAutoClaimUnsupported( RedisServerException exception ) {
+        string message = exception.Message;
+        return message.Contains( "XAUTOCLAIM", StringComparison.OrdinalIgnoreCase )
+            && (message.Contains( "unknown command", StringComparison.OrdinalIgnoreCase )
+                || message.Contains( "not supported", StringComparison.OrdinalIgnoreCase ));
     }
 
     /// <summary>
@@ -373,10 +590,73 @@ public sealed partial class SpotifyBatchQueueHelper {
         (string stream, string id) = ParseMessageId( messageId );
 
         IDatabase db = _redis.GetDatabase( );
-        _ = await db.StreamAcknowledgeAsync( stream, ConsumerGroup, id );
-        _ = await db.StreamDeleteAsync( stream, [id] );
+        _ = await db.ScriptEvaluateAsync(
+            RemoveDeliveryScript,
+            [stream],
+            [id, ConsumerGroup] );
+        QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Spotify, QueuePriority.Bulk );
 
         LogMessageAcknowledged( _logger, id, stream );
+    }
+
+    /// <summary>
+    /// Atomically transfers a rejected bulk delivery to the generic Spotify background stream.
+    /// </summary>
+    /// <param name="message">The claimed bulk delivery to transfer.</param>
+    /// <param name="cancellationToken">Token checked before the atomic Redis operation.</param>
+    /// <returns>
+    /// <see langword="true"/> when Redis created the background replacement and removed the bulk
+    /// source; <see langword="false"/> when the source had already been removed by another attempt.
+    /// </returns>
+    /// <remarks>
+    /// XADD, XACK, and XDEL run in one Lua script. A redelivery after an ambiguous client-side
+    /// response finds no source entry and therefore cannot create a second background copy.
+    /// </remarks>
+    public async Task<bool> ForwardToSingleItemAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        CancellationToken cancellationToken = default
+    ) {
+        ArgumentNullException.ThrowIfNull( message );
+        cancellationToken.ThrowIfCancellationRequested( );
+        (string stream, string id) = ParseMessageId( message.MessageId );
+        QueuedLookupRequest requeued = message.Payload with {
+            EnqueueOrigin = QueueEnqueueOrigin.Requeue,
+            BypassBulkRouting = true
+        };
+        string payload = JsonSerializer.Serialize( requeued, _jsonOptions );
+        string enqueuedAt = DateTimeOffset.UtcNow.ToString( "O" );
+
+        QueuePriority destinationPriority = message.Payload.OriginPriority == QueuePriority.Interactive
+            ? QueuePriority.Interactive
+            : QueuePriority.Background;
+        string destinationStream = destinationPriority == QueuePriority.Interactive
+            ? _interactiveStream
+            : _backgroundStream;
+
+        RedisResult result = await _redis.GetDatabase( ).ScriptEvaluateAsync(
+            ForwardToSingleItemScript,
+            keys: [stream, destinationStream],
+            values: [
+                id,
+                QueueStreamFieldNames.Payload,
+                payload,
+                QueueStreamFieldNames.EnqueuedAt,
+                enqueuedAt,
+                ConsumerGroup,
+                _workSignalChannel
+            ] );
+        RedisValue replacementId = (RedisValue)result;
+        if (!replacementId.HasValue) {
+            return false;
+        }
+
+        QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Spotify, QueuePriority.Bulk );
+        QueueMetrics.RecordRequeue( SupportedProviders.Spotify );
+        QueueMetrics.RecordEnqueue(
+            SupportedProviders.Spotify,
+            destinationPriority,
+            QueueEnqueueOrigin.Requeue );
+        return true;
     }
 
     /// <summary>
@@ -387,14 +667,14 @@ public sealed partial class SpotifyBatchQueueHelper {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>
     /// <see cref="RequeueOutcome.Requeued"/> when the message was re-added with an incremented
-    /// attempt; <see cref="RequeueOutcome.CapReached"/> when the retry cap was reached or the
-    /// payload was unserializable (the message is discarded); or
+    /// attempt; <see cref="RequeueOutcome.CapReached"/> when the retry cap was reached (the
+    /// original delivery remains pending until the caller records terminal saga state); or
     /// <see cref="RequeueOutcome.NotFound"/> when the original entry no longer exists.
     /// </returns>
     /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled before work begins.</exception>
     /// <remarks>
-    /// The original entry is always acknowledged and deleted first; on a successful requeue a fresh
-    /// entry is added with a new <c>enqueuedAt</c> timestamp and <c>AttemptCount + 1</c>. The caller
+    /// A fresh replacement is added before the original entry is acknowledged and deleted, with a
+    /// new <c>enqueuedAt</c> timestamp and <c>AttemptCount + 1</c>. The caller
     /// is responsible for finalizing the saga when the cap is reached.
     /// </remarks>
     public async Task<RequeueOutcome> RequeueAsync(
@@ -426,20 +706,18 @@ public sealed partial class SpotifyBatchQueueHelper {
             try {
                 request = JsonSerializer.Deserialize<QueuedLookupRequest>( rawPayload, _jsonOptions );
             } catch (JsonException) {
-                // Fall through — will requeue with attempt 1 if we can't parse
+                // Fall through to terminal poison handling if we cannot parse.
             }
         }
 
         int currentAttempt = request?.AttemptCount ?? 0;
 
-        // ACK and delete the original entry in both paths
-        _ = await db.StreamAcknowledgeAsync( stream, ConsumerGroup, id );
-        _ = await db.StreamDeleteAsync( stream, [id] );
-
-        if (currentAttempt >= LookupConstants.MaxQueueRetryAttempts) {
-            // Cap reached: log and signal caller to handle saga completion.
-            // The message is already ACK+deleted above (removed from the PEL and stream).
-            // Caller must write the failed provider state and publish completion events.
+        if (currentAttempt >= LookupConstants.MaxQueueRetryAttempts - 1) {
+            // The retry budget counts total executions: attempts 0..Max-2 may be replaced;
+            // the final execution at Max-1 is terminal and must not create a sixth delivery.
+            // The caller must durably record terminal saga state before removing this final
+            // recovery delivery. Leaving it in the PEL makes a Redis failure during that write
+            // recoverable through normal redelivery.
             LogMaxRetriesExceeded( _logger, id, LookupConstants.MaxQueueRetryAttempts, sagaId );
             return RequeueOutcome.CapReached;
         }
@@ -448,11 +726,20 @@ public sealed partial class SpotifyBatchQueueHelper {
             // Payload could not be deserialized — cannot safely increment AttemptCount.
             // Drop the message and signal CapReached so the caller writes failed saga state.
             LogPoisonPayloadDiscarded( _logger, id, sagaId );
+            _ = await db.ScriptEvaluateAsync(
+                RemoveDeliveryScript,
+                [stream],
+                [id, ConsumerGroup] );
+            QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Spotify, QueuePriority.Bulk );
+            QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, QueuePriority.Bulk, "poison_deleted" );
             return RequeueOutcome.CapReached;
         }
 
         // Build re-serialized payload with AttemptCount + 1
-        QueuedLookupRequest requeuedRequest = request with { AttemptCount = currentAttempt + 1 };
+        QueuedLookupRequest requeuedRequest = request with {
+            AttemptCount = currentAttempt + 1,
+            EnqueueOrigin = QueueEnqueueOrigin.Requeue
+        };
 
         string newPayload = JsonSerializer.Serialize( requeuedRequest, _jsonOptions );
 
@@ -461,7 +748,31 @@ public sealed partial class SpotifyBatchQueueHelper {
             new NameValueEntry( QueueStreamFieldNames.EnqueuedAt, DateTimeOffset.UtcNow.ToString( "O" ) )
         ];
 
-        _ = await db.StreamAddAsync( stream, fields );
+        RedisResult moveResult = await db.ScriptEvaluateAsync(
+            RequeueDeliveryScript,
+            [stream],
+            [
+                id,
+                ConsumerGroup,
+                QueueStreamFieldNames.Payload,
+                fields[0].Value,
+                QueueStreamFieldNames.EnqueuedAt,
+                fields[1].Value,
+                _bulkWorkSignalChannel
+            ] );
+        RedisValue replacementId = (RedisValue)moveResult;
+        if (!replacementId.HasValue) {
+            LogMessageNotFound( _logger, id, stream );
+            return RequeueOutcome.NotFound;
+        }
+        NotifyWorkAvailable( );
+
+        // Count the replacement as accepted immediately after XADD; cleanup failures must not
+        // erase the enqueue acceptance from telemetry.
+        QueueMetrics.RecordEnqueue( SupportedProviders.Spotify, QueuePriority.Bulk, QueueEnqueueOrigin.Requeue );
+
+        QueueMetrics.RecordDeliveryRemoved( SupportedProviders.Spotify, QueuePriority.Bulk );
+        QueueMetrics.RecordRequeue( SupportedProviders.Spotify );
 
         LogMessageRequeued( _logger, stream, currentAttempt + 1 );
         return RequeueOutcome.Requeued;
@@ -477,9 +788,9 @@ public sealed partial class SpotifyBatchQueueHelper {
     /// Known bulk stream prefixes are matched first (their keys themselves contain colons); the
     /// last-colon fallback handles any other well-formed composite id.
     /// </remarks>
-    private static (string stream, string id) ParseMessageId( string compositeId ) {
+    private (string stream, string id) ParseMessageId( string compositeId ) {
         // Format: stream:id where id may contain colons (Redis stream IDs are timestamp-sequence)
-        foreach (string streamPrefix in new[] { SpotifyConstants.BulkTrackIdStream, SpotifyConstants.BulkAlbumIdStream }) {
+        foreach (string streamPrefix in new[] { _bulkTrackStream, _bulkAlbumStream }) {
             if (compositeId.StartsWith( streamPrefix + ":", StringComparison.OrdinalIgnoreCase )) {
                 string id = compositeId[(streamPrefix.Length + 1)..];
                 return (streamPrefix, id);
@@ -535,14 +846,14 @@ public sealed partial class SpotifyBatchQueueHelper {
         Message = "XAUTOCLAIM recovered {Count} pending entries from {Stream}" )]
     private static partial void LogAutoClaimRecovered( ILogger logger, int count, string stream );
 
-    /// <summary>Logs that XAUTOCLAIM is unsupported by the server, disabling pending-entry recovery.</summary>
+    /// <summary>Logs that XAUTOCLAIM is unsupported; only dead-consumer recovery is disabled.</summary>
     /// <param name="logger">The logger to write to.</param>
     /// <param name="ex">The Redis error returned by the server.</param>
     /// <param name="stream">The stream key.</param>
     [LoggerMessage(
         EventId = LogEventIds.AutoClaimNotSupported,
         Level = LogLevel.Warning,
-        Message = "XAUTOCLAIM not supported on {Stream} — pending-entry recovery disabled (requires Redis ≥ 6.2)" )]
+        Message = "XAUTOCLAIM not supported on {Stream} — dead-consumer recovery disabled (XAUTOCLAIM requires Redis ≥ 6.2); current-consumer PEL recovery remains available" )]
     private static partial void LogAutoClaimNotSupported( ILogger logger, Exception ex, string stream );
 
     /// <summary>Logs that a stream entry payload failed to deserialize and was discarded.</summary>

--- a/src/BridgeBeats.Worker.Spotify/SpotifyBulkProcessorService.cs
+++ b/src/BridgeBeats.Worker.Spotify/SpotifyBulkProcessorService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using BridgeBeats.Contracts.Constants;
 using BridgeBeats.Contracts.DTOs;
@@ -6,6 +7,7 @@ using BridgeBeats.Contracts.Exceptions;
 using BridgeBeats.Contracts.Interfaces;
 using BridgeBeats.Contracts.Records;
 using BridgeBeats.Core.Domain.Providers.Spotify;
+using BridgeBeats.Core.Infrastructure.Queue;
 using BridgeBeats.Core.Infrastructure.Utilities;
 using BridgeBeats.Worker.Spotify.Logging;
 using BridgeBeats.Worker.Spotify.Metrics;
@@ -21,14 +23,15 @@ namespace BridgeBeats.Worker.Spotify;
 /// <remarks>
 /// Spotify's API allows fetching many ids in one call, so single-id lookups are diverted onto
 /// dedicated bulk streams (drained through <see cref="SpotifyBatchQueueHelper"/>) and processed here
-/// in batches. The loop polls every 500ms and flushes a stream when its depth reaches the per-batch
-/// maximum or when its oldest queued item exceeds the configured linger window
+/// in batches. The loop wakes on broker notifications and flushes a stream when its depth reaches
+/// the per-batch maximum or when its oldest queued item exceeds the configured linger window
 /// (<see cref="ShouldFlush"/>). On success it drives the same saga update and completion-publish path
 /// as the per-message queue processor. Failure handling has four distinct shapes: a rate-limit
-/// (<see cref="RetryAfterExceededException"/>) marks affected sagas partial and requeues the whole
-/// batch; a deterministic 4xx rejection (<see cref="SpotifyBulkRejectedException"/>) re-enqueues
-/// each item individually at Interactive priority so the per-message processor resolves them as
-/// single-id lookups (isolating any poison id); an empty result dictionary is treated as a
+/// (<see cref="ProviderRateLimitException"/>, including its <see cref="RetryAfterExceededException"/> subtype)
+/// marks affected sagas partial and requeues the whole
+/// batch; a deterministic 4xx rejection (<see cref="SpotifyBulkRejectedException"/>) atomically
+/// transfers each item to the single-item lane, preserving an interactive origin and otherwise
+/// using background priority (isolating any poison id); an empty result dictionary is treated as a
 /// transient request-level failure that arms an exponential per-stream cooldown and requeues the
 /// batch; and an absent key within a non-empty result is a per-id partial that requeues only that
 /// message.
@@ -51,12 +54,9 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     private readonly ISpotifyBulkLookupService _lookupService;
 
     /// <summary>
-    /// The Spotify request queue used to re-enqueue individual items at Interactive priority when
-    /// the bulk API rejects an entire batch with a 4xx response. The decorated queue passes
-    /// Interactive-priority SongIdLookup and AlbumIdLookup requests straight through to the inner
-    /// (generic priority) queue, so a re-enqueue at Interactive does not feed back into the bulk
-    /// streams. A future change that makes the decorator batch Interactive requests would silently
-    /// break this fallback and must update this path accordingly.
+    /// The Spotify request queue used for generic dead-letter operations initiated by the bulk
+    /// processor. Rejected-batch forwarding is owned by <see cref="SpotifyBatchQueueHelper"/> so
+    /// replacement enqueue and source cleanup can be one atomic Redis operation.
     /// </summary>
     private readonly IRequestQueue<QueuedLookupRequest> _requestQueue;
 
@@ -96,10 +96,7 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// <summary>Prefix of the per-lookup Pub/Sub completion channel (<c>complete:{lookupKey}</c>).</summary>
     private const string LookupCompleteChannelPrefix = "complete:";
 
-    /// <summary>Interval between bulk-flush checks (500ms).</summary>
-    private static readonly TimeSpan s_checkInterval = TimeSpan.FromMilliseconds( 500 );
-
-    /// <summary>Delay applied after an unhandled loop error before retrying (5 seconds).</summary>
+    /// <summary>Scheduled recovery event after an unhandled loop error (5 seconds).</summary>
     private static readonly TimeSpan s_errorDelay = TimeSpan.FromSeconds( 5 );
 
     /// <summary>
@@ -112,10 +109,9 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// <param name="sagaManager">Manager for saga state.</param>
     /// <param name="lookupService">Spotify bulk lookup service.</param>
     /// <param name="requestQueue">
-    /// The Spotify request queue used to re-enqueue items individually at Interactive priority when
-    /// the bulk API rejects an entire batch with a 4xx. Must be the queue registered for
-    /// <see cref="SupportedProviders.Spotify"/> (the <c>SpotifyBulkQueueDecorator</c>-wrapped instance
-    /// registered by <c>AddQueueProcessor</c>).
+    /// The Spotify request queue used for generic dead-letter operations. Must be the queue
+    /// registered for <see cref="SupportedProviders.Spotify"/> (the
+    /// <c>SpotifyBulkQueueDecorator</c>-wrapped instance registered by <c>AddQueueProcessor</c>).
     /// </param>
     /// <param name="logger">Logger for the service.</param>
     /// <param name="batchSettings">Bound batch settings supplying the linger window and base cooldown.</param>
@@ -149,19 +145,41 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     }
 
     /// <summary>
-    /// Ensures the bulk-stream consumer groups exist, then loops every check interval flushing the
-    /// track-id and album-id streams whenever their flush conditions are met, until cancellation.
+    /// Ensures the bulk-stream consumer groups exist, then reacts to enqueue notifications and exact
+    /// linger/rate-limit/cooldown expiry events until cancellation.
     /// </summary>
     /// <param name="stoppingToken">Token signaled when the host is shutting down.</param>
     /// <returns>A task that completes when the loop exits.</returns>
-    /// <remarks>Unhandled errors in an iteration are logged and retried after a short delay rather than crashing the host.</remarks>
+    /// <remarks>Unhandled errors are retried on a scheduled event rather than blocking a worker thread.</remarks>
     protected override async Task ExecuteAsync( CancellationToken stoppingToken ) {
         LogServiceStarting( _logger );
 
+        while (!stoppingToken.IsCancellationRequested) {
+            try {
+                await _batchHelper.InitializeWorkSignalAsync( stoppingToken );
+                break;
+            } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
+                return;
+            } catch (Exception ex) {
+                LogProcessorLoopError( _logger, ex );
+                long failedVersion = _batchHelper.CaptureWorkVersion( );
+                await _batchHelper.WaitForWorkAsync(
+                    failedVersion, DateTimeOffset.UtcNow.Add( s_errorDelay ), stoppingToken );
+            }
+        }
+
         // Ensure consumer groups exist for type-specific streams
-        await _batchHelper.EnsureConsumerGroupsAsync( stoppingToken );
+        try {
+            await _batchHelper.EnsureConsumerGroupsAsync( stoppingToken );
+        } catch (Exception ex) when (ex is not OperationCanceledException || !stoppingToken.IsCancellationRequested) {
+            LogProcessorLoopError( _logger, ex );
+            long failedVersion = _batchHelper.CaptureWorkVersion( );
+            await _batchHelper.WaitForWorkAsync(
+                failedVersion, DateTimeOffset.UtcNow.Add( s_errorDelay ), stoppingToken );
+        }
 
         while (!stoppingToken.IsCancellationRequested) {
+            long observedWorkVersion = _batchHelper.CaptureWorkVersion( );
             try {
                 // Check if we should process bulk track lookups
                 if (await ShouldProcessBulkTracksAsync( stoppingToken )) {
@@ -173,17 +191,78 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
                     await ProcessBulkAlbumLookupsAsync( stoppingToken );
                 }
 
-                // Wait before checking again
-                await Task.Delay( s_checkInterval, stoppingToken );
+                DateTimeOffset? nextWake = await GetNextBulkWakeAsync( stoppingToken );
+                await _batchHelper.WaitForWorkAsync( observedWorkVersion, nextWake, stoppingToken );
             } catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) {
                 break;
+            } catch (RedisServerException ex) when (ex.Message.Contains( "NOGROUP", StringComparison.OrdinalIgnoreCase )) {
+                try {
+                    await _batchHelper.EnsureConsumerGroupsAsync( stoppingToken );
+                } catch (Exception repairEx) when (repairEx is not OperationCanceledException || !stoppingToken.IsCancellationRequested) {
+                    LogProcessorLoopError( _logger, repairEx );
+                    await _batchHelper.WaitForWorkAsync(
+                        observedWorkVersion, DateTimeOffset.UtcNow.Add( s_errorDelay ), stoppingToken );
+                }
             } catch (Exception ex) {
                 LogProcessorLoopError( _logger, ex );
-                await Task.Delay( s_errorDelay, stoppingToken );
+                await _batchHelper.WaitForWorkAsync(
+                    observedWorkVersion, DateTimeOffset.UtcNow.Add( s_errorDelay ), stoppingToken );
             }
         }
 
         LogServiceStopping( _logger );
+    }
+
+    private async Task<DateTimeOffset?> GetNextBulkWakeAsync( CancellationToken ct ) {
+        IdLookupDepth depth = await _batchHelper.GetIdLookupDepthAsync( ct );
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        List<DateTimeOffset> candidates = [];
+
+        await AddCandidateAsync(
+            depth.BulkTrackIdCount,
+            SpotifyConstants.MaxTracksPerBatchLookup,
+            SpotifyConstants.BulkTracksEndpoint,
+            isTracks: true,
+            _trackIdCooldownUntil );
+        await AddCandidateAsync(
+            depth.BulkAlbumIdCount,
+            SpotifyConstants.MaxAlbumsPerBatchLookup,
+            SpotifyConstants.BulkAlbumsEndpoint,
+            isTracks: false,
+            _albumIdCooldownUntil );
+
+        return candidates.Count == 0 ? null : candidates.Min( );
+
+        async Task AddCandidateAsync(
+            int count,
+            int threshold,
+            string endpoint,
+            bool isTracks,
+            DateTimeOffset cooldownUntil
+        ) {
+            if (count == 0) return;
+
+            DateTimeOffset candidate = now;
+            RateLimitState rateLimit = await _rateLimitTracker.GetStateAsync(
+                SupportedProviders.Spotify, endpoint, ct );
+            if (rateLimit.IsRateLimited && rateLimit.RetryAfter is { } retryAfter && retryAfter > candidate) {
+                candidate = retryAfter;
+            }
+            if (cooldownUntil > candidate) candidate = cooldownUntil;
+
+            if (count < threshold) {
+                DateTimeOffset? oldest = await _batchHelper.GetOldestEnqueuedAtAsync( isTracks, ct );
+                if (oldest is null) {
+                    // An unparseable timestamp must not strand a low-volume batch.
+                    candidates.Add( candidate );
+                    return;
+                }
+                DateTimeOffset lingerDue = oldest.Value.Add( _batchLinger );
+                if (lingerDue > candidate) candidate = lingerDue;
+            }
+
+            candidates.Add( candidate );
+        }
     }
 
     // Pure flush predicate — extracted for testability
@@ -251,6 +330,8 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
             DateTimeOffset? oldest = await _batchHelper.GetOldestEnqueuedAtAsync( isTracks: true, ct );
             if (oldest.HasValue) {
                 oldestAge = DateTimeOffset.UtcNow - oldest.Value;
+            } else {
+                oldestAge = _batchLinger;
             }
         }
 
@@ -297,6 +378,8 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
             DateTimeOffset? oldest = await _batchHelper.GetOldestEnqueuedAtAsync( isTracks: false, ct );
             if (oldest.HasValue) {
                 oldestAge = DateTimeOffset.UtcNow - oldest.Value;
+            } else {
+                oldestAge = _batchLinger;
             }
         }
 
@@ -316,17 +399,18 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// dictionary is treated as a transient request-level failure: it arms the exponential track-id
     /// cooldown and requeues the whole batch. A present-but-<see langword="null"/> result records a
     /// not-found provider state; an absent key requeues only that message. A
-    /// <see cref="RetryAfterExceededException"/> is routed to <see cref="HandleBulkRateLimitAsync"/>.
-    /// A <see cref="SpotifyBulkRejectedException"/> (deterministic 4xx) re-enqueues each item
-    /// individually at Interactive priority and acknowledges the original bulk-stream messages so
-    /// the per-message processor handles them as single-id lookups. Any other exception requeues
-    /// the whole batch.
+    /// <see cref="ProviderRateLimitException"/> is routed to <see cref="HandleBulkRateLimitAsync"/>.
+    /// A <see cref="SpotifyBulkRejectedException"/> (deterministic 4xx) atomically transfers each
+    /// item to its origin-aware single-item lane while removing the original bulk delivery so the
+    /// per-message processor handles it individually. Any other exception requeues the whole batch.
     /// </remarks>
     internal async Task ProcessBulkTrackLookupsAsync( CancellationToken ct ) {
         LogProcessingBulkTracks( _logger );
 
         // Dequeue directly from the type-specific stream only.
         // Top-up from generic priority streams is intentionally omitted (would race the generic worker's unacked deliveries).
+        DateTimeOffset dequeueWallStart = DateTimeOffset.UtcNow;
+        Stopwatch dequeueWallTimer = Stopwatch.StartNew( );
         List<QueuedMessage<QueuedLookupRequest>> messages =
             [.. await _batchHelper.DequeueTrackIdBatchAsync( SpotifyConstants.MaxTracksPerBatchLookup, ct )];
 
@@ -351,7 +435,12 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
 
         try {
             // Call the bulk lookup API (GET /tracks?ids=...)
-            Dictionary<string, MusicLookupResult?> results = await _lookupService.GetTracksByIdsAsync( idToMessages.Keys );
+            Stopwatch httpTimer = Stopwatch.StartNew( );
+            using Activity? httpActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.provider_http" );
+            _ = (httpActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (httpActivity?.SetTag( QueueMetricTags.Priority, "bulk" ));
+            Dictionary<string, MusicLookupResult?> results;
+            try { results = await _lookupService.GetTracksByIdsAsync( idToMessages.Keys ); } finally { httpTimer.Stop( ); httpActivity?.Stop( ); QueueMetrics.ProviderHttpDuration.Record( httpTimer.Elapsed.TotalSeconds, new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ), new KeyValuePair<string, object?>( QueueMetricTags.Priority, "bulk" ) ); }
 
             // Empty dictionary = request failure (auth error, network error).
             // Requeue ALL messages without writing any saga state. Arm the request-failure
@@ -359,7 +448,7 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
             if (results.Count == 0) {
                 LogBulkDispatchRequeuingAll( _logger, messages.Count, "empty-dict (request failure)" );
                 ArmRequestFailureCooldown( ref _trackIdCooldownUntil, ref _consecutiveTrackIdFailures );
-                await RequeueAllAsync( messages, ct );
+                await RequeueAllAsync( messages, ct, dequeueWallTimer, dequeueWallStart );
                 return;
             }
 
@@ -377,22 +466,28 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
                         // Key absent from non-empty dict = partial parse failure.
                         // Requeue this individual message, no saga write.
                         LogBulkDispatchRequeuingOne( _logger, trackId, "absent key (partial parse)" );
-                        await RequeueSingleAsync( message, ct );
+                        await RequeueSingleAsync( message, ct, dequeueWallTimer, dequeueWallStart );
                     } else {
                         // key present, result may be null (genuine not-found) — correct path
-                        await ProcessBulkResultAsync( message, result, ct );
+                        await ProcessBulkResultAsync( message, result, ct, dequeueWallTimer, dequeueWallStart );
                     }
                 }
             }
 
             LogTrackLookupsSuccess( _logger, messages.Count );
-        } catch (RetryAfterExceededException ex) {
-            await HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkTracksEndpoint, ex, ct );
+        } catch (ProviderRateLimitException ex) {
+            await HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkTracksEndpoint, ex, ct, dequeueWallTimer, dequeueWallStart );
         } catch (SpotifyBulkRejectedException ex) {
-            await HandleBulkRejectionAsync( messages, ex, ct );
+            await HandleBulkRejectionAsync( messages, ex, ct, dequeueWallTimer, dequeueWallStart );
+        } catch (PostCommitAcknowledgementException) {
+            throw;
+        } catch (TerminalDlqRecoveryException) {
+            throw;
+        } catch (QueueDeliveryIdentityQuarantineException) {
+            throw;
         } catch (Exception ex) {
             LogTrackLookupsError( _logger, ex );
-            await RequeueAllAsync( messages, ct );
+            await RequeueAllAsync( messages, ct, dequeueWallTimer, dequeueWallStart );
         }
     }
 
@@ -413,6 +508,8 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
         LogProcessingBulkAlbums( _logger );
 
         // Type-specific stream only; no priority-stream top-up.
+        DateTimeOffset dequeueWallStart = DateTimeOffset.UtcNow;
+        Stopwatch dequeueWallTimer = Stopwatch.StartNew( );
         List<QueuedMessage<QueuedLookupRequest>> messages =
             [.. await _batchHelper.DequeueAlbumIdBatchAsync( SpotifyConstants.MaxAlbumsPerBatchLookup, ct )];
 
@@ -437,13 +534,18 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
 
         try {
             // Call the bulk lookup API (GET /albums?ids=...)
-            Dictionary<string, MusicLookupResult?> results = await _lookupService.GetAlbumsByIdsAsync( idToMessages.Keys );
+            Stopwatch httpTimer = Stopwatch.StartNew( );
+            using Activity? httpActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.provider_http" );
+            _ = (httpActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (httpActivity?.SetTag( QueueMetricTags.Priority, "bulk" ));
+            Dictionary<string, MusicLookupResult?> results;
+            try { results = await _lookupService.GetAlbumsByIdsAsync( idToMessages.Keys ); } finally { httpTimer.Stop( ); httpActivity?.Stop( ); QueueMetrics.ProviderHttpDuration.Record( httpTimer.Elapsed.TotalSeconds, new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ), new KeyValuePair<string, object?>( QueueMetricTags.Priority, "bulk" ) ); }
 
             // Empty dictionary = request failure → requeue ALL. Arm cooldown.
             if (results.Count == 0) {
                 LogBulkDispatchRequeuingAll( _logger, messages.Count, "empty-dict (request failure)" );
                 ArmRequestFailureCooldown( ref _albumIdCooldownUntil, ref _consecutiveAlbumIdFailures );
-                await RequeueAllAsync( messages, ct );
+                await RequeueAllAsync( messages, ct, dequeueWallTimer, dequeueWallStart );
                 return;
             }
 
@@ -460,21 +562,27 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
                     if (!keyPresent) {
                         // Absent key in non-empty dict = partial parse failure → requeue one
                         LogBulkDispatchRequeuingOne( _logger, albumId, "absent key (partial parse)" );
-                        await RequeueSingleAsync( message, ct );
+                        await RequeueSingleAsync( message, ct, dequeueWallTimer, dequeueWallStart );
                     } else {
-                        await ProcessBulkResultAsync( message, result, ct );
+                        await ProcessBulkResultAsync( message, result, ct, dequeueWallTimer, dequeueWallStart );
                     }
                 }
             }
 
             LogAlbumLookupsSuccess( _logger, messages.Count );
-        } catch (RetryAfterExceededException ex) {
-            await HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkAlbumsEndpoint, ex, ct );
+        } catch (ProviderRateLimitException ex) {
+            await HandleBulkRateLimitAsync( messages, SpotifyConstants.BulkAlbumsEndpoint, ex, ct, dequeueWallTimer, dequeueWallStart );
         } catch (SpotifyBulkRejectedException ex) {
-            await HandleBulkRejectionAsync( messages, ex, ct );
+            await HandleBulkRejectionAsync( messages, ex, ct, dequeueWallTimer, dequeueWallStart );
+        } catch (PostCommitAcknowledgementException) {
+            throw;
+        } catch (TerminalDlqRecoveryException) {
+            throw;
+        } catch (QueueDeliveryIdentityQuarantineException) {
+            throw;
         } catch (Exception ex) {
             LogAlbumLookupsError( _logger, ex );
-            await RequeueAllAsync( messages, ct );
+            await RequeueAllAsync( messages, ct, dequeueWallTimer, dequeueWallStart );
         }
     }
 
@@ -485,80 +593,193 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// <param name="message">The queued message whose saga is being updated.</param>
     /// <param name="result">The resolved result, or <see langword="null"/> when the id was not found.</param>
     /// <param name="ct">Token used to cancel the saga and publish operations.</param>
+    /// <param name="dequeueWallTimer">Timestamp started before the batch dequeue.</param>
+    /// <param name="dequeueWallStart">UTC timestamp captured immediately before the batch dequeue.</param>
     /// <returns>A task that completes once the saga is updated and the message acknowledged.</returns>
     /// <remarks>
     /// Ensures the saga exists, initializes the Spotify provider state, writes the provider result
-    /// (success when <paramref name="result"/> is non-null, otherwise a "Not found" failure), then
+    /// (success when <paramref name="result"/> is non-null, otherwise an unsuccessful leg with no
+    /// provider error message), then
     /// publishes saga-level and per-lookup completion before acknowledging. On error the message is
     /// requeued.
     /// </remarks>
     private async Task ProcessBulkResultAsync(
         QueuedMessage<QueuedLookupRequest> message,
         MusicLookupResult? result,
-        CancellationToken ct
+        CancellationToken ct,
+        Stopwatch dequeueWallTimer,
+        DateTimeOffset dequeueWallStart
     ) {
         QueuedLookupRequest request = message.Payload;
+        using Activity? wallActivity = StartHistoricalActivity( "queue.spotify.message.wall", dequeueWallStart );
+        _ = (wallActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+        _ = (wallActivity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+        bool legUpdated = false;
 
         try {
+            // Admit only the saga instance that owns this queued lookup. Bulk messages can outlive
+            // a saga replacement; creating or mutating a mismatched hash would cross-contaminate
+            // records. Producers create and fence the saga before publishing the delivery.
+            string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
+            LookupSagaState? saga = await _sagaManager.GetAsync( request.SagaId, ct );
+            if (saga is null) {
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace( request.SagaInstanceToken )
+                || !string.Equals( request.SagaInstanceToken, saga.InstanceToken, StringComparison.Ordinal )) {
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+
+            bool rootIdentityMatches = string.Equals( saga.LookupKey, lookupKey, StringComparison.Ordinal )
+                && saga.LookupType == request.LookupType
+                && string.Equals( saga.LookupValue, request.LookupValue, StringComparison.Ordinal );
+            bool initializedSpotifyLeg = saga.ProviderStates.TryGetValue( SupportedProviders.Spotify, out ProviderLookupState? spotifyState )
+                && !spotifyState.IsComplete;
+            if (saga.ProviderStates.TryGetValue( SupportedProviders.Spotify, out ProviderLookupState? completedSpotifyState )
+                && completedSpotifyState.IsComplete) {
+                if (completedSpotifyState.ErrorMessage is not null) {
+                    try {
+                        await _requestQueue.MoveToDlqAsync(
+                            message.MessageId,
+                            completedSpotifyState.ErrorMessage,
+                            ct );
+                    } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                        throw;
+                    } catch (Exception ex) {
+                        throw new TerminalDlqRecoveryException( message.MessageId, ex );
+                    }
+                    QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, message.Priority, "dlq_recovery" );
+                    return;
+                }
+                // A lost ACK can redeliver a child after its active Spotify leg was committed.
+                // Clear only this stale delivery; never re-query or mutate the completed leg.
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
+            if (!rootIdentityMatches && !initializedSpotifyLeg) {
+                await QuarantineBulkMessageAsync( message, "Saga identity does not match queued request.", ct );
+                return;
+            }
+
+            string instanceToken = request.SagaInstanceToken!;
+
             if (result is null
                 && request.FallbackLookupType is not null
                 && !string.IsNullOrWhiteSpace( request.FallbackLookupValue )) {
                 result = request.FallbackLookupType.Value switch {
                     LookupRequestType.IsrcLookup =>
-                        await _lookupService.GetInfoByISRCAsync( request.FallbackLookupValue ),
+                        await GetFallbackResultAsync( request, LookupRequestType.IsrcLookup, message.Priority, ct ),
                     LookupRequestType.UpcLookup =>
-                        await _lookupService.GetInfoByUPCAsync( request.FallbackLookupValue ),
+                        await GetFallbackResultAsync( request, LookupRequestType.UpcLookup, message.Priority, ct ),
                     _ => throw new InvalidOperationException(
                         $"Unsupported Spotify bulk fallback type {request.FallbackLookupType.Value}." )
                 };
             }
 
-            // Ensure the saga exists. JetStream fire-and-forget messages pre-compute a
-            // SagaId and enqueue without creating the saga (the generic worker normally does
-            // this). GetOrCreateAsync is idempotent — if the saga already exists it returns it.
-            // Use LookupKeyBuilder so the lookupKey matches the orchestrator format for typed ID lookups.
-            string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
-            _ = await _sagaManager.GetOrCreateAsync(
-                request.SagaId,
-                lookupKey,
-                request.LookupType,
-                request.LookupValue,
-                request.OriginPriority,
-                ct
-            );
-
             // Allocate the Spotify provider slot in the saga (idempotent)
-            await _sagaManager.InitializeProviderStatesAsync( request.SagaId, [SupportedProviders.Spotify], ct );
+            if (!await _sagaManager.TryInitializeProviderStatesAsync(
+                request.SagaId, [SupportedProviders.Spotify], instanceToken, ct )) {
+                await AcknowledgeStaleDeliveryAsync( message, ct );
+                return;
+            }
 
             // Write the lookup result (found or not-found)
-            await _sagaManager.UpdateProviderStateAsync(
-                request.SagaId,
-                new ProviderLookupState(
-                    Provider: SupportedProviders.Spotify,
-                    IsComplete: true,
-                    IsSuccess: result is not null,
-                    ResultJson: result is not null ? JsonSerializer.Serialize( result, _jsonOptions ) : null,
-                    CompletedAt: DateTimeOffset.UtcNow,
-                    ErrorMessage: result is null ? "Not found" : null
-                ),
-                ct
-            );
+            Stopwatch sagaTimer = Stopwatch.StartNew( );
+            using Activity? sagaActivity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.saga.update" );
+            _ = (sagaActivity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+            _ = (sagaActivity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+            try {
+                if (!await _sagaManager.TryUpdateProviderStateAsync(
+                    request.SagaId,
+                    new ProviderLookupState(
+                        Provider: SupportedProviders.Spotify,
+                        IsComplete: true,
+                        IsSuccess: result is not null,
+                        ResultJson: result is not null ? JsonSerializer.Serialize( result, _jsonOptions ) : null,
+                        CompletedAt: DateTimeOffset.UtcNow,
+                        ErrorMessage: null
+                    ),
+                    instanceToken,
+                    ct )) {
+                    await AcknowledgeStaleDeliveryAsync( message, ct );
+                    return;
+                }
+                legUpdated = true;
+            } finally {
+                sagaTimer.Stop( );
+                sagaActivity?.Stop( );
+                QueueMetrics.SagaUpdateDuration.Record( sagaTimer.Elapsed.TotalSeconds,
+                    new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                    new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+            }
 
-            // Check if saga is complete and publish completion events
-            await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
-            await PublishLookupCompletionAsync( request.SagaId, ct );
+            // The coordinator performs the authoritative completeness check. Publishing the saga id
+            // is a durable-progress hint and needs no fallible post-commit saga reread.
+            try {
+                await PublishSagaProgressAsync( request.SagaId );
+            } catch (Exception ex) {
+                // Provider state is already committed. Do not route this delivery through the
+                // ordinary lookup retry path, which could overwrite the successful leg at cap.
+                // Leave the delivery pending; reconciliation can publish completion and a
+                // redelivery can safely acknowledge the already-complete leg.
+                throw new PostCommitAcknowledgementException( message.MessageId, ex );
+            }
 
-            // Acknowledge the message
-            await _batchHelper.AcknowledgeAsync( message.MessageId );
+            // Acknowledge only after the provider state and completion publishes are committed.
+            // If XACK fails, leave the original PEL delivery pending for worker recovery; do not
+            // send the already-committed result through the ordinary retry/cap mutation path.
+            try {
+                await _batchHelper.AcknowledgeAsync( message.MessageId );
+                QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, message.Priority, "success" );
+            } catch (Exception ex) {
+                throw new PostCommitAcknowledgementException( message.MessageId, ex );
+            }
 
             LogBulkResultProcessed( _logger, request.SagaId, result is not null ? "found" : "not found" );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (UnreadableSagaStateException ex) {
+            await QuarantineBulkMessageAsync( message, ex.Message, ct );
+        } catch (PostCommitAcknowledgementException) {
+            throw;
+        } catch (TerminalDlqRecoveryException) {
+            throw;
+        } catch (QueueDeliveryIdentityQuarantineException) {
+            throw;
         } catch (Exception ex) {
             LogBulkResultError( _logger, ex, request.SagaId );
-            await RequeueSingleAsync( message, ct );
+            await RequeueSingleAsync( message, ct, dequeueWallTimer, dequeueWallStart, recordWall: false );
+        } finally {
+            wallActivity?.Stop( );
+            QueueMetrics.MessageWallDuration.Record( dequeueWallTimer.Elapsed.TotalSeconds,
+                new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+            if (legUpdated) {
+                QueueMetrics.RecordSagaLegCompleted( SupportedProviders.Spotify, message.Priority, "committed" );
+            }
         }
     }
 
     // Rate-limit and requeue helpers
+
+    private async Task QuarantineBulkMessageAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        string reason,
+        CancellationToken ct
+    ) {
+        try {
+            await _requestQueue.MoveToDlqAsync( message.MessageId, reason, ct );
+            QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, message.Priority, "identity_quarantine" );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) {
+            LogBulkResultError( _logger, ex, message.Payload.SagaId );
+            throw new QueueDeliveryIdentityQuarantineException( message.MessageId, message.Payload.SagaId, ex );
+        }
+    }
 
     /// <summary>
     /// Handles a bulk-endpoint rate limit by recording it, marking each affected saga partial, and
@@ -568,6 +789,8 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// <param name="endpoint">The bulk endpoint that was rate-limited.</param>
     /// <param name="ex">The exception carrying the retry-after value.</param>
     /// <param name="ct">Token used to cancel the work.</param>
+    /// <param name="dequeueWallTimer">Timestamp started before the batch dequeue.</param>
+    /// <param name="dequeueWallStart">UTC timestamp captured immediately before the batch dequeue.</param>
     /// <returns>A task that completes once all sagas are marked and the batch requeued.</returns>
     /// <remarks>
     /// Sets the endpoint rate limit in the tracker, then for each message marks its saga partial,
@@ -578,58 +801,121 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     internal async Task HandleBulkRateLimitAsync(
         IReadOnlyList<QueuedMessage<QueuedLookupRequest>> messages,
         string endpoint,
-        RetryAfterExceededException ex,
-        CancellationToken ct
+        ProviderRateLimitException ex,
+        CancellationToken ct,
+        Stopwatch? dequeueWallTimer = null,
+        DateTimeOffset? dequeueWallStart = null
     ) {
+        dequeueWallTimer ??= Stopwatch.StartNew( );
+        dequeueWallStart ??= DateTimeOffset.UtcNow;
         LogRateLimitEncountered( _logger, endpoint, ex.RetryAfterValue.ToString( ) );
 
-        DateTimeOffset retryAfter = DateTimeOffset.UtcNow.Add( ex.RetryAfterValue );
-        await _rateLimitTracker.SetRateLimitedAsync( SupportedProviders.Spotify, endpoint, retryAfter, ct );
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TimeSpan boundedRetry = TimeSpan.FromTicks( Math.Min( ex.RetryAfterValue.Ticks, (DateTimeOffset.MaxValue - now).Ticks ) );
+        DateTimeOffset retryAfter = now.Add( boundedRetry );
+        List<QueuedMessage<QueuedLookupRequest>> admittedMessages = [];
+        HashSet<string> wallRecordedMessageIds = [];
 
-        // SetIsPartialAsync + merge SetRateLimitInfoAsync + publish rate-limited sentinel so
-        // interactive callers whose request lands in a bulk batch do not hang until timeout on a 429.
-        foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
-            if (ct.IsCancellationRequested) { break; }
-            QueuedLookupRequest request = message.Payload;
-            try {
-                // Ensure the saga hash exists before writing provider state — JetStream fire-and-forget items pre-compute a SagaId without creating the saga.
-                string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
-                _ = await _sagaManager.GetOrCreateAsync( request.SagaId, lookupKey, request.LookupType, request.LookupValue, request.OriginPriority, ct );
+        try {
+            await _rateLimitTracker.SetRateLimitedAsync( SupportedProviders.Spotify, endpoint, retryAfter, ct );
 
-                await _sagaManager.SetIsPartialAsync( request.SagaId, true, ct );
+            // SetIsPartialAsync + merge SetRateLimitInfoAsync + publish rate-limited sentinel so
+            // interactive callers whose request lands in a bulk batch do not hang until timeout on a 429.
+            foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
+                if (ct.IsCancellationRequested) { break; }
+                QueuedLookupRequest request = message.Payload;
+                try {
+                    string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
+                    LookupSagaState? saga = await _sagaManager.GetAsync( request.SagaId, ct );
+                    if (saga is null) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        continue;
+                    }
+                    if (string.IsNullOrWhiteSpace( saga.InstanceToken )) {
+                        await QuarantineBulkMessageAsync( message, "Saga instance is missing or invalid.", ct );
+                        continue;
+                    }
+                    string instanceToken = saga.InstanceToken;
+                    if (string.IsNullOrWhiteSpace( request.SagaInstanceToken )
+                        || !string.Equals( request.SagaInstanceToken, instanceToken, StringComparison.Ordinal )) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        continue;
+                    }
+                    bool rootIdentityMatches = string.Equals( saga.LookupKey, lookupKey, StringComparison.Ordinal )
+                        && saga.LookupType == request.LookupType
+                        && string.Equals( saga.LookupValue, request.LookupValue, StringComparison.Ordinal );
+                    bool initializedSpotifyLeg = saga.ProviderStates.TryGetValue( SupportedProviders.Spotify, out ProviderLookupState? spotifyState )
+                        && !spotifyState.IsComplete;
+                    if (!rootIdentityMatches && !initializedSpotifyLeg) {
+                        await QuarantineBulkMessageAsync( message, "Saga identity does not match queued request.", ct );
+                        continue;
+                    }
 
-                LookupSagaState? saga = await _sagaManager.GetAsync( request.SagaId, ct );
-                List<ProviderRateLimitInfo> mergedRateLimitInfo = saga?.RateLimitInfo is not null
-                    ? [.. saga.RateLimitInfo.Where( r => r.Provider != SupportedProviders.Spotify )]
-                    : [];
-                mergedRateLimitInfo.Add( new ProviderRateLimitInfo( SupportedProviders.Spotify, retryAfter, endpoint ) );
-                await _sagaManager.SetRateLimitInfoAsync( request.SagaId, mergedRateLimitInfo, ct );
+                    if (!await _sagaManager.TrySetIsPartialAsync( request.SagaId, true, instanceToken, ct )) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        continue;
+                    }
 
-                await PublishRateLimitSentinelAsync( request.SagaId, ct );
+                    List<ProviderRateLimitInfo> mergedRateLimitInfo = saga?.RateLimitInfo is not null
+                        ? [.. saga.RateLimitInfo.Where( r => r.Provider != SupportedProviders.Spotify )]
+                        : [];
+                    mergedRateLimitInfo.Add( new ProviderRateLimitInfo( SupportedProviders.Spotify, retryAfter, endpoint ) );
+                    if (!await _sagaManager.TrySetRateLimitInfoAsync( request.SagaId, mergedRateLimitInfo, instanceToken, ct )) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        continue;
+                    }
 
-                LogBulkSagaMarkedPartial( _logger, request.SagaId, endpoint, retryAfter );
-            } catch (Exception sagaEx) {
-                LogBulkResultError( _logger, sagaEx, request.SagaId );
+                    await PublishRateLimitSentinelAsync( request.SagaId, instanceToken, ct );
+                    admittedMessages.Add( message );
+
+                    LogBulkSagaMarkedPartial( _logger, request.SagaId, endpoint, retryAfter );
+                } catch (PostCommitAcknowledgementException) {
+                    throw;
+                } catch (TerminalDlqRecoveryException) {
+                    throw;
+                } catch (QueueDeliveryIdentityQuarantineException) {
+                    throw;
+                } catch (Exception sagaEx) {
+                    LogBulkResultError( _logger, sagaEx, request.SagaId );
+                }
+            }
+
+            // Requeue admitted messages (with AttemptCount increment via RequeueAsync). Each
+            // admitted message owns its wall sample in RequeueSingleAsync.
+            await RequeueAllAsync(
+                admittedMessages,
+                ct,
+                dequeueWallTimer,
+                dequeueWallStart.Value,
+                wallRecordedMessageIds );
+        } finally {
+            // Quarantined, stale, failed, and cancellation-skipped messages never reach
+            // RequeueSingleAsync. Close the telemetry obligation for every dequeued message here,
+            // while the set prevents a duplicate sample for admitted messages already requeued.
+            foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
+                if (wallRecordedMessageIds.Add( message.MessageId )) {
+                    RecordMessageWall( message, dequeueWallTimer, dequeueWallStart.Value );
+                }
             }
         }
-
-        // Requeue all messages (with AttemptCount increment via RequeueAsync)
-        await RequeueAllAsync( messages, ct );
     }
 
     /// <summary>
-    /// Handles a deterministic 4xx bulk rejection by re-enqueueing each message individually at
-    /// Interactive priority, then acknowledging the original bulk-stream messages.
+    /// Handles a deterministic 4xx bulk rejection by atomically transferring each message to the
+    /// origin-aware single-item stream and removing the original bulk-stream delivery.
     /// </summary>
     /// <param name="messages">The messages whose bulk batch was rejected by the API.</param>
     /// <param name="ex">The exception carrying the HTTP status code of the rejection.</param>
     /// <param name="ct">Token used to stop early.</param>
-    /// <returns>A task that completes once all items are re-enqueued and acknowledged.</returns>
+    /// <param name="dequeueWallTimer">Timestamp started before the batch dequeue.</param>
+    /// <param name="dequeueWallStart">UTC timestamp captured immediately before the batch dequeue.</param>
+    /// <returns>A task that completes once all item transfers have been attempted.</returns>
     /// <remarks>
     /// A 4xx rejection is data-dependent: the batch contains at least one id the API cannot
-    /// accept. Re-enqueueing individually at Interactive lets the per-message processor
-    /// resolve each id with a single-id call so the poison id is isolated without penalizing
-    /// the remaining ids. AttemptCount is carried unchanged — the 4xx is a route change, not
+    /// accept. Re-enqueueing individually lets the per-message processor resolve each id with a
+    /// single-id call so the poison id is isolated without penalizing the remaining ids. Manual
+    /// interactive work remains interactive; maintenance work remains background. AttemptCount is
+    /// carried unchanged — the 4xx is a route change, not
     /// a failed lookup attempt. No cooldown is armed and no saga state is written; the
     /// per-message processor owns those on the next attempt. ArmRequestFailureCooldown is
     /// intentionally NOT called on this path.
@@ -637,22 +923,33 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     internal async Task HandleBulkRejectionAsync(
         IReadOnlyList<QueuedMessage<QueuedLookupRequest>> messages,
         SpotifyBulkRejectedException ex,
-        CancellationToken ct
+        CancellationToken ct,
+        Stopwatch? dequeueWallTimer = null,
+        DateTimeOffset? dequeueWallStart = null
     ) {
+        dequeueWallTimer ??= Stopwatch.StartNew( );
+        dequeueWallStart ??= DateTimeOffset.UtcNow;
         LogBulkBatchRejected( _logger, ex.HttpStatusCode, messages.Count );
 
         foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
             if (ct.IsCancellationRequested) { break; }
             try {
-                // Re-enqueue the original payload unchanged (preserves SagaId, LookupType,
-                // LookupValue, OriginPriority, AttemptCount) at Interactive priority so the
-                // SpotifyBulkQueueDecorator passes it straight through to the inner queue.
-                await _requestQueue.EnqueueAsync( message.Payload, QueuePriority.Interactive, ct );
-
-                // Acknowledge the original bulk-stream message now that a replacement is enqueued.
-                await _batchHelper.AcknowledgeAsync( message.MessageId );
+                // The helper performs XADD + XACK + XDEL atomically and checks source existence,
+                // so an ambiguous response or redelivery cannot create duplicate replacements.
+                _ = await _batchHelper.ForwardToSingleItemAsync( message, ct );
             } catch (Exception itemEx) {
                 LogRequeueError( _logger, itemEx, message.MessageId );
+                // Keep forward failures bounded. The atomic bulk requeue increments the attempt
+                // count; a persistent destination failure therefore reaches the normal cap rather
+                // than leaving one PEL entry to fail every reclaim window forever.
+                await RequeueSingleAsync(
+                    message,
+                    ct,
+                    dequeueWallTimer,
+                    dequeueWallStart.Value,
+                    recordWall: false );
+            } finally {
+                RecordMessageWall( message, dequeueWallTimer, dequeueWallStart.Value );
             }
         }
     }
@@ -662,15 +959,26 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// </summary>
     /// <param name="messages">The messages to requeue.</param>
     /// <param name="ct">Token used to stop requeuing early.</param>
+    /// <param name="dequeueWallTimer">Timestamp started before the batch dequeue.</param>
+    /// <param name="dequeueWallStart">UTC timestamp captured immediately before the batch dequeue.</param>
+    /// <param name="wallRecordedMessageIds">Optional set used to prevent duplicate wall samples.</param>
     /// <returns>A task that completes once all messages have been attempted.</returns>
     private async Task RequeueAllAsync(
         IReadOnlyList<QueuedMessage<QueuedLookupRequest>> messages,
-        CancellationToken ct
+        CancellationToken ct,
+        Stopwatch dequeueWallTimer,
+        DateTimeOffset dequeueWallStart,
+        HashSet<string>? wallRecordedMessageIds = null
     ) {
         foreach (QueuedMessage<QueuedLookupRequest> message in messages) {
             if (ct.IsCancellationRequested) { break; }
             try {
-                await RequeueSingleAsync( message, ct );
+                await RequeueSingleAsync( message, ct, dequeueWallTimer, dequeueWallStart,
+                    wallRecordedMessageIds: wallRecordedMessageIds );
+            } catch (PostCommitAcknowledgementException) {
+                throw;
+            } catch (QueueDeliveryIdentityQuarantineException) {
+                throw;
             } catch (Exception ex) {
                 LogRequeueError( _logger, ex, message.MessageId );
             }
@@ -682,6 +990,10 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// </summary>
     /// <param name="message">The message to requeue.</param>
     /// <param name="ct">Token used to cancel the work.</param>
+    /// <param name="dequeueWallTimer">Timestamp started before the batch dequeue.</param>
+    /// <param name="dequeueWallStart">UTC timestamp captured immediately before the batch dequeue.</param>
+    /// <param name="recordWall">Whether this helper owns the terminal wall sample.</param>
+    /// <param name="wallRecordedMessageIds">Optional set used to prevent duplicate wall samples.</param>
     /// <returns>A task that completes once the message is requeued or its saga is finalized.</returns>
     /// <remarks>
     /// When <see cref="SpotifyBatchQueueHelper.RequeueAsync"/> returns
@@ -689,39 +1001,148 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// saga-level and per-lookup completion are published so the lookup does not hang. Other outcomes
     /// require no further action here.
     /// </remarks>
-    private async Task RequeueSingleAsync( QueuedMessage<QueuedLookupRequest> message, CancellationToken ct ) {
+    private async Task RequeueSingleAsync(
+        QueuedMessage<QueuedLookupRequest> message,
+        CancellationToken ct,
+        Stopwatch dequeueWallTimer,
+        DateTimeOffset dequeueWallStart,
+        bool recordWall = true,
+        HashSet<string>? wallRecordedMessageIds = null
+    ) {
         QueuedLookupRequest request = message.Payload;
-        RequeueOutcome outcome = await _batchHelper.RequeueAsync( message.MessageId, request.SagaId, ct );
+        try {
+            RequeueOutcome outcome = await _batchHelper.RequeueAsync( message.MessageId, request.SagaId, ct );
 
-        if (outcome == RequeueOutcome.CapReached) {
-            // Cap hit or unrecoverable payload — write the failed provider state and
-            // publish completion so the saga coordinator and interactive waiters unblock.
-            try {
-                // Ensure the saga hash exists before writing provider state — JetStream fire-and-forget items pre-compute a SagaId without creating the saga.
-                string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
-                _ = await _sagaManager.GetOrCreateAsync( request.SagaId, lookupKey, request.LookupType, request.LookupValue, request.OriginPriority, ct );
+            if (outcome == RequeueOutcome.CapReached) {
+                // Cap hit or unrecoverable payload — write the failed provider state and
+                // publish completion so the saga coordinator and interactive waiters unblock.
+                try {
+                    string lookupKey = LookupKeyBuilder.TypedKey( request.LookupType, SupportedProviders.Spotify, request.LookupValue );
+                    LookupSagaState? saga = await _sagaManager.GetAsync( request.SagaId, ct );
+                    if (saga is null) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        return;
+                    }
+                    if (string.IsNullOrWhiteSpace( saga.InstanceToken )) {
+                        await QuarantineBulkMessageAsync( message, "Saga instance is missing or invalid.", ct );
+                        return;
+                    }
+                    string instanceToken = saga.InstanceToken;
+                    if (string.IsNullOrWhiteSpace( request.SagaInstanceToken )
+                        || !string.Equals( request.SagaInstanceToken, instanceToken, StringComparison.Ordinal )) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        return;
+                    }
+                    bool rootIdentityMatches = string.Equals( saga.LookupKey, lookupKey, StringComparison.Ordinal )
+                        && saga.LookupType == request.LookupType
+                        && string.Equals( saga.LookupValue, request.LookupValue, StringComparison.Ordinal );
+                    bool initializedSpotifyLeg = saga.ProviderStates.TryGetValue( SupportedProviders.Spotify, out ProviderLookupState? spotifyState )
+                        && !spotifyState.IsComplete;
+                    if (!rootIdentityMatches && !initializedSpotifyLeg) {
+                        await QuarantineBulkMessageAsync( message, "Saga identity does not match queued request.", ct );
+                        return;
+                    }
 
-                await _sagaManager.UpdateProviderStateAsync(
-                    request.SagaId,
-                    new ProviderLookupState(
-                        Provider: SupportedProviders.Spotify,
-                        IsComplete: true,
-                        IsSuccess: false,
-                        ResultJson: null,
-                        CompletedAt: DateTimeOffset.UtcNow,
-                        ErrorMessage: $"Bulk lookup failed after {LookupConstants.MaxQueueRetryAttempts} attempts"
-                    ),
-                    ct
-                );
-                await CheckAndPublishSagaCompletionAsync( request.SagaId, ct );
-                await PublishLookupCompletionAsync( request.SagaId, ct );
-            } catch (Exception ex) {
-                LogBulkResultError( _logger, ex, request.SagaId );
+                    if (!await _sagaManager.TryUpdateProviderStateAsync(
+                        request.SagaId,
+                        new ProviderLookupState(
+                            Provider: SupportedProviders.Spotify,
+                            IsComplete: true,
+                            IsSuccess: false,
+                            ResultJson: null,
+                            CompletedAt: DateTimeOffset.UtcNow,
+                            ErrorMessage: $"Bulk lookup failed after {LookupConstants.MaxQueueRetryAttempts} attempts"
+                        ),
+                        instanceToken,
+                        ct )) {
+                        await AcknowledgeStaleDeliveryAsync( message, ct );
+                        return;
+                    }
+                    try {
+                        await PublishSagaProgressAsync( request.SagaId );
+                    } catch (Exception ex) {
+                        throw new PostCommitAcknowledgementException( message.MessageId, ex );
+                    }
+                    try {
+                        await _requestQueue.MoveToDlqAsync(
+                            message.MessageId,
+                            $"Bulk lookup failed after {LookupConstants.MaxQueueRetryAttempts} attempts",
+                            ct );
+                    } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                        throw;
+                    } catch (Exception ex) {
+                        throw new TerminalDlqRecoveryException( message.MessageId, ex );
+                    }
+                    QueueMetrics.RecordSagaLegCompleted(
+                        SupportedProviders.Spotify,
+                        message.Priority,
+                        "committed_failure" );
+                } catch (PostCommitAcknowledgementException) {
+                    throw;
+                } catch (TerminalDlqRecoveryException) {
+                    throw;
+                } catch (QueueDeliveryIdentityQuarantineException) {
+                    throw;
+                } catch (Exception ex) {
+                    LogBulkResultError( _logger, ex, request.SagaId );
+                }
+            }
+            // RequeueOutcome.NotFound: entry already XDELed — another consumer processed it.
+            // Leave the saga untouched; logging was done inside RequeueAsync.
+            // RequeueOutcome.Requeued: nothing to do here.
+        } finally {
+            if (recordWall) {
+                RecordMessageWall( message, dequeueWallTimer, dequeueWallStart );
+                _ = (wallRecordedMessageIds?.Add( message.MessageId ));
             }
         }
-        // RequeueOutcome.NotFound: entry already XDELed — another consumer processed it.
-        // Leave the saga untouched; logging was done inside RequeueAsync.
-        // RequeueOutcome.Requeued: nothing to do here.
+    }
+
+    private async Task<MusicLookupResult?> GetFallbackResultAsync(
+        QueuedLookupRequest request,
+        LookupRequestType fallbackType,
+        QueuePriority priority,
+        CancellationToken ct
+    ) {
+        Stopwatch timer = Stopwatch.StartNew( );
+        ct.ThrowIfCancellationRequested( );
+        Activity? activity = QueueMetrics.ActivitySource.StartActivity( "queue.spotify.provider_http" );
+        _ = (activity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+        _ = (activity?.SetTag( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ));
+        try {
+            return fallbackType switch {
+                LookupRequestType.IsrcLookup => await _lookupService.GetInfoByISRCAsync( request.FallbackLookupValue! ),
+                LookupRequestType.UpcLookup => await _lookupService.GetInfoByUPCAsync( request.FallbackLookupValue! ),
+                _ => throw new InvalidOperationException( $"Unsupported Spotify bulk fallback type {fallbackType}." )
+            };
+        } finally {
+            timer.Stop( );
+            activity?.Stop( );
+            QueueMetrics.ProviderHttpDuration.Record( timer.Elapsed.TotalSeconds,
+                new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+                new KeyValuePair<string, object?>( QueueMetricTags.Priority, priority.ToString( ).ToLowerInvariant( ) ) );
+        }
+    }
+
+    private static void RecordMessageWall(
+        QueuedMessage<QueuedLookupRequest> message,
+        Stopwatch dequeueWallTimer,
+        DateTimeOffset dequeueWallStart
+    ) {
+        Activity? activity = StartHistoricalActivity( "queue.spotify.message.wall", dequeueWallStart );
+        _ = (activity?.SetTag( QueueMetricTags.Provider, "spotify" ));
+        _ = (activity?.SetTag( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ));
+        activity?.Stop( );
+        QueueMetrics.MessageWallDuration.Record( dequeueWallTimer.Elapsed.TotalSeconds,
+            new KeyValuePair<string, object?>( QueueMetricTags.Provider, "spotify" ),
+            new KeyValuePair<string, object?>( QueueMetricTags.Priority, message.Priority.ToString( ).ToLowerInvariant( ) ) );
+    }
+
+    private static Activity? StartHistoricalActivity( string name, DateTimeOffset startTime ) {
+        Activity? activity = QueueMetrics.ActivitySource.CreateActivity( name, ActivityKind.Internal );
+        if (activity is null) return null;
+        _ = activity.SetStartTime( startTime.UtcDateTime );
+        return activity.Start( );
     }
 
     /// <summary>
@@ -760,30 +1181,41 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
 
     // Saga completion and pub/sub helpers
 
+    private async Task PublishSagaProgressAsync( string sagaId ) {
+        ISubscriber subscriber = _redis.GetSubscriber( );
+        _ = await subscriber.PublishAsync( RedisChannel.Literal( SagaCompletedChannel ), sagaId );
+    }
+
     /// <summary>
     /// Publishes a saga-level completion event when the saga is complete and not yet finalized.
     /// </summary>
     /// <param name="sagaId">The saga to check and publish for.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Token used to cancel the saga read.</param>
     /// <returns>A task that completes once the check (and any publish) finishes.</returns>
     /// <remarks>
     /// No event is published when the saga is missing, not yet complete, or already has a final result
     /// uri. Errors are logged and swallowed so a publish failure does not abort batch processing.
     /// </remarks>
-    private async Task CheckAndPublishSagaCompletionAsync( string sagaId, CancellationToken ct ) {
+    private async Task<LookupSagaState?> CheckAndPublishSagaCompletionAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
-            if (saga is null || !saga.IsComplete || !string.IsNullOrEmpty( saga.FinalResultUri )) {
-                return;
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) {
+                return null;
+            }
+            if (!saga.IsComplete || !string.IsNullOrEmpty( saga.FinalResultUri )) {
+                return saga;
             }
 
             LogSagaComplete( _logger, sagaId );
 
             ISubscriber subscriber = _redis.GetSubscriber( );
             _ = await subscriber.PublishAsync( RedisChannel.Literal( SagaCompletedChannel ), sagaId );
+            return saga;
         } catch (Exception ex) {
             LogSagaCompletionCheckError( _logger, ex, sagaId );
+            return null;
         }
     }
 
@@ -791,6 +1223,7 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// Publishes a per-lookup completion event so synchronous waiters on the lookup are woken.
     /// </summary>
     /// <param name="sagaId">The saga whose lookup completion is published.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Token used to cancel the saga read.</param>
     /// <returns>A task that completes once the event is published.</returns>
     /// <remarks>
@@ -798,11 +1231,11 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// the <c>complete:{lookupKey}</c> channel. Nothing is published when the saga is missing; errors
     /// are logged and swallowed.
     /// </remarks>
-    private async Task PublishLookupCompletionAsync( string sagaId, CancellationToken ct ) {
+    private async Task PublishLookupCompletionAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
 
-            if (saga is null) {
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) {
                 return;
             }
 
@@ -820,19 +1253,31 @@ public sealed partial class SpotifyBulkProcessorService : BackgroundService {
     /// was deferred rather than completed.
     /// </summary>
     /// <param name="sagaId">The saga whose lookup is rate-limited.</param>
+    /// <param name="expectedInstanceToken">The saga instance fence.</param>
     /// <param name="ct">Token used to cancel the saga read.</param>
     /// <returns>A task that completes once the sentinel is published.</returns>
     /// <remarks>Nothing is published when the saga is missing; errors are logged and swallowed.</remarks>
-    private async Task PublishRateLimitSentinelAsync( string sagaId, CancellationToken ct ) {
+    private async Task PublishRateLimitSentinelAsync( string sagaId, string expectedInstanceToken, CancellationToken ct ) {
         try {
             LookupSagaState? saga = await _sagaManager.GetAsync( sagaId, ct );
-            if (saga is null) { return; }
+            if (saga is null || saga.InstanceToken != expectedInstanceToken) { return; }
 
             string channel = $"{LookupCompleteChannelPrefix}{saga.LookupKey}";
             ISubscriber subscriber = _redis.GetSubscriber( );
             _ = await subscriber.PublishAsync( RedisChannel.Literal( channel ), LookupConstants.RateLimitedSentinel );
         } catch (Exception ex) {
             LogBulkPublishRateLimitSentinelError( _logger, ex, sagaId );
+        }
+    }
+
+    private async Task AcknowledgeStaleDeliveryAsync( QueuedMessage<QueuedLookupRequest> message, CancellationToken ct ) {
+        try {
+            await _batchHelper.AcknowledgeAsync( message.MessageId );
+            QueueMetrics.RecordTerminalOutcome( SupportedProviders.Spotify, message.Priority, "stale_delivery" );
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
+        } catch (Exception ex) {
+            throw new PostCommitAcknowledgementException( message.MessageId, ex );
         }
     }
 

--- a/src/BridgeBeats.Worker.Spotify/packages.lock.json
+++ b/src/BridgeBeats.Worker.Spotify/packages.lock.json
@@ -56,35 +56,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -251,32 +251,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -477,42 +477,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -554,8 +554,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -574,7 +574,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"

--- a/src/BridgeBeats.Worker.Tidal/packages.lock.json
+++ b/src/BridgeBeats.Worker.Tidal/packages.lock.json
@@ -56,35 +56,35 @@
       },
       "idunno.AtProto": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "2c58YetcEjktBmu6lYzxKJRyqp6/6nATBjuNxyDPMfYL+dB4S6GQimqducAYFzDQOdv6468QYp99qv0TBji92g==",
+        "resolved": "3.1.0",
+        "contentHash": "OGyxErD82RXt4IOWFeSXgW2fWjLsj+PClt20L2UwW5M7shUy2gN/GS7fCoN6mWh9oCYddKagju5DOhT+t/kyoQ==",
         "dependencies": {
           "DnsClient": "1.8.0",
           "Duende.IdentityModel.OidcClient": "7.1.0",
           "Duende.IdentityModel.OidcClient.Extensions": "7.1.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "8.19.1",
-          "OpenTelemetry.Extensions.Hosting": "1.16.0",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
+          "OpenTelemetry.Extensions.Hosting": "1.17.0",
           "PeterO.Cbor": "4.5.5",
-          "SimpleBase": "5.6.1",
+          "SimpleBase": "5.6.3",
           "ZstdSharp.Port": "0.8.8",
-          "idunno.AtProto.Types": "3.0.0",
-          "idunno.Security.Ssrf": "5.3.0"
+          "idunno.AtProto.Types": "3.1.0",
+          "idunno.Security.Ssrf": "5.4.0"
         }
       },
       "idunno.AtProto.Types": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "y25DNCgzpey3qjHbCnP6bgI0229JHQXtuv6/fr69H731YcQ3JDrQ5BTTS16DsdxIyNz51XGZIURWdStwTIydmQ==",
+        "resolved": "3.1.0",
+        "contentHash": "iNszVvNsVX69vZu9MfEAuUJnp2OQHSoYoE24A/K49Hiy3GzOEclQDWAKzmodPGm2LtKYYQgXgcOYYheDfC8x0g==",
         "dependencies": {
-          "SimpleBase": "5.6.1"
+          "SimpleBase": "5.6.3"
         }
       },
       "idunno.Bluesky": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "43iK2fIvykGlllrxU3otcacftGeOqWYyXBpBkP7KghzjSuF/t7dSDzLcLLZKYKWoz7s8z70KAn7NRYsMRSM4QQ==",
+        "resolved": "3.1.0",
+        "contentHash": "7rfcR6nhPejIAhg/eEppR0lbZzVRY42FCh/cqDeBYYZqwn5JLK1ELVNsSB6aoY4rovwf8Ajc+8FzkE5isNAqfQ==",
         "dependencies": {
-          "idunno.AtProto": "3.0.0"
+          "idunno.AtProto": "3.1.0"
         }
       },
       "idunno.Security.Ssrf": {
@@ -251,32 +251,32 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+        "resolved": "8.21.0",
+        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "resolved": "8.21.0",
+        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.19.1"
+          "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "resolved": "8.21.0",
+        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+          "Microsoft.IdentityModel.Abstractions": "8.21.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.19.1",
-        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "resolved": "8.21.0",
+        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.19.1"
+          "Microsoft.IdentityModel.Logging": "8.21.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -477,42 +477,42 @@
       },
       "SimpleBase": {
         "type": "Transitive",
-        "resolved": "5.6.1",
-        "contentHash": "gCexR8/Laso8JFm8myi3uJfo6NYyZElg5qgRyGHok6jFNY/wQwLJHr0D4tb6645SBV2D6L8e/xV2RMSSKXYd5Q=="
+        "resolved": "5.6.3",
+        "contentHash": "ayL730f1gdQVYmFFLKSX83QcoltyKSMBsV94qfCBpZHMaJz/e3ALuXKZDD8SkseWbNHxBe0HxLRBe5OOpQ9HpA=="
       },
-      "SourceGear.sqlite3": {
+      "SQLite": {
         "type": "Transitive",
-        "resolved": "3.53.3",
-        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
         "dependencies": {
-          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
-          "SourceGear.sqlite3": "3.53.3"
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.config.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
         "dependencies": {
-          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
         }
       },
       "SQLitePCLRaw.core": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
       },
       "SQLitePCLRaw.provider.e_sqlite3": {
         "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
-          "SQLitePCLRaw.core": "3.0.4"
+          "SQLitePCLRaw.core": "3.0.5"
         }
       },
       "StackExchange.Redis": {
@@ -554,8 +554,8 @@
       "bridgebeats.contracts": {
         "type": "Project",
         "dependencies": {
-          "idunno.AtProto": "[3.0.0, )",
-          "idunno.Bluesky": "[3.0.0, )"
+          "idunno.AtProto": "[3.1.0, )",
+          "idunno.Bluesky": "[3.1.0, )"
         }
       },
       "bridgebeats.core": {
@@ -574,7 +574,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
           "QRCoder": "[1.8.0, )",
-          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.File": "[7.0.0, )",
           "idunno.Security.Ssrf": "[5.4.0, )"


### PR DESCRIPTION
- Fence saga mutations and refresh contexts to prevent stale work and incomplete writes.
- Make retries, acknowledgements, PEL recovery, and Spotify bulk fallbacks durable.
- Add bounded provider concurrency, lifecycle telemetry, and failure-path coverage.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
